### PR TITLE
feat: @lorekit/cli, lorekit-memory skill, and cross-framework hook plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "name": "lorekit",
+  "owner": { "name": "mthines", "url": "https://github.com/mthines" },
+  "metadata": {
+    "description": "LoreKit — shared persistent memory for coding agents.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "lorekit-memory",
+      "source": "./plugins/lorekit-claude",
+      "description": "Reads scoped lessons at session start and nudges a retrospective when a tool fails, backed by the LoreKit MCP server. Requires LOREKIT_MCP_URL and LOREKIT_TOKEN in the environment (or a project .mcp.json written by `npx @lorekit/cli install`)."
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,11 @@ in `packages/cli/src/{core,adapters}/`; each adapter reshapes I/O to its host. T
 copy is vendored from `packages/cli/skill/` — keep in sync via `node scripts/sync-plugin-skill.mjs` (a
 `--check` mode guards drift).
 
+**Cross-framework validation:** `packages/cli/test/frameworks.test.mjs` replays payload fixtures
+(`test/fixtures/<adapter>-<event>.json`) through the binary and asserts each host's output contract, runs
+`claude plugin validate` (skips if the CLI is absent), and structurally checks the Cursor/Codex configs.
+Harvest real fixtures with `LOREKIT_HOOK_RECORD=<dir>` set on the hook command (one run per framework).
+
 ---
 
 ## NX commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,11 +16,18 @@ lets humans browse, search, and manage those lessons.
 | `@lorekit/core` | `packages/mcp-core/` | Scope validator, DB client, 5 tool handlers, OTel tracer/meter |
 | `@lorekit/server` | `packages/mcp-server/` | Node.js HTTP server for Fly.io (OTel SDK init, auth, webhook) |
 | `@lorekit/web` | `packages/web/` | Next.js 15 dashboard (Vercel) |
-| `@lorekit/cli` | `packages/cli/` | Zero-dep Node CLI: `install` (scaffolds the `lorekit-memory` skill + `.mcp.json`) and `doctor` (connectivity/token/scope health checks). Ships the skill under `skill/lorekit-memory/`. |
+| `@lorekit/cli` | `packages/cli/` | Zero-dep Node CLI: `install` (scaffolds the `lorekit-memory` skill + `.mcp.json`), `doctor` (connectivity/token/scope health checks), and `hook` (the shared hook engine behind the plugins). Ships the skill under `skill/lorekit-memory/`. Verified by its own `node:test` suite; excluded from the NX TS lint gate. |
+| `plugins/` | `plugins/` | Per-framework deterministic bundles: `lorekit-claude` (marketplace plugin: skill + hooks + MCP), `lorekit-cursor` (rule + `stop` hook), `lorekit-codex` (feature-flagged hooks + `AGENTS.md` fallback, experimental). Root `.claude-plugin/marketplace.json` lists the Claude plugin. |
 | `supabase` | `supabase/` | Edge Functions (production MCP server), migrations, NX targets |
 
 The **production MCP server** is `supabase/functions/mcp/index.ts` (Deno, self-contained).
 `packages/mcp-server/` is the Node.js variant for Fly.io with full OTel.
+
+**Shared hook engine:** `lorekit hook --adapter <claude|cursor|codex> --event <name>` reads the host's
+JSON on stdin and injects lessons / a retrospective nudge on stdout, always exiting 0. Logic lives once
+in `packages/cli/src/{core,adapters}/`; each adapter reshapes I/O to its host. The Claude plugin's skill
+copy is vendored from `packages/cli/skill/` — keep in sync via `node scripts/sync-plugin-skill.mjs` (a
+`--check` mode guards drift).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ lets humans browse, search, and manage those lessons.
 | `@lorekit/core` | `packages/mcp-core/` | Scope validator, DB client, 5 tool handlers, OTel tracer/meter |
 | `@lorekit/server` | `packages/mcp-server/` | Node.js HTTP server for Fly.io (OTel SDK init, auth, webhook) |
 | `@lorekit/web` | `packages/web/` | Next.js 15 dashboard (Vercel) |
+| `@lorekit/cli` | `packages/cli/` | Zero-dep Node CLI: `install` (scaffolds the `lorekit-memory` skill + `.mcp.json`) and `doctor` (connectivity/token/scope health checks). Ships the skill under `skill/lorekit-memory/`. |
 | `supabase` | `supabase/` | Edge Functions (production MCP server), migrations, NX targets |
 
 The **production MCP server** is `supabase/functions/mcp/index.ts` (Deno, self-contained).

--- a/README.md
+++ b/README.md
@@ -60,6 +60,28 @@ In `.claude/skills/persistent-memory/config.json`:
 
 That's it. Your agent's lessons now survive every run and session.
 
+## Agent memory skill + CLI
+
+Prefer a one-command setup? The [`@lorekit/cli`](./packages/cli/) package
+installs a companion skill that makes agents use LoreKit autonomously —
+reading lessons when they start a task or navigate new code, and writing a
+lesson whenever something goes wrong (a stuck loop, a repeated failure, a
+gotcha, a costly wrong assumption). It mirrors the read-on-start /
+write-on-failure loop of the `aw` autonomous-workflow agent.
+
+```bash
+# Scaffold the lorekit-memory skill into .claude/skills and wire .mcp.json
+npx @lorekit/cli install \
+  --endpoint https://<project-ref>.supabase.co/functions/v1/mcp \
+  --token    lk_rw_<your-token>
+
+# Verify connectivity, token permission, and the git-derived scopes
+npx @lorekit/cli doctor
+```
+
+→ See [packages/cli/README.md](./packages/cli/README.md) for all commands and
+flags, and the installed skill's `SKILL.md` for the read/write protocol.
+
 ## Architecture
 
 LoreKit is an NX monorepo with three deployable pieces:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ npx @lorekit/cli doctor
 → See [packages/cli/README.md](./packages/cli/README.md) for all commands and
 flags, and the installed skill's `SKILL.md` for the read/write protocol.
 
+For a **deterministic** version that fires on host lifecycle events (no
+reliance on the agent invoking the skill), install a framework plugin. All
+three share one engine — the `lorekit hook` command — and differ only in thin
+per-host config:
+
+- **Claude Code** — a marketplace plugin (skill + `SessionStart` / failure /
+  `Stop` hooks + MCP): `/plugin marketplace add mthines/lorekit` then
+  `/plugin install lorekit-memory@lorekit`
+- **Cursor** — a rule + `stop` hook
+- **Codex** — feature-flagged hooks + an `AGENTS.md` fallback (experimental)
+
+→ See [plugins/README.md](./plugins/README.md).
+
 ## Architecture
 
 LoreKit is an NX monorepo with three deployable pieces:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,9 @@ export default [
   ...nx.configs['flat/typescript'],
   ...nx.configs['flat/javascript'],
   {
-    ignores: ['**/dist', '**/node_modules'],
+    // @lorekit/cli is a standalone, zero-dependency Node package (no TS build);
+    // it is verified by its own `node:test` suite, not the monorepo TS lint gate.
+    ignores: ['**/dist', '**/node_modules', 'packages/cli/**'],
   },
   {
     files: ['**/*.ts', '**/*.tsx'],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,7 +7,8 @@ export default [
   {
     // @lorekit/cli is a standalone, zero-dependency Node package (no TS build);
     // it is verified by its own `node:test` suite, not the monorepo TS lint gate.
-    ignores: ['**/dist', '**/node_modules', 'packages/cli/**'],
+    // `plugins/` and `scripts/` are template bundles and tooling, not app code.
+    ignores: ['**/dist', '**/node_modules', 'packages/cli/**', 'plugins/**', 'scripts/**'],
   },
   {
     files: ['**/*.ts', '**/*.tsx'],

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -112,6 +112,46 @@ which fire the `lorekit hook` engine on host lifecycle events. The skill and
 the hooks compose: hooks guarantee the *timing*, the skill supplies the
 *authoring judgment*.
 
+## Testing & validating across frameworks
+
+`npm test` (or `node --test test/*.test.mjs`) runs four layers, so you can
+validate all three integrations without launching each agent by hand:
+
+1. **Unit** — scope parsing, failure heuristic, lesson formatting, adapter
+   mapping/emit.
+2. **Engine end-to-end** — spawns the real `lorekit hook` binary for every
+   adapter/event, including a mock MCP server that proves the `SessionStart`
+   read path injects lessons, plus throttling and bad-input handling.
+3. **Cross-framework conformance** — replays payload **fixtures** through the
+   binary and asserts the stdout matches each host's documented contract
+   (`hookSpecificOutput.additionalContext` for Claude/Codex, `followup_message`
+   for Cursor).
+4. **Wiring** — runs `claude plugin validate` on the Claude bundle (skipped if
+   the `claude` CLI is absent) and structurally validates the Cursor and Codex
+   configs; also asserts the vendored skill is in sync with its source.
+
+### Harvesting real fixtures (one run per framework)
+
+Layer 3 ships with documented seed fixtures under `test/fixtures/`. To prove
+conformance against what each framework *actually* sends, record real payloads
+once by pointing its hook command at the recorder:
+
+```bash
+# Temporarily set this env for the hook command in the framework's config,
+# then drive the agent through a session start, a failing command, and a stop:
+LOREKIT_HOOK_RECORD=/abs/path/to/packages/cli/test/fixtures \
+  npx @lorekit/cli hook --adapter claude --event SessionStart
+```
+
+Each invocation overwrites `test/fixtures/<adapter>-<event>.json` with the real
+payload. Commit the updated fixtures; the conformance tests then run offline
+forever. This reduces manual validation to a single capture pass per tool.
+
+> The one thing no offline test can cover is a real model loop (the agent
+> actually consuming the injected context). `claude plugin validate` confirms
+> the real Claude CLI accepts the wiring; for a true live check, install the
+> plugin and start one session per tool.
+
 ## Security note
 
 `install` writes your token into `.mcp.json`. Keep that file out of version

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -53,6 +53,21 @@ lorekit doctor --deep     # also does a write → read → delete round-trip (ne
 
 Exit code is non-zero if any check fails, so it fits CI gates.
 
+### `lorekit hook`
+
+The **shared hook engine** behind the Claude Code / Cursor / Codex plugins.
+It is not run by hand — the plugins wire it into their hook config. It reads
+the host framework's JSON on stdin and prints that host's injection format on
+stdout (lessons at session start; a nudge on failure or at end of turn),
+always exiting 0 so it can never block the host agent.
+
+```bash
+lorekit hook --adapter <claude|cursor|codex> --event <SessionStart|Stop|…>
+```
+
+One engine serves all three hosts; each `--adapter` only reshapes input/output
+to that host's contract. See [`plugins/`](../../plugins/) for the bundles.
+
 ## Options
 
 | Flag | Meaning |
@@ -63,6 +78,8 @@ Exit code is non-zero if any check fails, so it fits CI gates.
 | `-y, --yes` | Non-interactive; never prompt |
 | `--force` | Overwrite existing skill files (`install`) |
 | `--deep` | Write/read/delete round-trip (`doctor`) |
+| `--adapter <name>` | Host framework for `hook`: `claude` / `cursor` / `codex` |
+| `--event <name>` | Host hook event for `hook` (else read from the stdin payload) |
 | `-h, --help` | Help |
 | `-v, --version` | Version |
 
@@ -87,6 +104,13 @@ The installed `lorekit-memory` skill teaches an agent to:
 This mirrors the read-on-start / write-on-failure loop of the `aw`
 autonomous-workflow agent. See the skill's own `SKILL.md` for the full
 protocol.
+
+The **skill** is model-invoked (the agent chooses to use it). For a
+**deterministic** guarantee — lessons injected on every session start, a nudge
+on every tool failure — use the framework plugins in [`plugins/`](../../plugins/),
+which fire the `lorekit hook` engine on host lifecycle events. The skill and
+the hooks compose: hooks guarantee the *timing*, the skill supplies the
+*authoring judgment*.
 
 ## Security note
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,94 @@
+# @lorekit/cli
+
+Install the **LoreKit shared-memory skill** into a project and run health
+checks against your LoreKit MCP server — a small, zero-dependency Node CLI.
+
+LoreKit gives coding agents a shared, persistent memory: lessons one agent
+learns are stored centrally and read by every other agent, in every session,
+CI included. This CLI wires an agent up to it in two commands.
+
+## Install
+
+```bash
+npx @lorekit/cli install
+npx @lorekit/cli doctor
+```
+
+Requires Node 18+ (for the built-in `fetch`). No dependencies.
+
+## Commands
+
+### `lorekit install`
+
+Scaffolds the `lorekit-memory` skill into `.claude/skills/lorekit-memory/` and
+adds (or updates) a `lorekit` server in the project's `.mcp.json`, preserving
+any other MCP servers already configured.
+
+```bash
+lorekit install \
+  --endpoint https://<project-ref>.supabase.co/functions/v1/mcp \
+  --token    lk_rw_your_token
+```
+
+If run in a TTY without `--endpoint` / `--token`, it prompts for them.
+Use `--yes` for non-interactive environments (endpoint required via flag/env).
+Use `--force` to overwrite an existing skill copy.
+
+### `lorekit doctor`
+
+Verifies the setup and prints a status report:
+
+- Node runtime is 18+
+- the `lorekit-memory` skill is installed
+- `.mcp.json` has a `lorekit` server
+- endpoint is real (not the `<project-ref>` placeholder)
+- token is present and its permission tier (`lk_rw_*` vs `lk_ro_*`)
+- the MCP endpoint is reachable and the token is accepted
+- the git-derived read/write scopes for the current directory
+
+```bash
+lorekit doctor            # config + connectivity checks
+lorekit doctor --deep     # also does a write → read → delete round-trip (needs lk_rw_*)
+```
+
+Exit code is non-zero if any check fails, so it fits CI gates.
+
+## Options
+
+| Flag | Meaning |
+|------|---------|
+| `-d, --dir <path>` | Target project root (default: cwd) |
+| `-e, --endpoint <url>` | LoreKit MCP endpoint |
+| `-t, --token <token>` | LoreKit token |
+| `-y, --yes` | Non-interactive; never prompt |
+| `--force` | Overwrite existing skill files (`install`) |
+| `--deep` | Write/read/delete round-trip (`doctor`) |
+| `-h, --help` | Help |
+| `-v, --version` | Version |
+
+## Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `LOREKIT_MCP_URL` / `LOREKIT_ENDPOINT` | endpoint fallback |
+| `LOREKIT_TOKEN` | token fallback |
+| `NO_COLOR` | disable colored output |
+
+## What the skill does
+
+The installed `lorekit-memory` skill teaches an agent to:
+
+- **Read** scoped lessons at the start of a task, on first navigation into
+  unfamiliar code, and before risky operations (narrow-to-broad scope merge).
+- **Write** a lesson when something goes wrong — a stuck loop, a repeated
+  failure, a gotcha, a near-miss, or a costly wrong assumption — phrased as an
+  observation and scoped to the narrowest namespace that fits.
+
+This mirrors the read-on-start / write-on-failure loop of the `aw`
+autonomous-workflow agent. See the skill's own `SKILL.md` for the full
+protocol.
+
+## Security note
+
+`install` writes your token into `.mcp.json`. Keep that file out of version
+control (LoreKit's root `.gitignore` already ignores `.mcp.json`).

--- a/packages/cli/bin/lorekit.mjs
+++ b/packages/cli/bin/lorekit.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// LoreKit CLI — install the shared-memory skill and run health checks.
+import process from 'node:process';
+import { parseArgs, log, err, c } from '../src/util.mjs';
+import { install } from '../src/install.mjs';
+import { doctor } from '../src/doctor.mjs';
+
+const VERSION = '1.0.0';
+
+const HELP = `${c.bold('lorekit')} — shared persistent memory for coding agents
+
+${c.bold('Usage')}
+  npx @lorekit/cli <command> [options]
+
+${c.bold('Commands')}
+  install     Scaffold the lorekit-memory skill into .claude/skills and
+              add the LoreKit server to .mcp.json.
+  doctor      Verify the skill install, MCP connectivity, token, and scope.
+
+${c.bold('Options')}
+  -d, --dir <path>        Target project root (default: current directory)
+  -e, --endpoint <url>    LoreKit MCP endpoint
+  -t, --token <token>     LoreKit token (lk_rw_* to allow writes, lk_ro_* read-only)
+  -y, --yes               Non-interactive; never prompt
+      --force             Overwrite existing skill files (install)
+      --deep              Do a write→read→delete round-trip (doctor, needs lk_rw_*)
+  -h, --help              Show this help
+  -v, --version           Print the version
+
+${c.bold('Environment')}
+  LOREKIT_MCP_URL / LOREKIT_ENDPOINT   endpoint fallback
+  LOREKIT_TOKEN                        token fallback
+  NO_COLOR                             disable colored output
+
+${c.bold('Examples')}
+  npx @lorekit/cli install --endpoint https://ref.supabase.co/functions/v1/mcp --token lk_rw_xxx
+  npx @lorekit/cli doctor --deep
+`;
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const args = parseArgs(argv, {
+    aliases: { d: 'dir', e: 'endpoint', t: 'token', y: 'yes', h: 'help', v: 'version' },
+    booleans: ['yes', 'force', 'deep', 'help', 'version'],
+  });
+
+  if (args.version) {
+    log(VERSION);
+    return 0;
+  }
+
+  const command = args._[0];
+
+  if (args.help || !command) {
+    log(HELP);
+    return command ? 0 : args.help ? 0 : 1;
+  }
+
+  switch (command) {
+    case 'install':
+      return install(args);
+    case 'doctor':
+      return doctor(args);
+    default:
+      err(`${c.red('Unknown command:')} ${command}\n`);
+      log(HELP);
+      return 1;
+  }
+}
+
+main()
+  .then((code) => process.exit(code ?? 0))
+  .catch((e) => {
+    err(`${c.red('Error:')} ${e && e.stack ? e.stack : e}`);
+    process.exit(1);
+  });

--- a/packages/cli/bin/lorekit.mjs
+++ b/packages/cli/bin/lorekit.mjs
@@ -4,6 +4,7 @@ import process from 'node:process';
 import { parseArgs, log, err, c } from '../src/util.mjs';
 import { install } from '../src/install.mjs';
 import { doctor } from '../src/doctor.mjs';
+import { hook } from '../src/hook.mjs';
 
 const VERSION = '1.0.0';
 
@@ -16,6 +17,9 @@ ${c.bold('Commands')}
   install     Scaffold the lorekit-memory skill into .claude/skills and
               add the LoreKit server to .mcp.json.
   doctor      Verify the skill install, MCP connectivity, token, and scope.
+  hook        Hook engine for Claude Code / Cursor / Codex. Reads the host's
+              JSON on stdin and injects lessons or a retrospective nudge.
+              Not run by hand — wired into a plugin's hook config.
 
 ${c.bold('Options')}
   -d, --dir <path>        Target project root (default: current directory)
@@ -24,6 +28,8 @@ ${c.bold('Options')}
   -y, --yes               Non-interactive; never prompt
       --force             Overwrite existing skill files (install)
       --deep              Do a write→read→delete round-trip (doctor, needs lk_rw_*)
+      --adapter <name>    Host framework for hook: claude | cursor | codex
+      --event <name>      Host hook event (else read from stdin payload)
   -h, --help              Show this help
   -v, --version           Print the version
 
@@ -43,6 +49,13 @@ async function main() {
     aliases: { d: 'dir', e: 'endpoint', t: 'token', y: 'yes', h: 'help', v: 'version' },
     booleans: ['yes', 'force', 'deep', 'help', 'version'],
   });
+
+  // `hook` is machine-facing: it must never print help/errors to stdout
+  // (that would corrupt the JSON the host parses). Handle it before the
+  // help/usage branch and always resolve to exit 0.
+  if (args._[0] === 'hook') {
+    return hook(args);
+  }
 
   if (args.version) {
     log(VERSION);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@lorekit/cli",
+  "version": "1.0.0",
+  "description": "Install the LoreKit shared-memory skill and run health checks for the LoreKit MCP server.",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "lorekit": "bin/lorekit.mjs"
+  },
+  "files": [
+    "bin",
+    "src",
+    "skill",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "lorekit",
+    "mcp",
+    "claude",
+    "agent",
+    "memory",
+    "skill",
+    "cli"
+  ],
+  "scripts": {
+    "start": "node bin/lorekit.mjs",
+    "doctor": "node bin/lorekit.mjs doctor",
+    "test": "node --test test/*.test.mjs"
+  }
+}

--- a/packages/cli/skill/lorekit-memory/SKILL.md
+++ b/packages/cli/skill/lorekit-memory/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: lorekit-memory
+description: >
+  Shared persistent memory for coding agents, backed by LoreKit's MCP server.
+  Reads scoped lessons at the start of a task or when navigating into
+  unfamiliar code (narrow-to-broad scope resolution across branch, repo,
+  project, and global), and writes a lesson when something goes wrong — a
+  stuck loop, a repeated command failure, a surprising gotcha, a near-miss,
+  or a wrong assumption that cost time. Lessons are phrased as observations
+  (never rigid rules), scoped to the narrowest namespace that fits, and
+  deduplicated on write. Use at task start, before risky operations, and
+  after any failure or retrospective. Triggers on "read lessons", "check
+  memory", "what do we know about", "remember this", "save a lesson",
+  "record this gotcha", "capture this lesson", "/lorekit-memory".
+user-invocable: true
+argument-hint: '[read|write] [scope-hint or lesson]'
+license: MIT
+metadata:
+  author: mthines
+  version: '1.0.0'
+  workflow_type: shared-memory-intake-and-retrospective
+  tags:
+    - lorekit
+    - persistent-memory
+    - shared-memory
+    - mcp
+    - lessons
+    - self-improvement
+    - retrospective
+---
+
+# LoreKit Memory
+
+Give every agent a shared, persistent memory.
+Lessons live in LoreKit (a Supabase-backed MCP server), so what one agent
+learns on one machine — or in CI — is available to every agent, everywhere,
+in the next session.
+
+This skill has two jobs, mirroring the read-on-start / write-on-failure loop
+of the `aw` autonomous-workflow agent:
+
+1. **Read** scoped lessons at the start of a task and before risky steps.
+2. **Write** a lesson when something goes wrong, so the next run avoids it.
+
+Both jobs run through LoreKit's `memory.*` MCP tools.
+If those tools are not connected, this skill is a no-op — say so once and
+continue the task; never block work because memory is unavailable.
+
+---
+
+## When to read (intake)
+
+Read at the moments where prior lessons change what you do:
+
+- **Task start** — before planning any non-trivial change.
+- **Navigation** — the first time you open an unfamiliar package, module, or subsystem.
+- **Before a risky operation** — migrations, deploys, worktree/branch surgery, force pushes, anything hard to reverse.
+
+Follow [rules/intake.md](./rules/intake.md).
+The short version: resolve the current scope, list lessons narrow-to-broad,
+and treat matches as *considerations*, not commands.
+
+## When to write (retrospective)
+
+Write when a run produces a durable observation worth carrying forward.
+The trigger is friction, not success. Ask the 30-second question:
+
+> Was there a stuck loop, a repeated failure, a surprise, a near-miss, or a
+> guess that paid off — something a future run would benefit from knowing?
+
+If yes, write it. If the answer is genuinely nothing, write nothing —
+empty retrospectives are skipped entirely.
+
+Follow [rules/retrospective.md](./rules/retrospective.md).
+The short version: phrase the lesson as an observation, pick the narrowest
+scope that fits, check for a near-duplicate first, then `memory.write`.
+
+---
+
+## Scope in one line
+
+Lessons are partitioned by a canonical scope string (`::` is the only separator):
+
+```text
+global                                universal principles
+project::{name}                       monorepo-wide
+repo::{owner}/{repo}                   this repository's codebase
+branch::{owner}/{repo}::{branch}       short-lived, this branch only
+```
+
+Read narrow-to-broad and merge; write to the narrowest scope that correctly
+describes where the lesson applies.
+Full resolution rules: [references/scope-resolution.md](./references/scope-resolution.md).
+
+---
+
+## The MCP tools
+
+| Tool | Use | Token |
+|------|-----|-------|
+| `memory.list` | List lessons for one scope (newest first, tag filter) | read |
+| `memory.search` | Full-text search across scopes (supports `repo::owner/*`) | read |
+| `memory.read` | Read one lesson by scope + key | read |
+| `memory.write` | Store or update a lesson (same scope+key updates in place) | read+write |
+
+Write tools need an `lk_rw_*` token; read tools accept `lk_rw_*` or `lk_ro_*`.
+A read-only token cannot write — if a write fails with an authorization error,
+report it and move on; do not retry.
+
+Every lesson this skill writes carries the tag `skill::lorekit-memory` plus a
+`source::<trigger>` tag (for example `source::stuck-loop`) so lessons are
+easy to find and audit later.
+
+---
+
+## Setup
+
+Install the skill and configure the MCP endpoint with the LoreKit CLI:
+
+```bash
+npx @lorekit/cli install
+npx @lorekit/cli doctor
+```
+
+`install` scaffolds this skill into `.claude/skills/` and adds the LoreKit
+server to `.mcp.json`.
+`doctor` verifies connectivity, token permission, and scope detection.
+See the CLI's own README for flags and troubleshooting.

--- a/packages/cli/skill/lorekit-memory/references/scope-resolution.md
+++ b/packages/cli/skill/lorekit-memory/references/scope-resolution.md
@@ -1,0 +1,65 @@
+# Scope resolution
+
+A scope string names the namespace a lesson belongs to.
+`::` is the **only** valid separator — a single `:` returns a 400 error.
+All segments are lowercased by the server.
+
+## The four scope types
+
+| Type | Format | Example |
+|------|--------|---------|
+| Global | `global` | `global` |
+| Project (monorepo) | `project::{name}` | `project::agent-skills` |
+| Repository | `repo::{owner}/{repo}` | `repo::mthines/lorekit` |
+| Branch | `branch::{owner}/{repo}::{branch}` | `branch::mthines/lorekit::feat/x` |
+
+## Deriving scope from the working directory
+
+1. Read the `origin` remote URL and normalize it to `owner/repo`:
+   - `git@github.com:mthines/lorekit.git` → `mthines/lorekit`
+   - `https://github.com/mthines/lorekit.git` → `mthines/lorekit`
+   - strip a trailing `.git`, lowercase the result.
+2. Read the current branch: `git rev-parse --abbrev-ref HEAD`.
+3. Compose:
+   - `repo::mthines/lorekit`
+   - `branch::mthines/lorekit::{branch}`
+4. If there is no git remote, there is no repo/branch scope — use `global`,
+   and optionally `project::{basename-of-repo-root}` for a monorepo.
+
+The LoreKit CLI's `doctor` command prints the scope it derives, which is a
+quick way to confirm the agent will read and write to the right place.
+
+## Read order (intake)
+
+Query most specific first, then merge; more specific scopes win on key collisions:
+
+```text
+branch::{owner}/{repo}::{branch}   →   repo::{owner}/{repo}   →   project::{name}   →   global
+```
+
+## Write scope (retrospective)
+
+Use the narrowest scope that correctly describes where the lesson applies:
+
+- Branch-scoped lessons do not pollute the repo's lesson set.
+- Repo-scoped lessons do not pollute global.
+- Only truly universal lessons belong in `global`.
+
+## Wildcards (search only)
+
+`memory.search` accepts an owner-level wildcard in `scopes`:
+
+```json
+{ "scopes": ["repo::mthines/*", "global"] }
+```
+
+Wildcards work **only** in `memory.search` — not in `memory.list`,
+`memory.read`, or `memory.write`.
+
+## Validation rules
+
+1. `::` is the only separator; a single `:` → 400.
+2. `repo::` must include a `/` (owner/repo); `repo::mthines` → 400.
+3. `branch::` must have exactly two `::` separators.
+4. Only `global`, `project`, `repo`, `branch` prefixes are valid.
+5. Segments are trimmed and lowercased on ingest.

--- a/packages/cli/skill/lorekit-memory/rules/intake.md
+++ b/packages/cli/skill/lorekit-memory/rules/intake.md
@@ -1,0 +1,61 @@
+# Intake — reading lessons before you act
+
+Run this at task start, on first navigation into an unfamiliar area, and
+before any hard-to-reverse operation.
+
+## 1. Resolve the current scope
+
+Derive scope from the working repository:
+
+- `origin` remote `owner/repo` → `repo::{owner}/{repo}`
+- current branch → `branch::{owner}/{repo}::{branch}`
+- no git remote → fall back to `global` (and `project::{dir}` for a monorepo)
+
+Lowercase every segment.
+See [../references/scope-resolution.md](../references/scope-resolution.md) for the exact derivation.
+
+## 2. List narrow-to-broad
+
+Query each scope from most specific to least, and merge the results:
+
+```text
+memory.list { scope: "branch::{owner}/{repo}::{branch}" }
+memory.list { scope: "repo::{owner}/{repo}" }
+memory.list { scope: "project::{name}" }        # only if a monorepo
+memory.list { scope: "global" }
+```
+
+When the same key appears at multiple levels, the **more specific scope wins**.
+
+Keep it cheap: a `limit` of 20–50 per scope is plenty.
+Filter with `tags: ["skill::lorekit-memory"]` when you only want this skill's
+lessons; drop the filter to see everything an agent has recorded.
+
+## 3. Search when the task has a keyword
+
+If the task is about a specific subsystem, error, or tool, add a full-text
+search across the owner's repos and global:
+
+```text
+memory.search {
+  q: "<subsystem or error keywords>",
+  scopes: ["repo::{owner}/*", "global"],
+  limit: 10
+}
+```
+
+## 4. Apply as considerations, not commands
+
+Lessons are observations from past runs ("last time, X went wrong when Y").
+They inform your approach and can bias decisions — but they are not rules and
+they can be stale.
+If a lesson contradicts what you observe in the current code, trust the code
+and consider writing a corrective lesson on the way out (see
+[retrospective.md](./retrospective.md)).
+
+## 5. Report briefly
+
+If lessons matched, note them in one or two lines before proceeding
+("LoreKit: 2 relevant lessons — worktree naming, migration order").
+If nothing matched, say nothing and continue.
+If the MCP tools are not connected, note it once and continue without them.

--- a/packages/cli/skill/lorekit-memory/rules/retrospective.md
+++ b/packages/cli/skill/lorekit-memory/rules/retrospective.md
@@ -1,0 +1,85 @@
+# Retrospective — writing a lesson when something goes wrong
+
+Run this after friction: a stuck loop, a repeated command failure, a
+surprising gotcha, a near-miss, a wrong assumption that cost time, or a guess
+that paid off and should be reused.
+Do **not** run it on smooth successes — there is nothing durable to record.
+
+## 1. Decide if there is a lesson
+
+Ask the 30-second question:
+
+> Would a future run in this repo (or anywhere) do better if it knew this?
+
+If no, stop — write nothing. Empty retrospectives are skipped.
+If yes, continue.
+
+## 2. Phrase it as an observation
+
+Write what happened and what worked, not a commandment.
+
+- Good: "Running `pnpm nx test mcp-core` without `supabase start` fails with a
+  connection refused error; start Supabase first."
+- Avoid: "ALWAYS start Supabase." (rules rot; observations age gracefully)
+
+Keep the body tight markdown. A sentence or three. Include the concrete
+signal (the error text, the command, the file) so future search finds it.
+
+## 3. Pick the narrowest scope that fits
+
+| The lesson is about… | Scope |
+|----------------------|-------|
+| A universal principle, true in any repo | `global` |
+| This repository's codebase or tooling | `repo::{owner}/{repo}` |
+| A monorepo-wide convention | `project::{name}` |
+| A throwaway detail of this branch only | `branch::{owner}/{repo}::{branch}` |
+
+When in doubt for a "stuff went bad" lesson, default to **repo** scope.
+Reserve `global` for things that are genuinely true everywhere.
+
+## 4. Choose a stable key
+
+Use a short, kebab-case, namespaced key so related lessons cluster and
+re-writes update in place instead of duplicating:
+
+```text
+lorekit-memory::<short-slug>
+# e.g. lorekit-memory::supabase-start-before-test
+```
+
+## 5. Deduplicate before writing
+
+Check for a near-duplicate first, so you update rather than pile up:
+
+```text
+memory.search { q: "<key words of the lesson>", scopes: ["repo::{owner}/{repo}", "global"] }
+```
+
+- Found the same situation under a key → reuse that **exact scope + key** and
+  `memory.write` an updated body (writing the same scope+key updates in place).
+  Optionally note "(seen again <short-context>)" so the recurrence is visible.
+- Nothing similar → write a new lesson with a fresh key.
+
+## 6. Write
+
+```text
+memory.write {
+  scope:        "repo::{owner}/{repo}",
+  key:          "lorekit-memory::supabase-start-before-test",
+  value:        "<observation in markdown>",
+  tags:         ["skill::lorekit-memory", "source::stuck-loop"],
+  source_agent: "<your agent name, if known>",
+  trigger:      "stuck-loop"
+}
+```
+
+Pick `trigger` / `source::*` from what actually happened:
+`stuck-loop`, `command-failure`, `gotcha`, `near-miss`, `assumption-wrong`,
+`paid-off`, or `manual`.
+
+## 7. Confirm
+
+State in one line what you recorded and where
+("LoreKit: wrote repo lesson `supabase-start-before-test`").
+If the write fails because the token is read-only or missing, say so once and
+continue — never retry a write that failed on authorization.

--- a/packages/cli/src/adapters/claude.mjs
+++ b/packages/cli/src/adapters/claude.mjs
@@ -1,0 +1,41 @@
+// Adapter for Claude Code hooks.
+// Contract: stdin JSON with snake_case fields; stdout injects context via
+// hookSpecificOutput.additionalContext. Non-blocking (we never set decision).
+export const claude = {
+  name: 'claude',
+
+  intentFor(event) {
+    switch (event) {
+      case 'SessionStart':
+        return 'read';
+      case 'PostToolUse':
+      case 'PostToolUseFailure':
+        return 'failure';
+      case 'Stop':
+        return 'retrospective';
+      default:
+        return 'noop';
+    }
+  },
+
+  // PostToolUseFailure fires only when a tool failed — no heuristic needed.
+  guaranteedFailure(event) {
+    return event === 'PostToolUseFailure';
+  },
+
+  parse(input) {
+    return {
+      cwd: input.cwd || null,
+      sessionId: input.session_id || null,
+      toolName: input.tool_name || 'tool',
+      toolResponse: input.tool_response || null,
+      event: input.hook_event_name || null,
+    };
+  },
+
+  emit(event, text) {
+    return JSON.stringify({
+      hookSpecificOutput: { hookEventName: event, additionalContext: text },
+    });
+  },
+};

--- a/packages/cli/src/adapters/codex.mjs
+++ b/packages/cli/src/adapters/codex.mjs
@@ -1,0 +1,36 @@
+// Adapter for OpenAI Codex CLI hooks (experimental; `codex_hooks` feature flag).
+// Codex mirrors Claude Code's event model and JSON shape closely, so we reuse
+// the same snake_case input fields and hookSpecificOutput.additionalContext
+// output. If a future Codex build diverges, only this file needs to change.
+export const codex = {
+  name: 'codex',
+
+  intentFor(event) {
+    switch (event) {
+      case 'SessionStart':
+        return 'read';
+      case 'PostToolUse':
+        return 'failure';
+      case 'Stop':
+        return 'retrospective';
+      default:
+        return 'noop';
+    }
+  },
+
+  parse(input) {
+    return {
+      cwd: input.cwd || (Array.isArray(input.workspace_roots) ? input.workspace_roots[0] : null),
+      sessionId: input.session_id || input.thread_id || null,
+      toolName: input.tool_name || 'tool',
+      toolResponse: input.tool_response || null,
+      event: input.hook_event_name || null,
+    };
+  },
+
+  emit(event, text) {
+    return JSON.stringify({
+      hookSpecificOutput: { hookEventName: event, additionalContext: text },
+    });
+  },
+};

--- a/packages/cli/src/adapters/cursor.mjs
+++ b/packages/cli/src/adapters/cursor.mjs
@@ -1,0 +1,42 @@
+// Adapter for Cursor hooks (.cursor/hooks.json, "version": 1).
+//
+// Cursor's hook surface is narrower than Claude/Codex:
+//   - there is no SessionStart, so the read-on-start path is handled by the
+//     bundled Cursor *rule* (the agent calls the MCP); the `beforeSubmitPrompt`
+//     hook is best-effort and injects via `followup_message` where supported.
+//   - `beforeShellExecution` fires *before* a command runs, so there is no exit
+//     code to inspect — reliable failure detection is not possible here.
+//   - the confirmed injection channel is `stop` → { followup_message }.
+//
+// Confirmed stdin fields: `command`, `file_path`, `edits`, `generation_id`.
+export const cursor = {
+  name: 'cursor',
+
+  intentFor(event) {
+    switch (event) {
+      case 'beforeSubmitPrompt':
+        return 'read';
+      case 'stop':
+        return 'retrospective';
+      default:
+        return 'noop';
+    }
+  },
+
+  parse(input) {
+    return {
+      cwd:
+        input.cwd ||
+        (Array.isArray(input.workspace_roots) ? input.workspace_roots[0] : null),
+      sessionId: input.generation_id || input.conversation_id || null,
+      toolName: 'command',
+      toolResponse: null,
+      event: input.hook_event_name || null,
+    };
+  },
+
+  // Cursor injects an agent-visible message via `followup_message`.
+  emit(_event, text) {
+    return JSON.stringify({ followup_message: text });
+  },
+};

--- a/packages/cli/src/config.mjs
+++ b/packages/cli/src/config.mjs
@@ -20,12 +20,27 @@ export function skillInstallDir(root) {
   return path.join(root, '.claude', 'skills', SKILL_NAME);
 }
 
+// Throwing read — used by `install` so a corrupt .mcp.json aborts the write
+// instead of silently clobbering the user's file.
 export function readJsonIfExists(file) {
   if (!fs.existsSync(file)) return null;
   try {
     return JSON.parse(fs.readFileSync(file, 'utf8'));
   } catch (e) {
     throw new Error(`Failed to parse ${file}: ${e.message}`);
+  }
+}
+
+// Non-throwing read — used by the diagnostic (doctor) and hook read paths,
+// which must degrade gracefully rather than crash on a malformed file.
+// Distinguishes absent from present-but-invalid so callers can report it.
+export function readMcpConfig(root) {
+  const file = mcpJsonPath(root);
+  if (!fs.existsSync(file)) return { present: false, valid: false, config: null };
+  try {
+    return { present: true, valid: true, config: JSON.parse(fs.readFileSync(file, 'utf8')) };
+  } catch {
+    return { present: true, valid: false, config: null };
   }
 }
 
@@ -46,8 +61,10 @@ export function upsertMcpServer(root, remoteUrl) {
 }
 
 // Pull the configured lorekit remote URL out of .mcp.json, if present.
+// Non-throwing: returns null when the file is absent, invalid, or has no
+// lorekit server. Callers that need to distinguish those use readMcpConfig.
 export function readLorekitServer(root) {
-  const config = readJsonIfExists(mcpJsonPath(root));
+  const { config } = readMcpConfig(root);
   const server = config && config.mcpServers && config.mcpServers.lorekit;
   if (!server) return null;
   const args = Array.isArray(server.args) ? server.args : [];
@@ -55,20 +72,25 @@ export function readLorekitServer(root) {
   return { server, url: url || null };
 }
 
-// Recursively copy the skill source into the target, skipping when present
-// unless `force` is set.
+// Recursively copy the skill source into the target, skipping files that
+// already exist unless `force` is set. Returns the number of files actually
+// written, so the caller can report "installed" / "updated" / "unchanged"
+// honestly instead of guessing from whether the directory pre-existed.
 export function copyDir(src, dest, { force = false } = {}) {
   fs.mkdirSync(dest, { recursive: true });
+  let written = 0;
   for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
     const from = path.join(src, entry.name);
     const to = path.join(dest, entry.name);
     if (entry.isDirectory()) {
-      copyDir(from, to, { force });
+      written += copyDir(from, to, { force });
     } else {
       if (fs.existsSync(to) && !force) continue;
       fs.copyFileSync(from, to);
+      written++;
     }
   }
+  return written;
 }
 
 // Resolve endpoint + token from flags, then env, in that order.

--- a/packages/cli/src/config.mjs
+++ b/packages/cli/src/config.mjs
@@ -1,0 +1,93 @@
+// Project layout + .mcp.json read/merge helpers.
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// packages/cli/ — the installable package root (this file lives in src/).
+export const PKG_ROOT = fileURLToPath(new URL('../', import.meta.url));
+export const SKILL_SOURCE = path.join(PKG_ROOT, 'skill', 'lorekit-memory');
+export const SKILL_NAME = 'lorekit-memory';
+
+export function resolveProjectRoot(dir) {
+  return path.resolve(dir || process.cwd());
+}
+
+export function mcpJsonPath(root) {
+  return path.join(root, '.mcp.json');
+}
+
+export function skillInstallDir(root) {
+  return path.join(root, '.claude', 'skills', SKILL_NAME);
+}
+
+export function readJsonIfExists(file) {
+  if (!fs.existsSync(file)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch (e) {
+    throw new Error(`Failed to parse ${file}: ${e.message}`);
+  }
+}
+
+// Merge a lorekit server entry into .mcp.json, preserving any other servers.
+export function upsertMcpServer(root, remoteUrl) {
+  const file = mcpJsonPath(root);
+  const config = readJsonIfExists(file) || {};
+  if (!config.mcpServers || typeof config.mcpServers !== 'object') {
+    config.mcpServers = {};
+  }
+  const existed = Boolean(config.mcpServers.lorekit);
+  config.mcpServers.lorekit = {
+    command: 'npx',
+    args: ['-y', 'mcp-remote', remoteUrl],
+  };
+  fs.writeFileSync(file, JSON.stringify(config, null, 2) + '\n');
+  return { file, existed };
+}
+
+// Pull the configured lorekit remote URL out of .mcp.json, if present.
+export function readLorekitServer(root) {
+  const config = readJsonIfExists(mcpJsonPath(root));
+  const server = config && config.mcpServers && config.mcpServers.lorekit;
+  if (!server) return null;
+  const args = Array.isArray(server.args) ? server.args : [];
+  const url = args.find((a) => typeof a === 'string' && /^https?:\/\//.test(a));
+  return { server, url: url || null };
+}
+
+// Recursively copy the skill source into the target, skipping when present
+// unless `force` is set.
+export function copyDir(src, dest, { force = false } = {}) {
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const from = path.join(src, entry.name);
+    const to = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDir(from, to, { force });
+    } else {
+      if (fs.existsSync(to) && !force) continue;
+      fs.copyFileSync(from, to);
+    }
+  }
+}
+
+// Resolve endpoint + token from flags, then env, in that order.
+export function resolveConnection(args) {
+  const endpoint =
+    args.endpoint ||
+    process.env.LOREKIT_MCP_URL ||
+    process.env.LOREKIT_ENDPOINT ||
+    null;
+  const token = args.token || process.env.LOREKIT_TOKEN || null;
+  return {
+    endpoint: typeof endpoint === 'string' ? endpoint.trim() : null,
+    token: typeof token === 'string' ? token.trim() : null,
+  };
+}
+
+export function tokenKind(token) {
+  if (!token) return 'none';
+  if (token.startsWith('lk_rw_')) return 'read-write';
+  if (token.startsWith('lk_ro_')) return 'read-only';
+  return 'unknown';
+}

--- a/packages/cli/src/config.mjs
+++ b/packages/cli/src/config.mjs
@@ -91,3 +91,20 @@ export function tokenKind(token) {
   if (token.startsWith('lk_ro_')) return 'read-only';
   return 'unknown';
 }
+
+// For hooks: resolve the connection from the project's .mcp.json first
+// (that is where `lorekit install` wrote the token), then fall back to env.
+// `splitEndpoint` is passed in to avoid a circular import with mcp.mjs.
+export function resolveProjectConnection(root, splitEndpoint) {
+  const configured = readLorekitServer(root);
+  if (configured && configured.url) {
+    const { endpoint, token } = splitEndpoint(configured.url);
+    if (endpoint && !endpoint.includes('<project-ref>')) {
+      return {
+        endpoint,
+        token: token || process.env.LOREKIT_TOKEN || null,
+      };
+    }
+  }
+  return resolveConnection({});
+}

--- a/packages/cli/src/core/failure.mjs
+++ b/packages/cli/src/core/failure.mjs
@@ -1,0 +1,28 @@
+// Heuristic: did a completed tool call fail? Framework-agnostic.
+// Conservative on purpose — a false "failed" nudges the agent needlessly.
+
+function num(v) {
+  return typeof v === 'number' ? v : typeof v === 'string' && /^-?\d+$/.test(v) ? Number(v) : null;
+}
+
+// `response` is the tool_response object (shape varies by framework/tool).
+export function isFailure(toolName, response) {
+  if (!response || typeof response !== 'object') return false;
+
+  // Explicit error flags set by the harness.
+  if (response.is_error === true || response.isError === true) return true;
+  if (response.interrupted === true) return false; // user abort, not a lesson
+
+  // Exit codes from shell-style tools.
+  for (const field of ['exit_code', 'exitCode', 'code', 'returnCode']) {
+    const n = num(response[field]);
+    if (n !== null) return n !== 0;
+  }
+
+  // Some tools report status directly.
+  if (typeof response.status === 'string') {
+    return /^(error|fail(ed)?)$/i.test(response.status);
+  }
+
+  return false;
+}

--- a/packages/cli/src/core/lessons.mjs
+++ b/packages/cli/src/core/lessons.mjs
@@ -1,0 +1,77 @@
+// Shared hook logic: fetch and format lessons; build the nudge text.
+// Framework-agnostic — adapters shape these strings into each tool's contract.
+import { mcpCall } from '../mcp.mjs';
+import { deriveScope } from '../scope.mjs';
+
+const MAX_LESSONS = 15;
+
+// Pull the JSON payload out of an MCP tools/call result envelope.
+// LoreKit returns tool output as { content: [{ type: 'text', text: '<json>' }] }.
+function unwrap(result) {
+  if (!result) return null;
+  if (Array.isArray(result.content)) {
+    const text = result.content.map((c) => (c && c.text) || '').join('');
+    try {
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  }
+  return result;
+}
+
+// Read lessons narrow-to-broad and merge; more specific scope wins on key.
+export async function fetchLessons(endpoint, token, cwd) {
+  const scope = deriveScope(cwd);
+  const byKey = new Map();
+  for (const s of scope.readOrder) {
+    const res = await mcpCall(endpoint, token, 'tools/call', {
+      name: 'memory.list',
+      arguments: { scope: s, limit: 25 },
+    });
+    if (!res.ok) continue;
+    const payload = unwrap(res.result);
+    const entries = payload && Array.isArray(payload.entries) ? payload.entries : [];
+    for (const e of entries) {
+      if (e && e.key && !byKey.has(e.key)) byKey.set(e.key, { ...e, scope: s });
+    }
+  }
+  return { scope, lessons: [...byKey.values()].slice(0, MAX_LESSONS) };
+}
+
+// Render lessons as a compact markdown block, or null when there are none.
+export function formatLessons(lessons, scope) {
+  if (!lessons || lessons.length === 0) return null;
+  const header =
+    `LoreKit — ${lessons.length} shared lesson(s) for ${scope.repoScope || 'this workspace'}. ` +
+    `Treat as considerations, not rules; trust the current code if they conflict.`;
+  const body = lessons
+    .map((l) => {
+      const first = String(l.value || '').split('\n')[0].slice(0, 300);
+      return `- (${l.scope}) ${l.key}: ${first}`;
+    })
+    .join('\n');
+  return `${header}\n${body}`;
+}
+
+// The retrospective nudge emitted at end-of-turn (one-shot per session).
+export function retrospectiveNudge(scope) {
+  const writeScope = scope.repoScope || 'global';
+  return (
+    'LoreKit retrospective: if this session hit a stuck loop, a repeated ' +
+    'command failure, a surprising gotcha, a near-miss, or a wrong assumption ' +
+    'that cost time, record it now via the lorekit-memory skill ' +
+    `(memory.write to ${writeScope}, phrased as an observation). ` +
+    'If nothing was durable, do nothing.'
+  );
+}
+
+// The nudge emitted when a tool failure is detected.
+export function failureNudge(toolName, scope) {
+  const writeScope = scope.repoScope || 'global';
+  return (
+    `LoreKit: the last ${toolName} call failed. If this is a recurring or ` +
+    'non-obvious failure, consider recording the fix as a lesson via ' +
+    `lorekit-memory (memory.write to ${writeScope}), so the next run avoids it.`
+  );
+}

--- a/packages/cli/src/core/record.mjs
+++ b/packages/cli/src/core/record.mjs
@@ -1,0 +1,27 @@
+// Fixture recorder. When LOREKIT_HOOK_RECORD points at a directory, every hook
+// invocation writes the exact payload the host sent to
+// <dir>/<adapter>-<event>.json. Run each framework ONCE with this env set to
+// harvest real fixtures; the replay tests then run offline forever.
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function recordFixture(adapter, event, raw) {
+  const dir = process.env.LOREKIT_HOOK_RECORD;
+  if (!dir) return;
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    let stdin;
+    try {
+      stdin = JSON.parse(raw);
+    } catch {
+      stdin = raw; // keep the raw string if it was not valid JSON
+    }
+    const name = `${adapter}-${event || 'unknown'}.json`;
+    fs.writeFileSync(
+      path.join(dir, name),
+      JSON.stringify({ adapter, event: event || null, stdin }, null, 2) + '\n',
+    );
+  } catch {
+    // Recording must never affect the host — swallow any error.
+  }
+}

--- a/packages/cli/src/core/state.mjs
+++ b/packages/cli/src/core/state.mjs
@@ -1,0 +1,27 @@
+// One-shot throttle so a hook fires an injection at most once per session/tag.
+// Prevents nudge spam and, on Stop hooks, avoids re-injection loops.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+function stateDir() {
+  const base = process.env.CLAUDE_PLUGIN_DATA || path.join(os.tmpdir(), 'lorekit-hooks');
+  fs.mkdirSync(base, { recursive: true });
+  return base;
+}
+
+// Returns true the FIRST time called for a given (sessionId, tag), false after.
+// Missing sessionId → always true (cannot throttle without a key).
+export function firstTimeThisSession(sessionId, tag) {
+  if (!sessionId) return true;
+  const hash = crypto.createHash('sha256').update(`${sessionId}:${tag}`).digest('hex').slice(0, 16);
+  const marker = path.join(stateDir(), `${hash}.seen`);
+  try {
+    // wx fails if the file already exists → not the first time.
+    fs.writeFileSync(marker, '', { flag: 'wx' });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/doctor.mjs
+++ b/packages/cli/src/doctor.mjs
@@ -1,0 +1,146 @@
+// `lorekit doctor` — verify the skill install and the LoreKit MCP connection.
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import {
+  SKILL_NAME,
+  resolveProjectRoot,
+  skillInstallDir,
+  readLorekitServer,
+  resolveConnection,
+  tokenKind,
+} from './config.mjs';
+import { splitEndpoint, mcpCall } from './mcp.mjs';
+import { deriveScope } from './scope.mjs';
+import { log, heading, status, c } from './util.mjs';
+
+const AUTH_CODES = new Set([401, 403, -32001]);
+
+export async function doctor(args) {
+  const root = resolveProjectRoot(args.dir);
+  let failures = 0;
+  let warnings = 0;
+  const record = (kind, label, detail) => {
+    if (kind === 'fail') failures++;
+    if (kind === 'warn') warnings++;
+    status(kind, label, detail);
+  };
+
+  heading('LoreKit doctor');
+  log(`  project: ${c.dim(root)}\n`);
+
+  // 1. Runtime.
+  const major = Number(process.versions.node.split('.')[0]);
+  record(major >= 18 ? 'pass' : 'fail', 'node runtime', `v${process.versions.node}${major < 18 ? ' — need v18+ for fetch' : ''}`);
+
+  // 2. Skill installed.
+  const skillMd = path.join(skillInstallDir(root), 'SKILL.md');
+  if (fs.existsSync(skillMd)) {
+    record('pass', `skill ${SKILL_NAME}`, path.relative(root, skillMd) || skillMd);
+  } else {
+    record('fail', `skill ${SKILL_NAME}`, 'not found — run `lorekit install`');
+  }
+
+  // 3. Connection config: prefer explicit flags/env, else .mcp.json.
+  const override = resolveConnection(args);
+  const configured = readLorekitServer(root);
+  const fromMcp = configured ? splitEndpoint(configured.url) : { endpoint: null, token: null };
+
+  const endpoint = override.endpoint || fromMcp.endpoint;
+  const token = override.token || fromMcp.token;
+
+  if (configured) {
+    record('pass', '.mcp.json', 'lorekit server configured');
+  } else {
+    record('warn', '.mcp.json', 'no lorekit server entry — run `lorekit install`');
+  }
+
+  if (!endpoint) {
+    record('fail', 'endpoint', 'none — set it in .mcp.json or pass --endpoint');
+  } else if (endpoint.includes('<project-ref>')) {
+    record('fail', 'endpoint', `still a placeholder: ${endpoint}`);
+  } else {
+    record('pass', 'endpoint', endpoint);
+  }
+
+  const kind = tokenKind(token);
+  if (kind === 'none') record('fail', 'token', 'none configured');
+  else if (kind === 'read-only') record('warn', 'token', 'read-only (lk_ro_*) — reads only, no writes');
+  else if (kind === 'unknown') record('warn', 'token', 'unrecognized prefix (expected lk_rw_* / lk_ro_*)');
+  else record('pass', 'token', 'read+write (lk_rw_*)');
+
+  // 4. Connectivity.
+  if (endpoint && !endpoint.includes('<project-ref>') && token) {
+    const res = await mcpCall(endpoint, token, 'tools/list', {});
+    if (res.networkError) {
+      record('fail', 'connectivity', res.networkError);
+    } else if (res.ok) {
+      const tools = res.result && Array.isArray(res.result.tools) ? res.result.tools.length : null;
+      record('pass', 'connectivity', tools !== null ? `reachable, ${tools} tools` : 'reachable');
+    } else if (res.error && AUTH_CODES.has(res.error.code)) {
+      record('fail', 'connectivity', `auth rejected (${res.error.code}) — check your token`);
+    } else if (res.error) {
+      // Reached the server and got a JSON-RPC envelope back; auth passed.
+      record('warn', 'connectivity', `reachable, server said: ${res.error.message || res.error.code}`);
+    } else {
+      record('warn', 'connectivity', `unexpected response (HTTP ${res.httpStatus})`);
+    }
+
+    // 5. Optional deep round-trip (write → read → clean up). Needs a rw token.
+    if (args.deep) {
+      await deepCheck(endpoint, token, root, record);
+    }
+  } else {
+    record('warn', 'connectivity', 'skipped — need a valid endpoint and token');
+  }
+
+  // 6. Scope.
+  const scope = deriveScope(root);
+  if (scope.hasRemote) {
+    record('info', 'read scope', scope.readOrder.join('  →  '));
+    record('info', 'write scope', `${scope.repoScope} (default for "went wrong" lessons)`);
+  } else {
+    record('warn', 'scope', 'no git remote here — lessons fall back to global');
+  }
+
+  // Summary.
+  heading('Summary');
+  if (failures === 0 && warnings === 0) {
+    log(`  ${c.green('All checks passed.')} LoreKit memory is ready.`);
+  } else {
+    log(`  ${failures ? c.red(failures + ' failed') : c.green('0 failed')}, ${warnings ? c.yellow(warnings + ' warning(s)') : '0 warnings'}.`);
+  }
+  return failures === 0 ? 0 : 1;
+}
+
+async function deepCheck(endpoint, token, root, record) {
+  if (tokenKind(token) !== 'read-write') {
+    record('warn', 'round-trip', 'skipped — needs a read+write token');
+    return;
+  }
+  const scope = deriveScope(root);
+  const writeScope = scope.repoScope || 'global';
+  const key = 'lorekit-memory::doctor-check';
+  const value = 'LoreKit doctor round-trip check. Safe to delete.';
+
+  const w = await mcpCall(endpoint, token, 'tools/call', {
+    name: 'memory.write',
+    arguments: { scope: writeScope, key, value, tags: ['skill::lorekit-memory', 'source::doctor'], trigger: 'manual' },
+  });
+  if (!w.ok) {
+    record('fail', 'round-trip', `write failed: ${w.error ? w.error.message || w.error.code : w.networkError}`);
+    return;
+  }
+  const r = await mcpCall(endpoint, token, 'tools/call', {
+    name: 'memory.read',
+    arguments: { scope: writeScope, key },
+  });
+  const readBack = r.ok && JSON.stringify(r.result || '').includes('round-trip');
+  record(readBack ? 'pass' : 'warn', 'round-trip', readBack ? `wrote + read back in ${writeScope}` : 'wrote, but read-back was inconclusive');
+
+  // Clean up.
+  await mcpCall(endpoint, token, 'tools/call', {
+    name: 'memory.delete',
+    arguments: { scope: writeScope, key, force: true },
+  });
+}

--- a/packages/cli/src/doctor.mjs
+++ b/packages/cli/src/doctor.mjs
@@ -7,6 +7,7 @@ import {
   resolveProjectRoot,
   skillInstallDir,
   readLorekitServer,
+  readMcpConfig,
   resolveConnection,
   tokenKind,
 } from './config.mjs';
@@ -43,13 +44,16 @@ export async function doctor(args) {
 
   // 3. Connection config: prefer explicit flags/env, else .mcp.json.
   const override = resolveConnection(args);
-  const configured = readLorekitServer(root);
+  const mcp = readMcpConfig(root);
+  const configured = mcp.valid ? readLorekitServer(root) : null;
   const fromMcp = configured ? splitEndpoint(configured.url) : { endpoint: null, token: null };
 
   const endpoint = override.endpoint || fromMcp.endpoint;
   const token = override.token || fromMcp.token;
 
-  if (configured) {
+  if (mcp.present && !mcp.valid) {
+    record('fail', '.mcp.json', 'invalid JSON — fix it or re-run `lorekit install`');
+  } else if (configured) {
     record('pass', '.mcp.json', 'lorekit server configured');
   } else {
     record('warn', '.mcp.json', 'no lorekit server entry — run `lorekit install`');

--- a/packages/cli/src/hook.mjs
+++ b/packages/cli/src/hook.mjs
@@ -9,6 +9,7 @@ import { deriveScope } from './scope.mjs';
 import { fetchLessons, formatLessons, retrospectiveNudge, failureNudge } from './core/lessons.mjs';
 import { isFailure } from './core/failure.mjs';
 import { firstTimeThisSession } from './core/state.mjs';
+import { recordFixture } from './core/record.mjs';
 import { claude } from './adapters/claude.mjs';
 import { cursor } from './adapters/cursor.mjs';
 import { codex } from './adapters/codex.mjs';
@@ -54,6 +55,10 @@ async function run(args) {
 
   const parsed = adapter.parse(input);
   const event = args.event || parsed.event;
+
+  // Harvest the real payload when recording is enabled (opt-in via env).
+  recordFixture(args.adapter, event, raw);
+
   if (!event) return 0;
 
   const intent = adapter.intentFor(event);

--- a/packages/cli/src/hook.mjs
+++ b/packages/cli/src/hook.mjs
@@ -1,0 +1,94 @@
+// `lorekit hook --adapter <claude|cursor|codex> [--event <name>]`
+// The shared hook engine. Reads the framework's JSON on stdin, runs the shared
+// logic, and prints the framework-shaped injection on stdout. Always exits 0 —
+// a memory hook must never block or break the host agent.
+import process from 'node:process';
+import { resolveProjectRoot, resolveProjectConnection } from './config.mjs';
+import { splitEndpoint } from './mcp.mjs';
+import { deriveScope } from './scope.mjs';
+import { fetchLessons, formatLessons, retrospectiveNudge, failureNudge } from './core/lessons.mjs';
+import { isFailure } from './core/failure.mjs';
+import { firstTimeThisSession } from './core/state.mjs';
+import { claude } from './adapters/claude.mjs';
+import { cursor } from './adapters/cursor.mjs';
+import { codex } from './adapters/codex.mjs';
+
+const ADAPTERS = { claude, cursor, codex };
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let data = '';
+    if (process.stdin.isTTY) return resolve('');
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (c) => (data += c));
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(data));
+  });
+}
+
+export async function hook(args) {
+  // Guarded so any unexpected error still exits 0 (never break the host agent).
+  try {
+    return await run(args);
+  } catch {
+    return 0;
+  }
+}
+
+async function run(args) {
+  const adapter = ADAPTERS[args.adapter];
+  if (!adapter) {
+    // Unknown adapter: stay silent, don't disrupt the host.
+    return 0;
+  }
+
+  const raw = await readStdin();
+  let input = {};
+  if (raw && raw.trim()) {
+    try {
+      input = JSON.parse(raw);
+    } catch {
+      input = {};
+    }
+  }
+
+  const parsed = adapter.parse(input);
+  const event = args.event || parsed.event;
+  if (!event) return 0;
+
+  const intent = adapter.intentFor(event);
+  if (intent === 'noop') return 0;
+
+  const root = resolveProjectRoot(
+    args.dir || process.env.CLAUDE_PROJECT_DIR || parsed.cwd || undefined,
+  );
+  const scope = deriveScope(root);
+  const emit = (text) => {
+    if (text) process.stdout.write(adapter.emit(event, text));
+  };
+
+  if (intent === 'read') {
+    if (!firstTimeThisSession(parsed.sessionId, 'read')) return 0;
+    const { endpoint, token } = resolveProjectConnection(root, splitEndpoint);
+    if (!endpoint || !token) return 0; // memory not configured — stay silent
+    const { scope: readScope, lessons } = await fetchLessons(endpoint, token, root);
+    emit(formatLessons(lessons, readScope));
+    return 0;
+  }
+
+  if (intent === 'failure') {
+    const known = adapter.guaranteedFailure ? adapter.guaranteedFailure(event) : false;
+    if (!known && !isFailure(parsed.toolName, parsed.toolResponse)) return 0;
+    if (!firstTimeThisSession(parsed.sessionId, 'failure')) return 0;
+    emit(failureNudge(parsed.toolName, scope));
+    return 0;
+  }
+
+  if (intent === 'retrospective') {
+    if (!firstTimeThisSession(parsed.sessionId, 'retro')) return 0;
+    emit(retrospectiveNudge(scope));
+    return 0;
+  }
+
+  return 0;
+}

--- a/packages/cli/src/install.mjs
+++ b/packages/cli/src/install.mjs
@@ -1,0 +1,90 @@
+// `lorekit install` — scaffold the skill and wire the MCP server.
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+import process from 'node:process';
+import {
+  SKILL_SOURCE,
+  SKILL_NAME,
+  resolveProjectRoot,
+  skillInstallDir,
+  copyDir,
+  upsertMcpServer,
+  resolveConnection,
+  tokenKind,
+} from './config.mjs';
+import { buildRemoteUrl } from './mcp.mjs';
+import { deriveScope } from './scope.mjs';
+import { log, err, heading, status, c } from './util.mjs';
+
+function ask(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => rl.question(question, (a) => { rl.close(); resolve(a.trim()); }));
+}
+
+const DEFAULT_ENDPOINT_HINT = 'https://<project-ref>.supabase.co/functions/v1/mcp';
+
+export async function install(args) {
+  const root = resolveProjectRoot(args.dir);
+  const nonInteractive = Boolean(args.yes) || !process.stdin.isTTY;
+
+  heading('LoreKit install');
+  log(`  project: ${c.dim(root)}`);
+
+  // 1. Connection details.
+  let { endpoint, token } = resolveConnection(args);
+
+  if (!endpoint) {
+    if (nonInteractive) {
+      err(
+        `\n${c.red('Missing endpoint.')} Pass --endpoint ${DEFAULT_ENDPOINT_HINT} ` +
+          `or set LOREKIT_MCP_URL.`,
+      );
+      return 1;
+    }
+    endpoint = await ask(`  LoreKit MCP endpoint [${DEFAULT_ENDPOINT_HINT}]: `);
+    if (!endpoint) endpoint = DEFAULT_ENDPOINT_HINT;
+  }
+  if (!token && !nonInteractive) {
+    token = await ask('  LoreKit token (lk_rw_… to allow writes, blank to skip): ');
+    token = token || null;
+  }
+
+  // 2. Install the skill files.
+  const dest = skillInstallDir(root);
+  const skillExisted = fs.existsSync(path.join(dest, 'SKILL.md'));
+  copyDir(SKILL_SOURCE, dest, { force: Boolean(args.force) });
+
+  // 3. Wire .mcp.json.
+  const remoteUrl = buildRemoteUrl(endpoint, token);
+  const { file, existed } = upsertMcpServer(root, remoteUrl);
+
+  // 4. Report.
+  heading('Done');
+  status('pass', `skill ${SKILL_NAME}`, `${skillExisted ? 'updated' : 'installed'} → ${path.relative(root, dest) || dest}`);
+  status('pass', '.mcp.json', `${existed ? 'updated' : 'created'} lorekit server → ${path.relative(root, file) || file}`);
+
+  const kind = tokenKind(token);
+  if (kind === 'none') {
+    status('warn', 'token', 'none configured — reads/writes will fail until a token is set');
+  } else if (kind === 'read-only') {
+    status('warn', 'token', 'read-only (lk_ro_*) — the skill can read lessons but not write them');
+  } else if (kind === 'unknown') {
+    status('warn', 'token', 'unrecognized prefix — expected lk_rw_* or lk_ro_*');
+  } else {
+    status('pass', 'token', 'read+write (lk_rw_*)');
+  }
+
+  const scope = deriveScope(root);
+  if (scope.hasRemote) {
+    status('info', 'scope', `${scope.repoScope}${scope.branchScope ? `  ·  ${scope.branchScope}` : ''}`);
+  } else {
+    status('warn', 'scope', 'no git remote — lessons will fall back to global');
+  }
+
+  log(`\n  Next: ${c.cyan('npx @lorekit/cli doctor')} to verify the connection.`);
+  if (token) {
+    log(`  ${c.dim('Note: your token now lives in .mcp.json — keep it out of version control.')}`);
+  }
+  return 0;
+}

--- a/packages/cli/src/install.mjs
+++ b/packages/cli/src/install.mjs
@@ -53,7 +53,7 @@ export async function install(args) {
   // 2. Install the skill files.
   const dest = skillInstallDir(root);
   const skillExisted = fs.existsSync(path.join(dest, 'SKILL.md'));
-  copyDir(SKILL_SOURCE, dest, { force: Boolean(args.force) });
+  const written = copyDir(SKILL_SOURCE, dest, { force: Boolean(args.force) });
 
   // 3. Wire .mcp.json.
   const remoteUrl = buildRemoteUrl(endpoint, token);
@@ -61,7 +61,12 @@ export async function install(args) {
 
   // 4. Report.
   heading('Done');
-  status('pass', `skill ${SKILL_NAME}`, `${skillExisted ? 'updated' : 'installed'} → ${path.relative(root, dest) || dest}`);
+  const skillState = !skillExisted
+    ? 'installed'
+    : written > 0
+      ? `updated (${written} file(s) written)`
+      : 'unchanged — pass --force to overwrite';
+  status(skillExisted && written === 0 ? 'info' : 'pass', `skill ${SKILL_NAME}`, `${skillState} → ${path.relative(root, dest) || dest}`);
   status('pass', '.mcp.json', `${existed ? 'updated' : 'created'} lorekit server → ${path.relative(root, file) || file}`);
 
   const kind = tokenKind(token);

--- a/packages/cli/src/mcp.mjs
+++ b/packages/cli/src/mcp.mjs
@@ -28,10 +28,12 @@ let idCounter = 0;
 
 // Returns { ok, httpStatus, result, error, networkError }.
 export async function mcpCall(endpoint, token, method, params = {}, { timeoutMs = 10000 } = {}) {
-  const url = buildRemoteUrl(endpoint, token);
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
+    // Inside the try so a malformed endpoint yields the documented
+    // { ok:false, networkError } shape instead of throwing at the call site.
+    const url = buildRemoteUrl(endpoint, token);
     const res = await fetch(url, {
       method: 'POST',
       headers: {

--- a/packages/cli/src/mcp.mjs
+++ b/packages/cli/src/mcp.mjs
@@ -1,0 +1,87 @@
+// Minimal MCP-over-HTTP (JSON-RPC 2.0) client for the LoreKit endpoint.
+// Zero dependencies — uses the global fetch (Node 18+).
+
+// Split a configured server URL like ".../mcp?token=lk_rw_x" into
+// { endpoint: ".../mcp", token: "lk_rw_x" }.
+export function splitEndpoint(url) {
+  if (!url) return { endpoint: null, token: null };
+  try {
+    const u = new URL(url);
+    const token = u.searchParams.get('token');
+    u.searchParams.delete('token');
+    const endpoint = u.origin + u.pathname + (u.search || '');
+    return { endpoint, token: token || null };
+  } catch {
+    return { endpoint: url, token: null };
+  }
+}
+
+// Build the mcp-remote URL that goes into .mcp.json args.
+export function buildRemoteUrl(endpoint, token) {
+  if (!token) return endpoint;
+  const u = new URL(endpoint);
+  u.searchParams.set('token', token);
+  return u.toString();
+}
+
+let idCounter = 0;
+
+// Returns { ok, httpStatus, result, error, networkError }.
+export async function mcpCall(endpoint, token, method, params = {}, { timeoutMs = 10000 } = {}) {
+  const url = buildRemoteUrl(endpoint, token);
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: ++idCounter, method, params }),
+      signal: controller.signal,
+    });
+
+    const text = await res.text();
+    const json = parseBody(text);
+
+    if (json && json.error) {
+      return { ok: false, httpStatus: res.status, error: json.error };
+    }
+    if (!res.ok) {
+      return {
+        ok: false,
+        httpStatus: res.status,
+        error: { code: res.status, message: text.slice(0, 200) || res.statusText },
+      };
+    }
+    return { ok: true, httpStatus: res.status, result: json ? json.result : undefined };
+  } catch (e) {
+    return { ok: false, networkError: String(e && e.message ? e.message : e) };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// The endpoint may answer as plain JSON or as an SSE frame ("data: {...}").
+function parseBody(text) {
+  if (!text) return null;
+  const trimmed = text.trim();
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const line = trimmed
+      .split('\n')
+      .map((l) => l.trim())
+      .find((l) => l.startsWith('data:'));
+    if (line) {
+      try {
+        return JSON.parse(line.slice('data:'.length).trim());
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+}

--- a/packages/cli/src/scope.mjs
+++ b/packages/cli/src/scope.mjs
@@ -1,0 +1,59 @@
+// Derive LoreKit scope strings from the git working directory.
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+function git(args, cwd) {
+  try {
+    return execFileSync('git', args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// git@github.com:Owner/Repo.git  →  owner/repo
+// https://github.com/Owner/Repo  →  owner/repo
+export function ownerRepoFromRemote(url) {
+  if (!url) return null;
+  let s = url.trim().replace(/\.git$/i, '');
+  s = s.replace(/^git@[^:]+:/, ''); // scp-style
+  s = s.replace(/^ssh:\/\/git@[^/]+\//, '');
+  s = s.replace(/^https?:\/\/[^/]+\//, '');
+  const parts = s.split('/').filter(Boolean);
+  if (parts.length < 2) return null;
+  const owner = parts[parts.length - 2];
+  const repo = parts[parts.length - 1];
+  return `${owner}/${repo}`.toLowerCase();
+}
+
+// Returns { ownerRepo, branch, repoScope, branchScope, projectScope, readOrder }.
+export function deriveScope(cwd = process.cwd()) {
+  const remote = git(['config', '--get', 'remote.origin.url'], cwd);
+  const ownerRepo = ownerRepoFromRemote(remote);
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], cwd);
+  const root = git(['rev-parse', '--show-toplevel'], cwd) || cwd;
+  const projectName = path.basename(root).toLowerCase();
+
+  const repoScope = ownerRepo ? `repo::${ownerRepo}` : null;
+  const branchScope =
+    ownerRepo && branch && branch !== 'HEAD'
+      ? `branch::${ownerRepo}::${branch.toLowerCase()}`
+      : null;
+  const projectScope = `project::${projectName}`;
+
+  const readOrder = [branchScope, repoScope, 'global'].filter(Boolean);
+
+  return {
+    ownerRepo,
+    branch,
+    projectName,
+    repoScope,
+    branchScope,
+    projectScope,
+    readOrder,
+    hasRemote: Boolean(ownerRepo),
+  };
+}

--- a/packages/cli/src/util.mjs
+++ b/packages/cli/src/util.mjs
@@ -1,0 +1,77 @@
+// Tiny zero-dependency console helpers. No colors when not a TTY (CI-friendly).
+import process from 'node:process';
+
+const useColor = process.stdout.isTTY && process.env.NO_COLOR === undefined;
+
+const wrap = (code) => (s) => (useColor ? `[${code}m${s}[0m` : String(s));
+
+export const c = {
+  bold: wrap('1'),
+  dim: wrap('2'),
+  red: wrap('31'),
+  green: wrap('32'),
+  yellow: wrap('33'),
+  cyan: wrap('36'),
+};
+
+export const sym = {
+  pass: useColor ? c.green('✓') : 'PASS',
+  fail: useColor ? c.red('✗') : 'FAIL',
+  warn: useColor ? c.yellow('!') : 'WARN',
+  info: useColor ? c.cyan('•') : '-',
+};
+
+export function log(msg = '') {
+  process.stdout.write(`${msg}\n`);
+}
+
+export function err(msg = '') {
+  process.stderr.write(`${msg}\n`);
+}
+
+export function heading(title) {
+  log(`\n${c.bold(title)}`);
+}
+
+// A single doctor-style status line.
+export function status(kind, label, detail) {
+  const mark = sym[kind] ?? sym.info;
+  const tail = detail ? ` ${c.dim('— ' + detail)}` : '';
+  log(`  ${mark} ${label}${tail}`);
+}
+
+// Minimal flag parser: --key value, --key=value, -k value, and bare --flags.
+// `aliases` maps short → long; `booleans` lists flags that take no value.
+export function parseArgs(argv, { aliases = {}, booleans = [] } = {}) {
+  const out = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    let token = argv[i];
+    if (!token.startsWith('-')) {
+      out._.push(token);
+      continue;
+    }
+    let value;
+    const eq = token.indexOf('=');
+    if (eq !== -1) {
+      value = token.slice(eq + 1);
+      token = token.slice(0, eq);
+    }
+    let key = token.replace(/^-+/, '');
+    if (aliases[key]) key = aliases[key];
+    if (booleans.includes(key)) {
+      out[key] = true;
+      continue;
+    }
+    if (value === undefined) {
+      const next = argv[i + 1];
+      if (next !== undefined && !next.startsWith('-')) {
+        value = next;
+        i++;
+      } else {
+        value = true; // treat as boolean-ish when no value follows
+      }
+    }
+    out[key] = value;
+  }
+  return out;
+}

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -1,0 +1,57 @@
+// Regression tests for the .mcp.json read paths and copyDir accounting.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  readMcpConfig,
+  readLorekitServer,
+  readJsonIfExists,
+  copyDir,
+  mcpJsonPath,
+} from '../src/config.mjs';
+
+function tmpRoot() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'lk-cfg-'));
+}
+
+test('readMcpConfig distinguishes absent / valid / invalid', () => {
+  const root = tmpRoot();
+  assert.deepEqual(readMcpConfig(root), { present: false, valid: false, config: null });
+
+  fs.writeFileSync(mcpJsonPath(root), '{ this is not json ');
+  const bad = readMcpConfig(root);
+  assert.equal(bad.present, true);
+  assert.equal(bad.valid, false);
+
+  fs.writeFileSync(mcpJsonPath(root), JSON.stringify({ mcpServers: {} }));
+  const ok = readMcpConfig(root);
+  assert.equal(ok.valid, true);
+  assert.ok(ok.config.mcpServers);
+});
+
+test('readLorekitServer never throws on a malformed .mcp.json', () => {
+  const root = tmpRoot();
+  fs.writeFileSync(mcpJsonPath(root), '{ broken');
+  assert.doesNotThrow(() => readLorekitServer(root));
+  assert.equal(readLorekitServer(root), null); // degrades to "no server"
+});
+
+test('readJsonIfExists still throws on malformed JSON (install clobber-guard)', () => {
+  const root = tmpRoot();
+  fs.writeFileSync(mcpJsonPath(root), '{ broken');
+  assert.throws(() => readJsonIfExists(mcpJsonPath(root)), /Failed to parse/);
+});
+
+test('copyDir reports how many files it actually wrote', () => {
+  const src = tmpRoot();
+  fs.mkdirSync(path.join(src, 'sub'));
+  fs.writeFileSync(path.join(src, 'a.txt'), 'a');
+  fs.writeFileSync(path.join(src, 'sub', 'b.txt'), 'b');
+  const dest = path.join(tmpRoot(), 'out');
+
+  assert.equal(copyDir(src, dest), 2); // fresh install: both files written
+  assert.equal(copyDir(src, dest), 0); // re-run without --force: nothing written
+  assert.equal(copyDir(src, dest, { force: true }), 2); // force: both rewritten
+});

--- a/packages/cli/test/fixtures/claude-PostToolUseFailure.json
+++ b/packages/cli/test/fixtures/claude-PostToolUseFailure.json
@@ -1,0 +1,16 @@
+{
+  "adapter": "claude",
+  "event": "PostToolUseFailure",
+  "stdin": {
+    "hook_event_name": "PostToolUseFailure",
+    "session_id": "fx-cc-fail",
+    "tool_name": "Bash",
+    "tool_input": {
+      "command": "npm test"
+    },
+    "tool_response": {
+      "exit_code": 1,
+      "stderr": "boom"
+    }
+  }
+}

--- a/packages/cli/test/fixtures/claude-SessionStart.json
+++ b/packages/cli/test/fixtures/claude-SessionStart.json
@@ -1,0 +1,11 @@
+{
+  "adapter": "claude",
+  "event": "SessionStart",
+  "stdin": {
+    "hook_event_name": "SessionStart",
+    "session_id": "fx-cc-ss",
+    "cwd": "/repo",
+    "source": "startup",
+    "model": "claude-sonnet-5"
+  }
+}

--- a/packages/cli/test/fixtures/claude-Stop.json
+++ b/packages/cli/test/fixtures/claude-Stop.json
@@ -1,0 +1,10 @@
+{
+  "adapter": "claude",
+  "event": "Stop",
+  "stdin": {
+    "hook_event_name": "Stop",
+    "session_id": "fx-cc-stop",
+    "last_assistant_message": "done",
+    "stop_reason": "end_turn"
+  }
+}

--- a/packages/cli/test/fixtures/codex-PostToolUse.json
+++ b/packages/cli/test/fixtures/codex-PostToolUse.json
@@ -1,0 +1,12 @@
+{
+  "adapter": "codex",
+  "event": "PostToolUse",
+  "stdin": {
+    "hook_event_name": "PostToolUse",
+    "session_id": "fx-cx-fail",
+    "tool_name": "shell",
+    "tool_response": {
+      "is_error": true
+    }
+  }
+}

--- a/packages/cli/test/fixtures/codex-SessionStart.json
+++ b/packages/cli/test/fixtures/codex-SessionStart.json
@@ -1,0 +1,9 @@
+{
+  "adapter": "codex",
+  "event": "SessionStart",
+  "stdin": {
+    "hook_event_name": "SessionStart",
+    "session_id": "fx-cx-ss",
+    "cwd": "/repo"
+  }
+}

--- a/packages/cli/test/fixtures/codex-Stop.json
+++ b/packages/cli/test/fixtures/codex-Stop.json
@@ -1,0 +1,8 @@
+{
+  "adapter": "codex",
+  "event": "Stop",
+  "stdin": {
+    "hook_event_name": "Stop",
+    "session_id": "fx-cx-stop"
+  }
+}

--- a/packages/cli/test/fixtures/cursor-beforeSubmitPrompt.json
+++ b/packages/cli/test/fixtures/cursor-beforeSubmitPrompt.json
@@ -1,0 +1,12 @@
+{
+  "adapter": "cursor",
+  "event": "beforeSubmitPrompt",
+  "stdin": {
+    "hook_event_name": "beforeSubmitPrompt",
+    "generation_id": "fx-cu-read",
+    "workspace_roots": [
+      "/repo"
+    ],
+    "prompt": "add a feature"
+  }
+}

--- a/packages/cli/test/fixtures/cursor-stop.json
+++ b/packages/cli/test/fixtures/cursor-stop.json
@@ -1,0 +1,8 @@
+{
+  "adapter": "cursor",
+  "event": "stop",
+  "stdin": {
+    "hook_event_name": "stop",
+    "generation_id": "fx-cu-stop"
+  }
+}

--- a/packages/cli/test/frameworks.test.mjs
+++ b/packages/cli/test/frameworks.test.mjs
@@ -1,0 +1,123 @@
+// Cross-framework conformance:
+//   1. Replay recorded/seed payloads through the real binary and assert the
+//      stdout matches each host's documented output contract.
+//   2. Validate each host's wiring config (Claude via `claude plugin validate`
+//      when available; Cursor/Codex structurally).
+//   3. Assert the vendored Claude skill is in sync with its single source.
+//
+// Fixtures live in test/fixtures/. Seed payloads ship with the repo; run each
+// framework once with LOREKIT_HOOK_RECORD=<dir> to overwrite them with the real
+// payloads that framework sends, then this suite proves conformance offline.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = fileURLToPath(new URL('.', import.meta.url));
+const BIN = path.join(HERE, '..', 'bin', 'lorekit.mjs');
+const REPO = path.join(HERE, '..', '..', '..');
+const FIXTURES = path.join(HERE, 'fixtures');
+
+function freshStateDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'lk-fx-'));
+}
+
+function runFixture(fx) {
+  const args = [BIN, 'hook', '--adapter', fx.adapter, '--dir', REPO];
+  if (fx.event) args.push('--event', fx.event);
+  return execFileSync('node', args, {
+    input: JSON.stringify(fx.stdin),
+    encoding: 'utf8',
+    env: { ...process.env, CLAUDE_PLUGIN_DATA: freshStateDir() },
+  });
+}
+
+// Each host's stdout contract. Returns true if `obj` is a valid injection.
+function conformsToContract(adapter, event, obj) {
+  if (adapter === 'claude' || adapter === 'codex') {
+    const h = obj.hookSpecificOutput;
+    return !!h && typeof h.additionalContext === 'string' && h.hookEventName === event;
+  }
+  if (adapter === 'cursor') {
+    return typeof obj.followup_message === 'string';
+  }
+  return false;
+}
+
+// Events that MUST produce output regardless of MCP connectivity.
+const ALWAYS_EMITS = new Set(['Stop', 'stop', 'PostToolUseFailure']);
+
+const fixtureFiles = fs
+  .readdirSync(FIXTURES)
+  .filter((f) => f.endsWith('.json'))
+  .sort();
+
+test('fixtures exist for every adapter', () => {
+  const adapters = new Set(
+    fixtureFiles.map((f) => JSON.parse(fs.readFileSync(path.join(FIXTURES, f), 'utf8')).adapter),
+  );
+  for (const a of ['claude', 'cursor', 'codex']) {
+    assert.ok(adapters.has(a), `missing a fixture for adapter "${a}"`);
+  }
+});
+
+for (const file of fixtureFiles) {
+  const fx = JSON.parse(fs.readFileSync(path.join(FIXTURES, file), 'utf8'));
+  test(`fixture ${file} → output conforms to the ${fx.adapter} contract`, () => {
+    const out = runFixture(fx);
+    if (out === '') {
+      // Empty is only acceptable for events that need MCP connectivity (reads).
+      assert.ok(!ALWAYS_EMITS.has(fx.event), `${file} produced no output but its event must always emit`);
+      return;
+    }
+    let obj;
+    assert.doesNotThrow(() => (obj = JSON.parse(out)), `${file} produced non-JSON stdout`);
+    assert.ok(conformsToContract(fx.adapter, fx.event, obj), `${file} output violates the ${fx.adapter} contract: ${out}`);
+  });
+}
+
+test('Claude plugin config validates (claude plugin validate)', (t) => {
+  const version = spawnSync('claude', ['--version'], { encoding: 'utf8' });
+  if (version.status !== 0) {
+    t.skip('claude CLI not installed');
+    return;
+  }
+  const res = spawnSync('claude', ['plugin', 'validate', path.join(REPO, 'plugins', 'lorekit-claude')], {
+    encoding: 'utf8',
+    timeout: 60000,
+  });
+  assert.equal(res.status, 0, `claude plugin validate failed:\n${res.stdout}\n${res.stderr}`);
+});
+
+test('Cursor hooks.json is structurally valid', () => {
+  const cfg = JSON.parse(fs.readFileSync(path.join(REPO, 'plugins', 'lorekit-cursor', 'hooks.json'), 'utf8'));
+  assert.equal(cfg.version, 1);
+  assert.ok(Array.isArray(cfg.hooks.stop) && cfg.hooks.stop.length > 0);
+  assert.match(cfg.hooks.stop[0].command, /@lorekit\/cli/);
+  assert.match(cfg.hooks.stop[0].command, /--adapter cursor/);
+  const rule = fs.readFileSync(path.join(REPO, 'plugins', 'lorekit-cursor', 'rules', 'lorekit-memory.mdc'), 'utf8');
+  assert.match(rule, /alwaysApply:\s*true/);
+});
+
+test('Codex config declares the feature flag, MCP server, and hooks', () => {
+  const toml = fs.readFileSync(path.join(REPO, 'plugins', 'lorekit-codex', 'config.toml.example'), 'utf8');
+  assert.match(toml, /codex_hooks\s*=\s*true/);
+  assert.match(toml, /\[mcp_servers\.lorekit\]/);
+  for (const ev of ['SessionStart', 'PostToolUse', 'Stop']) {
+    assert.match(toml, new RegExp(`\\[\\[hooks\\.${ev}\\]\\]`), `config.toml missing [[hooks.${ev}]]`);
+  }
+  const hooks = JSON.parse(fs.readFileSync(path.join(REPO, 'plugins', 'lorekit-codex', 'hooks.json'), 'utf8'));
+  for (const ev of ['SessionStart', 'PostToolUse', 'Stop']) {
+    assert.ok(Array.isArray(hooks.hooks[ev]), `hooks.json missing ${ev}`);
+  }
+});
+
+test('the vendored Claude skill is in sync with its source', () => {
+  const res = spawnSync('node', [path.join(REPO, 'scripts', 'sync-plugin-skill.mjs'), '--check'], {
+    encoding: 'utf8',
+  });
+  assert.equal(res.status, 0, res.stdout + res.stderr);
+});

--- a/packages/cli/test/hook.integration.test.mjs
+++ b/packages/cli/test/hook.integration.test.mjs
@@ -1,0 +1,179 @@
+// End-to-end: spawn the real `lorekit hook` binary, feed each host's JSON on
+// stdin, and assert the stdout injection. Covers the full path including
+// argument parsing, stdin reading, throttling, and (via a mock MCP server)
+// the SessionStart lesson-read path.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { execFileSync, spawn } from 'node:child_process';
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BIN = fileURLToPath(new URL('../bin/lorekit.mjs', import.meta.url));
+const REPO = fileURLToPath(new URL('../../../', import.meta.url));
+
+function freshStateDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'lk-hook-'));
+}
+
+// Run the hook binary. Always returns { stdout, code } — the hook must exit 0.
+function runHook({ adapter, event, input = {}, dir = REPO, env = {} }) {
+  const args = [BIN, 'hook', '--adapter', adapter, '--dir', dir];
+  if (event) args.push('--event', event);
+  let stdout = '';
+  let code = 0;
+  try {
+    stdout = execFileSync('node', args, {
+      input: JSON.stringify(input),
+      encoding: 'utf8',
+      env: { CLAUDE_PLUGIN_DATA: freshStateDir(), ...process.env, ...env },
+    });
+  } catch (e) {
+    code = e.status ?? 1;
+    stdout = e.stdout ? String(e.stdout) : '';
+  }
+  return { stdout, code };
+}
+
+// Async variant — required whenever the test process also runs a server the
+// child talks to, since execFileSync would block this process's event loop.
+function runHookAsync({ adapter, event, input = {}, dir = REPO, env = {} }) {
+  return new Promise((resolve) => {
+    const args = [BIN, 'hook', '--adapter', adapter, '--dir', dir];
+    if (event) args.push('--event', event);
+    const child = spawn('node', args, {
+      env: { CLAUDE_PLUGIN_DATA: freshStateDir(), ...process.env, ...env },
+    });
+    let stdout = '';
+    child.stdout.on('data', (d) => (stdout += d));
+    child.on('close', (code) => resolve({ stdout, code }));
+    child.stdin.end(JSON.stringify(input));
+  });
+}
+
+test('claude Stop injects a retrospective nudge', () => {
+  const { stdout, code } = runHook({
+    adapter: 'claude',
+    input: { hook_event_name: 'Stop', session_id: 'stop-1' },
+  });
+  assert.equal(code, 0);
+  const out = JSON.parse(stdout);
+  assert.equal(out.hookSpecificOutput.hookEventName, 'Stop');
+  assert.match(out.hookSpecificOutput.additionalContext, /retrospective/i);
+});
+
+test('claude PostToolUseFailure nudges even with an empty response (guaranteed failure)', () => {
+  const { stdout } = runHook({
+    adapter: 'claude',
+    input: { hook_event_name: 'PostToolUseFailure', session_id: 'f-1', tool_name: 'Edit', tool_response: {} },
+  });
+  assert.match(JSON.parse(stdout).hookSpecificOutput.additionalContext, /failed/);
+});
+
+test('claude PostToolUse with exit_code 0 stays silent', () => {
+  const { stdout } = runHook({
+    adapter: 'claude',
+    input: { hook_event_name: 'PostToolUse', session_id: 'ok-1', tool_name: 'Bash', tool_response: { exit_code: 0 } },
+  });
+  assert.equal(stdout, '');
+});
+
+test('codex PostToolUse uses the failure heuristic (is_error)', () => {
+  const { stdout } = runHook({
+    adapter: 'codex',
+    input: { hook_event_name: 'PostToolUse', session_id: 'cx-1', tool_name: 'shell', tool_response: { is_error: true } },
+  });
+  assert.match(JSON.parse(stdout).hookSpecificOutput.additionalContext, /failed/);
+});
+
+test('cursor stop returns a followup_message', () => {
+  const { stdout } = runHook({
+    adapter: 'cursor',
+    input: { hook_event_name: 'stop', generation_id: 'g-1' },
+  });
+  assert.match(JSON.parse(stdout).followup_message, /retrospective/i);
+});
+
+test('unknown adapter exits 0 and prints nothing', () => {
+  const { stdout, code } = runHook({ adapter: 'nope', input: { hook_event_name: 'Stop' } });
+  assert.equal(code, 0);
+  assert.equal(stdout, '');
+});
+
+test('malformed stdin exits 0 and prints nothing', () => {
+  let stdout = '';
+  let code = 0;
+  try {
+    stdout = execFileSync('node', [BIN, 'hook', '--adapter', 'claude', '--event', 'Stop', '--dir', REPO], {
+      input: 'this is not json',
+      encoding: 'utf8',
+      env: { CLAUDE_PLUGIN_DATA: freshStateDir(), ...process.env },
+    });
+  } catch (e) {
+    code = e.status ?? 1;
+  }
+  // Stop has no tool data and needs no stdin fields, so it still nudges;
+  // the point is it must not crash on unparseable input.
+  assert.equal(code, 0);
+  assert.ok(stdout === '' || stdout.includes('retrospective'));
+});
+
+test('the nudge fires at most once per session (throttle)', () => {
+  const state = freshStateDir();
+  const input = { hook_event_name: 'Stop', session_id: 'dup-1' };
+  const a = runHook({ adapter: 'claude', input, env: { CLAUDE_PLUGIN_DATA: state } });
+  const b = runHook({ adapter: 'claude', input, env: { CLAUDE_PLUGIN_DATA: state } });
+  assert.notEqual(a.stdout, '');
+  assert.equal(b.stdout, ''); // second call in the same session is suppressed
+});
+
+test('SessionStart reads lessons from the MCP server and injects them', async () => {
+  // Mock LoreKit MCP endpoint that returns one lesson for any scope.
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          result: {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  entries: [{ key: 'lorekit-memory::demo', value: 'Demo lesson first line\nsecond', tags: [] }],
+                }),
+              },
+            ],
+          },
+        }),
+      );
+    });
+  });
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+  const tmpProject = freshStateDir(); // no git remote, no .mcp.json → scope 'global', creds from env
+
+  try {
+    const { stdout, code } = await runHookAsync({
+      adapter: 'claude',
+      dir: tmpProject,
+      input: { hook_event_name: 'SessionStart', session_id: 'read-1', cwd: tmpProject },
+      env: {
+        LOREKIT_MCP_URL: `http://127.0.0.1:${port}/mcp`,
+        LOREKIT_TOKEN: 'lk_ro_test',
+      },
+    });
+    assert.equal(code, 0);
+    const ctx = JSON.parse(stdout).hookSpecificOutput.additionalContext;
+    assert.match(ctx, /lorekit-memory::demo/);
+    assert.match(ctx, /Demo lesson first line/);
+    assert.doesNotMatch(ctx, /second/); // only the first line is summarized
+  } finally {
+    server.close();
+  }
+});

--- a/packages/cli/test/hooks.test.mjs
+++ b/packages/cli/test/hooks.test.mjs
@@ -1,0 +1,72 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isFailure } from '../src/core/failure.mjs';
+import { formatLessons, retrospectiveNudge, failureNudge } from '../src/core/lessons.mjs';
+import { claude } from '../src/adapters/claude.mjs';
+import { cursor } from '../src/adapters/cursor.mjs';
+import { codex } from '../src/adapters/codex.mjs';
+
+test('isFailure reads exit codes and error flags conservatively', () => {
+  assert.equal(isFailure('Bash', { exit_code: 1 }), true);
+  assert.equal(isFailure('Bash', { exit_code: 0 }), false);
+  assert.equal(isFailure('Bash', { exitCode: 2 }), true);
+  assert.equal(isFailure('X', { is_error: true }), true);
+  assert.equal(isFailure('X', { status: 'error' }), true);
+  assert.equal(isFailure('X', { status: 'success' }), false);
+  assert.equal(isFailure('X', { interrupted: true }), false); // user abort, not a lesson
+  assert.equal(isFailure('X', {}), false);
+  assert.equal(isFailure('X', null), false);
+});
+
+test('formatLessons returns null when empty and a block otherwise', () => {
+  assert.equal(formatLessons([], { repoScope: 'repo::a/b' }), null);
+  const out = formatLessons(
+    [{ key: 'k1', value: 'first line\nsecond', scope: 'repo::a/b' }],
+    { repoScope: 'repo::a/b' },
+  );
+  assert.match(out, /k1/);
+  assert.match(out, /repo::a\/b/);
+  assert.match(out, /considerations, not rules/);
+  assert.doesNotMatch(out, /second/); // only the first line is included
+});
+
+test('nudges name the write scope', () => {
+  assert.match(retrospectiveNudge({ repoScope: 'repo::a/b' }), /memory\.write to repo::a\/b/);
+  assert.match(failureNudge('Bash', { repoScope: null }), /memory\.write to global/);
+});
+
+test('adapter event → intent mapping', () => {
+  assert.equal(claude.intentFor('SessionStart'), 'read');
+  assert.equal(claude.intentFor('PostToolUse'), 'failure');
+  assert.equal(claude.intentFor('PostToolUseFailure'), 'failure');
+  assert.equal(claude.intentFor('Stop'), 'retrospective');
+  assert.equal(claude.intentFor('Whatever'), 'noop');
+
+  assert.equal(codex.intentFor('SessionStart'), 'read');
+  assert.equal(codex.intentFor('Stop'), 'retrospective');
+
+  assert.equal(cursor.intentFor('beforeSubmitPrompt'), 'read');
+  assert.equal(cursor.intentFor('stop'), 'retrospective');
+  assert.equal(cursor.intentFor('beforeShellExecution'), 'noop');
+});
+
+test('adapters emit their framework-specific output shape', () => {
+  assert.deepEqual(JSON.parse(claude.emit('Stop', 'hi')), {
+    hookSpecificOutput: { hookEventName: 'Stop', additionalContext: 'hi' },
+  });
+  assert.deepEqual(JSON.parse(codex.emit('SessionStart', 'hi')), {
+    hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: 'hi' },
+  });
+  assert.deepEqual(JSON.parse(cursor.emit('stop', 'hi')), { followup_message: 'hi' });
+});
+
+test('adapters normalize their native stdin fields', () => {
+  const c = claude.parse({ cwd: '/p', session_id: 's', tool_name: 'Bash', tool_response: { exit_code: 1 } });
+  assert.equal(c.cwd, '/p');
+  assert.equal(c.sessionId, 's');
+  assert.equal(c.toolName, 'Bash');
+
+  const cu = cursor.parse({ generation_id: 'g', workspace_roots: ['/w'] });
+  assert.equal(cu.sessionId, 'g');
+  assert.equal(cu.cwd, '/w');
+});

--- a/packages/cli/test/unit.test.mjs
+++ b/packages/cli/test/unit.test.mjs
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { ownerRepoFromRemote } from '../src/scope.mjs';
+import { splitEndpoint, buildRemoteUrl } from '../src/mcp.mjs';
+import { tokenKind } from '../src/config.mjs';
+import { parseArgs } from '../src/util.mjs';
+
+test('ownerRepoFromRemote normalizes remote URL variants', () => {
+  assert.equal(ownerRepoFromRemote('git@github.com:mthines/LoreKit.git'), 'mthines/lorekit');
+  assert.equal(ownerRepoFromRemote('https://github.com/mthines/lorekit.git'), 'mthines/lorekit');
+  assert.equal(ownerRepoFromRemote('https://github.com/mthines/lorekit'), 'mthines/lorekit');
+  assert.equal(ownerRepoFromRemote('ssh://git@github.com/mthines/lorekit.git'), 'mthines/lorekit');
+  assert.equal(ownerRepoFromRemote(''), null);
+  assert.equal(ownerRepoFromRemote('not-a-url'), null);
+});
+
+test('splitEndpoint pulls the token out of the query string', () => {
+  const { endpoint, token } = splitEndpoint('https://ref.supabase.co/functions/v1/mcp?token=lk_rw_abc');
+  assert.equal(endpoint, 'https://ref.supabase.co/functions/v1/mcp');
+  assert.equal(token, 'lk_rw_abc');
+});
+
+test('splitEndpoint tolerates a URL with no token', () => {
+  const { endpoint, token } = splitEndpoint('https://ref.supabase.co/functions/v1/mcp');
+  assert.equal(endpoint, 'https://ref.supabase.co/functions/v1/mcp');
+  assert.equal(token, null);
+});
+
+test('buildRemoteUrl round-trips with splitEndpoint', () => {
+  const url = buildRemoteUrl('https://ref.supabase.co/functions/v1/mcp', 'lk_ro_xyz');
+  assert.equal(splitEndpoint(url).token, 'lk_ro_xyz');
+});
+
+test('tokenKind classifies by prefix', () => {
+  assert.equal(tokenKind('lk_rw_abc'), 'read-write');
+  assert.equal(tokenKind('lk_ro_abc'), 'read-only');
+  assert.equal(tokenKind('sbp_xyz'), 'unknown');
+  assert.equal(tokenKind(null), 'none');
+});
+
+test('parseArgs handles flags, values, =, and aliases', () => {
+  const args = parseArgs(['install', '-e', 'https://x', '--token=lk_rw_1', '--yes'], {
+    aliases: { e: 'endpoint', t: 'token' },
+    booleans: ['yes'],
+  });
+  assert.equal(args._[0], 'install');
+  assert.equal(args.endpoint, 'https://x');
+  assert.equal(args.token, 'lk_rw_1');
+  assert.equal(args.yes, true);
+});

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,55 @@
+# LoreKit plugins
+
+Deterministic shared-memory integrations for three coding agents. All three
+share one engine — the `lorekit hook` command in [`@lorekit/cli`](../packages/cli/) —
+and differ only in the thin, declarative config that wires it to each host.
+
+```
+                    ┌───────────────────────────────┐
+  host hook event   │  npx @lorekit/cli hook          │
+  (JSON on stdin) ─→│    --adapter <claude|cursor|…>  │─→ inject lessons /
+                    │    --event  <SessionStart|…>    │   retrospective nudge
+                    │  (scope + MCP fetch + heuristic)│   (JSON on stdout)
+                    └───────────────────────────────┘
+                                   ↕
+                       LoreKit MCP server (memory.*)
+```
+
+| Bundle | Read on start | Failure / retrospective | Notes |
+|--------|---------------|-------------------------|-------|
+| [`lorekit-claude`](./lorekit-claude/) | `SessionStart` hook | `PostToolUseFailure` + `Stop` hooks | Full Claude Code plugin (skill + hooks + MCP). Installable via the marketplace. |
+| [`lorekit-cursor`](./lorekit-cursor/) | rule (`beforeSubmitPrompt` best-effort) | `stop` hook | Cursor has no session-start / post-exec-result events; the rule carries the read path. |
+| [`lorekit-codex`](./lorekit-codex/) | `SessionStart` hook | `PostToolUse` + `Stop` hooks | Experimental (feature-flagged); `AGENTS.md` fallback included. |
+
+Why one engine and not three copies: every host invokes hooks as an external
+process with JSON over stdio, so the logic (scope derivation, MCP fetch,
+failure heuristic, retrospective) lives once in the zero-dependency CLI, and
+each per-host **adapter** only reshapes input/output to that host's contract.
+No build step is required — the CLI is plain ESM.
+
+## Claude Code (marketplace)
+
+```bash
+# From this repo (or point at the GitHub repo)
+/plugin marketplace add mthines/lorekit
+/plugin install lorekit-memory@lorekit
+```
+
+Set `LOREKIT_MCP_URL` and `LOREKIT_TOKEN` in your environment, or run
+`npx @lorekit/cli install` in the project to write a `.mcp.json`. Then
+`npx @lorekit/cli doctor` to verify.
+
+## Cursor / Codex
+
+See each bundle's README for copy-in instructions:
+[Cursor](./lorekit-cursor/README.md) · [Codex](./lorekit-codex/README.md).
+
+## Keeping the Claude skill in sync
+
+`lorekit-claude/skills/lorekit-memory/` is vendored from the single source at
+`packages/cli/skill/lorekit-memory/`. Re-sync after editing the source:
+
+```bash
+node scripts/sync-plugin-skill.mjs        # copy source → plugin
+node scripts/sync-plugin-skill.mjs --check # CI: fail if they differ
+```

--- a/plugins/lorekit-claude/.claude-plugin/plugin.json
+++ b/plugins/lorekit-claude/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "lorekit-memory",
+  "description": "Shared persistent memory for coding agents. Reads scoped lessons at session start and nudges a retrospective when a tool fails, backed by the LoreKit MCP server.",
+  "version": "1.0.0",
+  "author": { "name": "mthines" },
+  "homepage": "https://github.com/mthines/lorekit",
+  "license": "MIT",
+  "keywords": ["memory", "mcp", "lessons", "lorekit", "self-improvement"]
+}

--- a/plugins/lorekit-claude/hooks/hooks.json
+++ b/plugins/lorekit-claude/hooks/hooks.json
@@ -1,0 +1,34 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y @lorekit/cli hook --adapter claude --event SessionStart --dir \"${CLAUDE_PROJECT_DIR}\""
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y @lorekit/cli hook --adapter claude --event PostToolUseFailure --dir \"${CLAUDE_PROJECT_DIR}\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx -y @lorekit/cli hook --adapter claude --event Stop --dir \"${CLAUDE_PROJECT_DIR}\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/lorekit-claude/skills/lorekit-memory/SKILL.md
+++ b/plugins/lorekit-claude/skills/lorekit-memory/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: lorekit-memory
+description: >
+  Shared persistent memory for coding agents, backed by LoreKit's MCP server.
+  Reads scoped lessons at the start of a task or when navigating into
+  unfamiliar code (narrow-to-broad scope resolution across branch, repo,
+  project, and global), and writes a lesson when something goes wrong — a
+  stuck loop, a repeated command failure, a surprising gotcha, a near-miss,
+  or a wrong assumption that cost time. Lessons are phrased as observations
+  (never rigid rules), scoped to the narrowest namespace that fits, and
+  deduplicated on write. Use at task start, before risky operations, and
+  after any failure or retrospective. Triggers on "read lessons", "check
+  memory", "what do we know about", "remember this", "save a lesson",
+  "record this gotcha", "capture this lesson", "/lorekit-memory".
+user-invocable: true
+argument-hint: '[read|write] [scope-hint or lesson]'
+license: MIT
+metadata:
+  author: mthines
+  version: '1.0.0'
+  workflow_type: shared-memory-intake-and-retrospective
+  tags:
+    - lorekit
+    - persistent-memory
+    - shared-memory
+    - mcp
+    - lessons
+    - self-improvement
+    - retrospective
+---
+
+# LoreKit Memory
+
+Give every agent a shared, persistent memory.
+Lessons live in LoreKit (a Supabase-backed MCP server), so what one agent
+learns on one machine — or in CI — is available to every agent, everywhere,
+in the next session.
+
+This skill has two jobs, mirroring the read-on-start / write-on-failure loop
+of the `aw` autonomous-workflow agent:
+
+1. **Read** scoped lessons at the start of a task and before risky steps.
+2. **Write** a lesson when something goes wrong, so the next run avoids it.
+
+Both jobs run through LoreKit's `memory.*` MCP tools.
+If those tools are not connected, this skill is a no-op — say so once and
+continue the task; never block work because memory is unavailable.
+
+---
+
+## When to read (intake)
+
+Read at the moments where prior lessons change what you do:
+
+- **Task start** — before planning any non-trivial change.
+- **Navigation** — the first time you open an unfamiliar package, module, or subsystem.
+- **Before a risky operation** — migrations, deploys, worktree/branch surgery, force pushes, anything hard to reverse.
+
+Follow [rules/intake.md](./rules/intake.md).
+The short version: resolve the current scope, list lessons narrow-to-broad,
+and treat matches as *considerations*, not commands.
+
+## When to write (retrospective)
+
+Write when a run produces a durable observation worth carrying forward.
+The trigger is friction, not success. Ask the 30-second question:
+
+> Was there a stuck loop, a repeated failure, a surprise, a near-miss, or a
+> guess that paid off — something a future run would benefit from knowing?
+
+If yes, write it. If the answer is genuinely nothing, write nothing —
+empty retrospectives are skipped entirely.
+
+Follow [rules/retrospective.md](./rules/retrospective.md).
+The short version: phrase the lesson as an observation, pick the narrowest
+scope that fits, check for a near-duplicate first, then `memory.write`.
+
+---
+
+## Scope in one line
+
+Lessons are partitioned by a canonical scope string (`::` is the only separator):
+
+```text
+global                                universal principles
+project::{name}                       monorepo-wide
+repo::{owner}/{repo}                   this repository's codebase
+branch::{owner}/{repo}::{branch}       short-lived, this branch only
+```
+
+Read narrow-to-broad and merge; write to the narrowest scope that correctly
+describes where the lesson applies.
+Full resolution rules: [references/scope-resolution.md](./references/scope-resolution.md).
+
+---
+
+## The MCP tools
+
+| Tool | Use | Token |
+|------|-----|-------|
+| `memory.list` | List lessons for one scope (newest first, tag filter) | read |
+| `memory.search` | Full-text search across scopes (supports `repo::owner/*`) | read |
+| `memory.read` | Read one lesson by scope + key | read |
+| `memory.write` | Store or update a lesson (same scope+key updates in place) | read+write |
+
+Write tools need an `lk_rw_*` token; read tools accept `lk_rw_*` or `lk_ro_*`.
+A read-only token cannot write — if a write fails with an authorization error,
+report it and move on; do not retry.
+
+Every lesson this skill writes carries the tag `skill::lorekit-memory` plus a
+`source::<trigger>` tag (for example `source::stuck-loop`) so lessons are
+easy to find and audit later.
+
+---
+
+## Setup
+
+Install the skill and configure the MCP endpoint with the LoreKit CLI:
+
+```bash
+npx @lorekit/cli install
+npx @lorekit/cli doctor
+```
+
+`install` scaffolds this skill into `.claude/skills/` and adds the LoreKit
+server to `.mcp.json`.
+`doctor` verifies connectivity, token permission, and scope detection.
+See the CLI's own README for flags and troubleshooting.

--- a/plugins/lorekit-claude/skills/lorekit-memory/references/scope-resolution.md
+++ b/plugins/lorekit-claude/skills/lorekit-memory/references/scope-resolution.md
@@ -1,0 +1,65 @@
+# Scope resolution
+
+A scope string names the namespace a lesson belongs to.
+`::` is the **only** valid separator — a single `:` returns a 400 error.
+All segments are lowercased by the server.
+
+## The four scope types
+
+| Type | Format | Example |
+|------|--------|---------|
+| Global | `global` | `global` |
+| Project (monorepo) | `project::{name}` | `project::agent-skills` |
+| Repository | `repo::{owner}/{repo}` | `repo::mthines/lorekit` |
+| Branch | `branch::{owner}/{repo}::{branch}` | `branch::mthines/lorekit::feat/x` |
+
+## Deriving scope from the working directory
+
+1. Read the `origin` remote URL and normalize it to `owner/repo`:
+   - `git@github.com:mthines/lorekit.git` → `mthines/lorekit`
+   - `https://github.com/mthines/lorekit.git` → `mthines/lorekit`
+   - strip a trailing `.git`, lowercase the result.
+2. Read the current branch: `git rev-parse --abbrev-ref HEAD`.
+3. Compose:
+   - `repo::mthines/lorekit`
+   - `branch::mthines/lorekit::{branch}`
+4. If there is no git remote, there is no repo/branch scope — use `global`,
+   and optionally `project::{basename-of-repo-root}` for a monorepo.
+
+The LoreKit CLI's `doctor` command prints the scope it derives, which is a
+quick way to confirm the agent will read and write to the right place.
+
+## Read order (intake)
+
+Query most specific first, then merge; more specific scopes win on key collisions:
+
+```text
+branch::{owner}/{repo}::{branch}   →   repo::{owner}/{repo}   →   project::{name}   →   global
+```
+
+## Write scope (retrospective)
+
+Use the narrowest scope that correctly describes where the lesson applies:
+
+- Branch-scoped lessons do not pollute the repo's lesson set.
+- Repo-scoped lessons do not pollute global.
+- Only truly universal lessons belong in `global`.
+
+## Wildcards (search only)
+
+`memory.search` accepts an owner-level wildcard in `scopes`:
+
+```json
+{ "scopes": ["repo::mthines/*", "global"] }
+```
+
+Wildcards work **only** in `memory.search` — not in `memory.list`,
+`memory.read`, or `memory.write`.
+
+## Validation rules
+
+1. `::` is the only separator; a single `:` → 400.
+2. `repo::` must include a `/` (owner/repo); `repo::mthines` → 400.
+3. `branch::` must have exactly two `::` separators.
+4. Only `global`, `project`, `repo`, `branch` prefixes are valid.
+5. Segments are trimmed and lowercased on ingest.

--- a/plugins/lorekit-claude/skills/lorekit-memory/rules/intake.md
+++ b/plugins/lorekit-claude/skills/lorekit-memory/rules/intake.md
@@ -1,0 +1,61 @@
+# Intake — reading lessons before you act
+
+Run this at task start, on first navigation into an unfamiliar area, and
+before any hard-to-reverse operation.
+
+## 1. Resolve the current scope
+
+Derive scope from the working repository:
+
+- `origin` remote `owner/repo` → `repo::{owner}/{repo}`
+- current branch → `branch::{owner}/{repo}::{branch}`
+- no git remote → fall back to `global` (and `project::{dir}` for a monorepo)
+
+Lowercase every segment.
+See [../references/scope-resolution.md](../references/scope-resolution.md) for the exact derivation.
+
+## 2. List narrow-to-broad
+
+Query each scope from most specific to least, and merge the results:
+
+```text
+memory.list { scope: "branch::{owner}/{repo}::{branch}" }
+memory.list { scope: "repo::{owner}/{repo}" }
+memory.list { scope: "project::{name}" }        # only if a monorepo
+memory.list { scope: "global" }
+```
+
+When the same key appears at multiple levels, the **more specific scope wins**.
+
+Keep it cheap: a `limit` of 20–50 per scope is plenty.
+Filter with `tags: ["skill::lorekit-memory"]` when you only want this skill's
+lessons; drop the filter to see everything an agent has recorded.
+
+## 3. Search when the task has a keyword
+
+If the task is about a specific subsystem, error, or tool, add a full-text
+search across the owner's repos and global:
+
+```text
+memory.search {
+  q: "<subsystem or error keywords>",
+  scopes: ["repo::{owner}/*", "global"],
+  limit: 10
+}
+```
+
+## 4. Apply as considerations, not commands
+
+Lessons are observations from past runs ("last time, X went wrong when Y").
+They inform your approach and can bias decisions — but they are not rules and
+they can be stale.
+If a lesson contradicts what you observe in the current code, trust the code
+and consider writing a corrective lesson on the way out (see
+[retrospective.md](./retrospective.md)).
+
+## 5. Report briefly
+
+If lessons matched, note them in one or two lines before proceeding
+("LoreKit: 2 relevant lessons — worktree naming, migration order").
+If nothing matched, say nothing and continue.
+If the MCP tools are not connected, note it once and continue without them.

--- a/plugins/lorekit-claude/skills/lorekit-memory/rules/retrospective.md
+++ b/plugins/lorekit-claude/skills/lorekit-memory/rules/retrospective.md
@@ -1,0 +1,85 @@
+# Retrospective — writing a lesson when something goes wrong
+
+Run this after friction: a stuck loop, a repeated command failure, a
+surprising gotcha, a near-miss, a wrong assumption that cost time, or a guess
+that paid off and should be reused.
+Do **not** run it on smooth successes — there is nothing durable to record.
+
+## 1. Decide if there is a lesson
+
+Ask the 30-second question:
+
+> Would a future run in this repo (or anywhere) do better if it knew this?
+
+If no, stop — write nothing. Empty retrospectives are skipped.
+If yes, continue.
+
+## 2. Phrase it as an observation
+
+Write what happened and what worked, not a commandment.
+
+- Good: "Running `pnpm nx test mcp-core` without `supabase start` fails with a
+  connection refused error; start Supabase first."
+- Avoid: "ALWAYS start Supabase." (rules rot; observations age gracefully)
+
+Keep the body tight markdown. A sentence or three. Include the concrete
+signal (the error text, the command, the file) so future search finds it.
+
+## 3. Pick the narrowest scope that fits
+
+| The lesson is about… | Scope |
+|----------------------|-------|
+| A universal principle, true in any repo | `global` |
+| This repository's codebase or tooling | `repo::{owner}/{repo}` |
+| A monorepo-wide convention | `project::{name}` |
+| A throwaway detail of this branch only | `branch::{owner}/{repo}::{branch}` |
+
+When in doubt for a "stuff went bad" lesson, default to **repo** scope.
+Reserve `global` for things that are genuinely true everywhere.
+
+## 4. Choose a stable key
+
+Use a short, kebab-case, namespaced key so related lessons cluster and
+re-writes update in place instead of duplicating:
+
+```text
+lorekit-memory::<short-slug>
+# e.g. lorekit-memory::supabase-start-before-test
+```
+
+## 5. Deduplicate before writing
+
+Check for a near-duplicate first, so you update rather than pile up:
+
+```text
+memory.search { q: "<key words of the lesson>", scopes: ["repo::{owner}/{repo}", "global"] }
+```
+
+- Found the same situation under a key → reuse that **exact scope + key** and
+  `memory.write` an updated body (writing the same scope+key updates in place).
+  Optionally note "(seen again <short-context>)" so the recurrence is visible.
+- Nothing similar → write a new lesson with a fresh key.
+
+## 6. Write
+
+```text
+memory.write {
+  scope:        "repo::{owner}/{repo}",
+  key:          "lorekit-memory::supabase-start-before-test",
+  value:        "<observation in markdown>",
+  tags:         ["skill::lorekit-memory", "source::stuck-loop"],
+  source_agent: "<your agent name, if known>",
+  trigger:      "stuck-loop"
+}
+```
+
+Pick `trigger` / `source::*` from what actually happened:
+`stuck-loop`, `command-failure`, `gotcha`, `near-miss`, `assumption-wrong`,
+`paid-off`, or `manual`.
+
+## 7. Confirm
+
+State in one line what you recorded and where
+("LoreKit: wrote repo lesson `supabase-start-before-test`").
+If the write fails because the token is read-only or missing, say so once and
+continue — never retry a write that failed on authorization.

--- a/plugins/lorekit-codex/AGENTS.snippet.md
+++ b/plugins/lorekit-codex/AGENTS.snippet.md
@@ -1,0 +1,18 @@
+<!-- Append to your project's AGENTS.md. This is the fallback for Codex builds
+     without hooks, and a useful reinforcement even when hooks are enabled. -->
+
+## Shared memory (LoreKit)
+
+You have LoreKit MCP tools (`memory.list`, `memory.search`, `memory.read`,
+`memory.write`) for shared, persistent lessons.
+
+- **At the start of a task**, read lessons narrow-to-broad and merge them:
+  `memory.list` for `branch::{owner}/{repo}::{branch}`, then
+  `repo::{owner}/{repo}`, then `global`. Treat them as considerations, not
+  rules. Derive `{owner}/{repo}` and `{branch}` from git, lowercased.
+- **When something goes wrong** — a stuck loop, a repeated failure, a gotcha,
+  a near-miss, or a wrong assumption that cost time — record it with
+  `memory.write` to the narrowest fitting scope (default `repo::{owner}/{repo}`),
+  key `lorekit-memory::<slug>`, tags `["skill::lorekit-memory", "source::gotcha"]`,
+  phrased as an observation. Search first to update a near-duplicate. If
+  nothing durable happened, write nothing.

--- a/plugins/lorekit-codex/README.md
+++ b/plugins/lorekit-codex/README.md
@@ -1,0 +1,28 @@
+# LoreKit for Codex CLI
+
+> ⚠️ **Experimental.** Codex hooks require the `codex_hooks` feature flag, are
+> disabled on Windows, and first shipped in Codex v0.114 (2026). Codex mirrors
+> Claude Code's hook event model, so LoreKit reuses the same adapter — but the
+> exact config key layout can vary between Codex versions. If a hook does not
+> fire, check the Codex docs and adjust `config.toml.example` / `hooks.json`.
+
+## Install
+
+1. Merge `config.toml.example` into `~/.codex/config.toml` (feature flag, the
+   `lorekit` MCP server, and the three hooks). Fill in your endpoint + token.
+2. Or, if your Codex build reads a standalone `hooks.json`, use `hooks.json`
+   here instead of the `[hooks.*]` tables.
+3. Append `AGENTS.snippet.md` to your project's `AGENTS.md`. This is the
+   reliable fallback for builds without hooks and reinforces the behavior when
+   hooks are enabled.
+
+Hooks call `npx -y @lorekit/cli`; `npm i -g @lorekit/cli` lowers latency.
+Verify the connection with `npx @lorekit/cli doctor`.
+
+## What fires
+
+| Event | Behavior |
+|-------|----------|
+| `SessionStart` | Injects scoped lessons read from LoreKit |
+| `PostToolUse` | On a detected tool failure, nudges the agent to record a lesson (once per session) |
+| `Stop` | Injects the retrospective nudge (once per session) |

--- a/plugins/lorekit-codex/config.toml.example
+++ b/plugins/lorekit-codex/config.toml.example
@@ -1,0 +1,26 @@
+# LoreKit for Codex CLI — add to ~/.codex/config.toml
+#
+# Codex hooks are EXPERIMENTAL: they require the feature flag below, are
+# disabled on Windows, and first shipped in Codex v0.114. The exact hook key
+# layout may change between Codex versions — check the Codex docs if a hook
+# does not fire, and adjust the [hooks.*] tables to match.
+
+[features]
+codex_hooks = true
+
+# --- MCP server -------------------------------------------------------------
+# Replace <project-ref> and <your-lorekit-token>.
+[mcp_servers.lorekit]
+command = "npx"
+args = ["-y", "mcp-remote", "https://<project-ref>.supabase.co/functions/v1/mcp?token=<your-lorekit-token>"]
+
+# --- Hooks ------------------------------------------------------------------
+# Codex mirrors Claude Code's event model, so the same adapter is used.
+[[hooks.SessionStart]]
+command = ["npx", "-y", "@lorekit/cli", "hook", "--adapter", "codex", "--event", "SessionStart"]
+
+[[hooks.PostToolUse]]
+command = ["npx", "-y", "@lorekit/cli", "hook", "--adapter", "codex", "--event", "PostToolUse"]
+
+[[hooks.Stop]]
+command = ["npx", "-y", "@lorekit/cli", "hook", "--adapter", "codex", "--event", "Stop"]

--- a/plugins/lorekit-codex/hooks.json
+++ b/plugins/lorekit-codex/hooks.json
@@ -1,0 +1,13 @@
+{
+  "hooks": {
+    "SessionStart": [
+      { "command": ["npx", "-y", "@lorekit/cli", "hook", "--adapter", "codex", "--event", "SessionStart"] }
+    ],
+    "PostToolUse": [
+      { "command": ["npx", "-y", "@lorekit/cli", "hook", "--adapter", "codex", "--event", "PostToolUse"] }
+    ],
+    "Stop": [
+      { "command": ["npx", "-y", "@lorekit/cli", "hook", "--adapter", "codex", "--event", "Stop"] }
+    ]
+  }
+}

--- a/plugins/lorekit-cursor/README.md
+++ b/plugins/lorekit-cursor/README.md
@@ -1,0 +1,29 @@
+# LoreKit for Cursor
+
+Cursor's hook surface is narrower than Claude Code's — there is no
+`SessionStart` event and `beforeShellExecution` fires *before* a command runs
+(so there is no exit code to inspect). This bundle therefore splits the work:
+
+- **Reading lessons** is driven by a **rule** (`rules/lorekit-memory.mdc`),
+  which tells the agent to query LoreKit at task start and write lessons when
+  something goes wrong.
+- **The retrospective nudge** is driven by the **`stop` hook**, which injects a
+  `followup_message` reminding the agent to record a lesson.
+- The **`beforeSubmitPrompt` hook** is best-effort and injects lessons where the
+  Cursor version supports it; the rule is the reliable read path.
+
+## Install
+
+Copy the three files into your project (or your home `~/.cursor/`):
+
+```bash
+mkdir -p .cursor/rules
+cp plugins/lorekit-cursor/hooks.json          .cursor/hooks.json
+cp plugins/lorekit-cursor/rules/lorekit-memory.mdc  .cursor/rules/
+cp plugins/lorekit-cursor/mcp.json            .cursor/mcp.json   # then fill in your endpoint + token
+```
+
+Hooks call `npx -y @lorekit/cli` — install it globally (`npm i -g @lorekit/cli`)
+for lower latency and change the command to `lorekit` if you prefer.
+
+Verify with `npx @lorekit/cli doctor`.

--- a/plugins/lorekit-cursor/hooks.json
+++ b/plugins/lorekit-cursor/hooks.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "beforeSubmitPrompt": [
+      { "command": "npx -y @lorekit/cli hook --adapter cursor --event beforeSubmitPrompt" }
+    ],
+    "stop": [
+      { "command": "npx -y @lorekit/cli hook --adapter cursor --event stop" }
+    ]
+  }
+}

--- a/plugins/lorekit-cursor/mcp.json
+++ b/plugins/lorekit-cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "lorekit": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://<project-ref>.supabase.co/functions/v1/mcp?token=<your-lorekit-token>"]
+    }
+  }
+}

--- a/plugins/lorekit-cursor/rules/lorekit-memory.mdc
+++ b/plugins/lorekit-cursor/rules/lorekit-memory.mdc
@@ -1,0 +1,44 @@
+---
+description: Read and write shared lessons via LoreKit at the start of a task and when something goes wrong.
+alwaysApply: true
+---
+
+# LoreKit shared memory
+
+You have access to LoreKit, a shared persistent memory, through its MCP tools
+(`memory.list`, `memory.search`, `memory.read`, `memory.write`).
+
+Cursor cannot inject lessons automatically at session start, so it is your
+job to use LoreKit at the right moments:
+
+## Read at the start of a task
+
+Before planning a non-trivial change, and the first time you open an
+unfamiliar part of the codebase, read prior lessons narrow-to-broad and merge
+them (more specific scope wins):
+
+1. `memory.list { scope: "branch::{owner}/{repo}::{branch}" }`
+2. `memory.list { scope: "repo::{owner}/{repo}" }`
+3. `memory.list { scope: "global" }`
+
+Derive `{owner}/{repo}` from the git `origin` remote and `{branch}` from the
+current branch, all lowercased. Treat lessons as considerations, not rules —
+trust the current code if they conflict.
+
+## Write when something goes wrong
+
+When a run hits a stuck loop, a repeated command failure, a surprising
+gotcha, a near-miss, or a wrong assumption that cost time, record it:
+
+```text
+memory.write {
+  scope: "repo::{owner}/{repo}",
+  key:   "lorekit-memory::<short-slug>",
+  value: "<what happened, phrased as an observation>",
+  tags:  ["skill::lorekit-memory", "source::gotcha"]
+}
+```
+
+Pick the narrowest scope that fits (branch / repo / project / global), and
+search first (`memory.search`) so you update a near-duplicate instead of
+creating a new one. If nothing durable happened, write nothing.

--- a/scripts/sync-plugin-skill.mjs
+++ b/scripts/sync-plugin-skill.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Sync the lorekit-memory skill from its single source into the Claude plugin.
+// Source of truth: packages/cli/skill/lorekit-memory
+// Vendored copy:   plugins/lorekit-claude/skills/lorekit-memory
+//
+//   node scripts/sync-plugin-skill.mjs          copy source → plugin
+//   node scripts/sync-plugin-skill.mjs --check  exit 1 if they differ (CI)
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const SRC = path.join(ROOT, 'packages/cli/skill/lorekit-memory');
+const DEST = path.join(ROOT, 'plugins/lorekit-claude/skills/lorekit-memory');
+
+function walk(dir, base = dir, acc = new Map()) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, base, acc);
+    else acc.set(path.relative(base, p), fs.readFileSync(p, 'utf8'));
+  }
+  return acc;
+}
+
+const check = process.argv.includes('--check');
+const src = walk(SRC);
+
+if (check) {
+  let dest;
+  try {
+    dest = walk(DEST);
+  } catch {
+    dest = new Map();
+  }
+  const diffs = [];
+  for (const [rel, content] of src) {
+    if (dest.get(rel) !== content) diffs.push(rel);
+  }
+  for (const rel of dest.keys()) {
+    if (!src.has(rel)) diffs.push(`${rel} (stale)`);
+  }
+  if (diffs.length) {
+    console.error('Plugin skill out of sync with source:\n  ' + diffs.join('\n  '));
+    console.error('Run: node scripts/sync-plugin-skill.mjs');
+    process.exit(1);
+  }
+  console.log('Plugin skill is in sync.');
+  process.exit(0);
+}
+
+fs.rmSync(DEST, { recursive: true, force: true });
+for (const [rel, content] of src) {
+  const to = path.join(DEST, rel);
+  fs.mkdirSync(path.dirname(to), { recursive: true });
+  fs.writeFileSync(to, content);
+}
+console.log(`Synced ${src.size} file(s) → ${path.relative(ROOT, DEST)}`);


### PR DESCRIPTION
Base PR of a stack. Adds a zero-dependency companion so any coding agent can use LoreKit's shared memory autonomously — read lessons on start, write a lesson when something goes wrong — plus deterministic hook integrations for Claude Code, Cursor, and Codex.

## What's here

- **`@lorekit/cli`** (`packages/cli/`, zero-dep Node ESM):
  - `install` — scaffolds the `lorekit-memory` skill into `.claude/skills/` and wires the LoreKit server into `.mcp.json` (honest `installed` / `updated (N files)` / `unchanged` reporting).
  - `doctor` — verifies runtime, skill install, `.mcp.json` (incl. a clean `invalid JSON` failure instead of a crash), token tier, MCP connectivity, and git-derived scopes; `--deep` does a write→read→delete round-trip.
  - `hook` — the shared engine behind the plugins: reads the host's JSON on stdin, injects scoped lessons at session start / a retrospective nudge on failure or stop, and **always exits 0** so it can never block the host.
- **`lorekit-memory` skill** — read-on-start / write-on-failure loop (mirrors the `aw` agent), scoped narrow→broad, lessons phrased as observations.
- **Plugins** (`plugins/`): `lorekit-claude` (marketplace plugin: skill + hooks + MCP), `lorekit-cursor` (rule + `stop` hook), `lorekit-codex` (feature-flagged hooks + `AGENTS.md` fallback, experimental). One engine, thin per-host adapters (`src/adapters/`).
- **Tests**: unit + integration (spawns the real binary + a mock MCP server) + cross-framework conformance (payload fixtures + a recorder + `claude plugin validate`). `scripts/sync-plugin-skill.mjs` keeps the vendored plugin skill in sync with its source.

## Verification
- `node --test packages/cli/test/*.test.mjs` → **38/38 green**
- `node scripts/sync-plugin-skill.mjs --check` → in sync
- The CLI is intentionally excluded from the NX TS lint/typecheck gate (zero-dep, own `node:test` suite) — documented in `eslint.config.mjs`.

## Reviewed
Two reviewer passes (9/10). Non-blocking follow-ups left as planned items, not applied:
1. `mcp.mjs` sends the token as both `Authorization: Bearer` and `?token=`; the server reads the header first, so the query copy is redundant and puts a write-token in request URLs. Deferred pending verification that the Bearer header survives the Supabase gateway (vs. the `?token=` channel `mcp-remote` uses).
2. `deriveScope` runs twice on `SessionStart` (minor redundant `git` spawns).

Stacked PRs follow: a local `.lore/` file store + `off/local/remote` control, then a local stdio MCP server.

---
_Generated by [Claude Code](https://claude.ai/code/session_019PMqhJr8ADx9gsSif6L8vm)_