### PR TITLE
feat(cli): controllable local/remote memory backend (off | local | remote)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -40,10 +40,14 @@ Verifies the setup and prints a status report:
 
 - Node runtime is 18+
 - the `lorekit-memory` skill is installed
-- `.mcp.json` has a `lorekit` server
-- endpoint is real (not the `<project-ref>` placeholder)
-- token is present and its permission tier (`lk_rw_*` vs `lk_ro_*`)
-- the MCP endpoint is reachable and the token is accepted
+- the **resolved memory mode and which source decided it**, plus any active
+  deny constraints
+- for `local`: the store path, entry count, and whether it is committed or
+  gitignored
+- for `remote`: `.mcp.json` has a `lorekit` server, the endpoint is real (not
+  the `<project-ref>` placeholder), the token and its permission tier
+  (`lk_rw_*` vs `lk_ro_*`), and that the endpoint is reachable
+- for `off`: a note that memory is disabled
 - the git-derived read/write scopes for the current directory
 
 ```bash
@@ -68,6 +72,120 @@ lorekit hook --adapter <claude|cursor|codex> --event <SessionStart|Stop|…>
 One engine serves all three hosts; each `--adapter` only reshapes input/output
 to that host's contract. See [`plugins/`](../../plugins/) for the bundles.
 
+## Memory modes & the control model
+
+Memory has a controllable backend. Three **modes**:
+
+| Mode | Where lessons live | Notes |
+|------|--------------------|-------|
+| `off` | nowhere | Memory is disabled — every hook event and store op is a silent no-op. |
+| `local` | markdown files in two tiers (see below) | **Local means _not_ on the hosted website** — local lessons never sync to the LoreKit dashboard. That is the point of local: private-by-default, greppable, git-native. |
+| `remote` | the LoreKit MCP server (hosted) | The shared, cross-machine backend. Reads stay silent until an endpoint + token are configured. This is the default. |
+
+### Local store layout — two tiers
+
+Local mode mirrors the two-tier model used by the `aw` / persistent-memory
+loops: a per-user **home** tier plus an opt-in per-repo **project** tier.
+
+| Tier | Path | Availability |
+|------|------|--------------|
+| **home** | `~/.lorekit/` (override with `LOREKIT_HOME`) | Always available — per-user, cross-repo. |
+| **project** | `<repo>/.lorekit/` (override with `LOREKIT_STORE`) | **Opt-in:** active only when the directory exists. Create it once to start persisting repo/branch lessons in the project. |
+
+Each tier is foldered by canonical scope, one markdown file per lesson, with
+YAML frontmatter (`scope, key, tags, source_agent, trigger, created, updated,
+archived_at`) and the lesson as the body:
+
+```
+~/.lorekit/            <repo>/.lorekit/     (opt-in)
+├── config.json        ├── global/
+├── global/            ├── repo/<owner>/<repo>/
+├── repo/<o>/<r>/      └── branch/<owner>/<repo>/<branch>/
+└── branch/<o>/<r>/…       └── <slug-of-key>.md
+```
+
+**Read = two-tier merge.** For each scope in the read order, entries from both
+tiers are unioned and the **project tier wins on a key collision** (closer scope
+wins), consistent with the remote narrow→broad merge.
+
+**Write routing by scope:**
+
+- `global` → **home** tier.
+- `repo::` / `branch::` → **project** tier when it exists (opted-in), else the
+  **home** tier.
+
+To start persisting repo/branch lessons in the project, create
+`<repo>/.lorekit/` (or run `lorekit migrate --to project --yes`). Commit it to
+share lessons with your team (git-native sharing); add it to `.gitignore` to
+keep them private to your checkout.
+
+**Delete / archive across tiers.** Deleting or archiving a key removes the
+closest (project) copy first; a broader **home** copy, if any, remains and takes
+a second delete. This is deliberate — one `delete` never reaches through and
+erases your cross-repo home lesson.
+
+> **Same tiering, two realizations (local ⟷ remote).** The tiered, closer-wins
+> merge-read is identical in both backends. Local expresses "universal vs
+> team-shared" as two physical **locations** (home dir vs committed project
+> dir); remote expresses the same distinction through the canonical **scopes**
+> in one shared DB (`global` ≈ your cross-repo home, `repo::` ≈ team-shared) —
+> sharing comes from the account/token, so remote needs no second location.
+> Different mechanism, same concept.
+
+### `lorekit migrate` — relocation / rename tool
+
+Moved or renamed a local store (e.g. an old `.lore/`)? `migrate` re-writes its
+entries into the current two-tier layout so lessons are never stranded:
+
+```bash
+lorekit migrate --from .lore              # dry-run: preview counts per scope
+lorekit migrate --from .lore --yes        # apply, routing each entry by scope
+lorekit migrate --from .lore --to project --yes   # force all entries into the project tier
+```
+
+Dry-run (preview) by default; `--yes` (or `--apply`) applies. Idempotent — a
+re-run is a no-op. It reads LoreKit's own on-disk format only (it does **not**
+import persistent-memory's `~/.agent-memory/<bucket>/` format).
+
+### The control model — two layers, deny-wins
+
+Two config layers decide the mode:
+
+- **User / machine** — env `LOREKIT_MODE`, `LOREKIT_HOME`, `LOREKIT_STORE`,
+  `LOREKIT_DENY` (and `LOREKIT_MCP_URL` / `LOREKIT_TOKEN` for remote), plus a
+  user config file `~/.lorekit/config.json`.
+- **Repo / team** — a `.lorekit.json` at the repo root (and/or the existing
+  `lorekit` block in `.mcp.json` for the connection).
+
+Both files share one schema:
+
+```jsonc
+{
+  "mode": "local",        // select a mode (off | local | remote)
+  "store": ".lorekit",    // project-tier store dir (relative to repo root, or absolute)
+  "deny": ["remote"]      // forbid modes outright — deny always wins
+}
+```
+
+**Precedence (a _selection_ within what is allowed):**
+`env LOREKIT_MODE` → user config `mode` → repo config `mode` → built-in default
+(`remote`).
+
+**Constraints (`deny`) always win.** Denies are a **union** across every source
+and only ever accumulate — a user-level hard opt-out is a **ceiling the repo
+cannot override**:
+
+- A user who declares `"deny": ["remote"]` (privacy / compliance) can never be
+  flipped to remote by any repo default or env flag — they resolve to `local`
+  (if they selected it) or `off`, never `remote`.
+- A repo or CI job that declares `"deny": ["local"]` (no `.lorekit/` in the tree)
+  makes local unselectable there — an env `LOREKIT_MODE=local` is capped, and
+  resolution falls through to `remote`, or `off` if both are denied.
+
+`off` is never deniable, so it is always the terminal fallback. Run
+`lorekit doctor` to see the resolved mode, **which source decided it**, and any
+active deny constraints.
+
 ## Options
 
 | Flag | Meaning |
@@ -75,7 +193,12 @@ to that host's contract. See [`plugins/`](../../plugins/) for the bundles.
 | `-d, --dir <path>` | Target project root (default: cwd) |
 | `-e, --endpoint <url>` | LoreKit MCP endpoint |
 | `-t, --token <token>` | LoreKit token |
-| `-y, --yes` | Non-interactive; never prompt |
+| `--mode <mode>` | Memory mode override for `doctor`: `off` / `local` / `remote` |
+| `--store <path>` | Local project-tier store directory (default `.lorekit`) |
+| `--from <path>` | Source store to migrate from (`migrate`) |
+| `--to <tier>` | Migration destination tier: `home` / `project` (`migrate`; default routes by scope) |
+| `--apply` | Apply the migration — alias of `--yes` (`migrate`) |
+| `-y, --yes` | Non-interactive / apply; never prompt |
 | `--force` | Overwrite existing skill files (`install`) |
 | `--deep` | Write/read/delete round-trip (`doctor`) |
 | `--adapter <name>` | Host framework for `hook`: `claude` / `cursor` / `codex` |
@@ -87,6 +210,10 @@ to that host's contract. See [`plugins/`](../../plugins/) for the bundles.
 
 | Variable | Purpose |
 |----------|---------|
+| `LOREKIT_MODE` | select a mode: `off` / `local` / `remote` |
+| `LOREKIT_DENY` | comma-separated modes to forbid (deny-wins); e.g. `remote` |
+| `LOREKIT_HOME` | home-tier root + config directory (default `~/.lorekit`) |
+| `LOREKIT_STORE` | project-tier store directory (default `.lorekit`) |
 | `LOREKIT_MCP_URL` / `LOREKIT_ENDPOINT` | endpoint fallback |
 | `LOREKIT_TOKEN` | token fallback |
 | `NO_COLOR` | disable colored output |

--- a/packages/cli/bin/lorekit.mjs
+++ b/packages/cli/bin/lorekit.mjs
@@ -5,6 +5,7 @@ import { parseArgs, log, err, c } from '../src/util.mjs';
 import { install } from '../src/install.mjs';
 import { doctor } from '../src/doctor.mjs';
 import { hook } from '../src/hook.mjs';
+import { migrate } from '../src/migrate.mjs';
 
 const VERSION = '1.0.0';
 
@@ -17,6 +18,8 @@ ${c.bold('Commands')}
   install     Scaffold the lorekit-memory skill into .claude/skills and
               add the LoreKit server to .mcp.json.
   doctor      Verify the skill install, MCP connectivity, token, and scope.
+  migrate     Relocate a LoreKit-format local store into the current layout.
+              Dry-run by default; pass --yes to apply. Idempotent.
   hook        Hook engine for Claude Code / Cursor / Codex. Reads the host's
               JSON on stdin and injects lessons or a retrospective nudge.
               Not run by hand — wired into a plugin's hook config.
@@ -25,15 +28,25 @@ ${c.bold('Options')}
   -d, --dir <path>        Target project root (default: current directory)
   -e, --endpoint <url>    LoreKit MCP endpoint
   -t, --token <token>     LoreKit token (lk_rw_* to allow writes, lk_ro_* read-only)
-  -y, --yes               Non-interactive; never prompt
+      --mode <mode>       Memory mode: off | local | remote (doctor override)
+      --store <path>      Local project-tier store directory (default: .lorekit)
+      --from <path>       Source store to migrate from (migrate)
+      --to <tier>         Migration destination tier: home | project (migrate;
+                          default routes each entry by scope)
+      --apply             Apply the migration (alias of --yes) (migrate)
+  -y, --yes               Non-interactive / apply; never prompt
       --force             Overwrite existing skill files (install)
-      --deep              Do a write→read→delete round-trip (doctor, needs lk_rw_*)
+      --deep              Do a write→read→delete round-trip (doctor)
       --adapter <name>    Host framework for hook: claude | cursor | codex
       --event <name>      Host hook event (else read from stdin payload)
   -h, --help              Show this help
   -v, --version           Print the version
 
 ${c.bold('Environment')}
+  LOREKIT_MODE                         off | local | remote (select a mode)
+  LOREKIT_DENY                         comma list of forbidden modes (deny-wins)
+  LOREKIT_HOME                         home-tier root + config dir (default ~/.lorekit)
+  LOREKIT_STORE                        project-tier store directory (default .lorekit)
   LOREKIT_MCP_URL / LOREKIT_ENDPOINT   endpoint fallback
   LOREKIT_TOKEN                        token fallback
   NO_COLOR                             disable colored output
@@ -41,13 +54,15 @@ ${c.bold('Environment')}
 ${c.bold('Examples')}
   npx @lorekit/cli install --endpoint https://ref.supabase.co/functions/v1/mcp --token lk_rw_xxx
   npx @lorekit/cli doctor --deep
+  npx @lorekit/cli migrate --from .lore                 # preview a rename
+  npx @lorekit/cli migrate --from .lore --to project --yes
 `;
 
 async function main() {
   const argv = process.argv.slice(2);
   const args = parseArgs(argv, {
     aliases: { d: 'dir', e: 'endpoint', t: 'token', y: 'yes', h: 'help', v: 'version' },
-    booleans: ['yes', 'force', 'deep', 'help', 'version'],
+    booleans: ['yes', 'force', 'deep', 'apply', 'help', 'version'],
   });
 
   // `hook` is machine-facing: it must never print help/errors to stdout
@@ -74,6 +89,8 @@ async function main() {
       return install(args);
     case 'doctor':
       return doctor(args);
+    case 'migrate':
+      return migrate(args);
     default:
       err(`${c.red('Unknown command:')} ${command}\n`);
       log(HELP);

--- a/packages/cli/skill/lorekit-memory/SKILL.md
+++ b/packages/cli/skill/lorekit-memory/SKILL.md
@@ -46,6 +46,17 @@ Both jobs run through LoreKit's `memory.*` MCP tools.
 If those tools are not connected, this skill is a no-op — say so once and
 continue the task; never block work because memory is unavailable.
 
+> **Modes.** Memory has a controllable backend (`lorekit doctor` shows the
+> resolved one): `remote` (the hosted LoreKit server — the default), `local`
+> (markdown files in two tiers — a per-user **home** tier at `~/.lorekit/` and
+> an opt-in per-repo **project** tier at `<repo>/.lorekit/`), or `off`
+> (disabled). **`local` means _not_ on the hosted website** — local lessons stay
+> on disk and never sync to the LoreKit dashboard. `global` lessons go to home;
+> `repo`/`branch` lessons go to the project tier once you create `<repo>/.lorekit/`
+> (commit it to share with your team, or gitignore it to keep it private), else
+> home. See the `@lorekit/cli` README for the control model, the two-tier merge,
+> and precedence/deny rules.
+
 ---
 
 ## When to read (intake)

--- a/packages/cli/src/control.mjs
+++ b/packages/cli/src/control.mjs
@@ -1,0 +1,152 @@
+// The control model: decide the memory mode (off | local | remote), the store
+// target, who decided, and which deny constraints are active.
+//
+// Two layers of config, two kinds of statement:
+//   - a SELECT (`mode`) chooses a mode within what is allowed;
+//   - a DENY forbids a mode outright and can never be overridden.
+//
+// Deny always wins. Denies are a UNION across every source and only ever
+// accumulate — so a user-level "never remote" (privacy/compliance) is a ceiling
+// no repo config or default can lift, and "never local" (no `.lorekit/` in the
+// tree / CI) is enforceable the same way. `off` is always allowed (you cannot
+// deny "disabled"), so it is the terminal fallback.
+//
+// Local mode is two-tier (mirroring the persistent-memory home + project-shared
+// model): a per-user `home` tier at $LOREKIT_HOME (default `~/.lorekit/`) and an
+// opt-in per-repo `project` tier at `<repo>/.lorekit/` (overridable with
+// $LOREKIT_STORE). The resolved local `storeTarget` is `{ home, project }`.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveProjectConnection } from './config.mjs';
+import { splitEndpoint } from './mcp.mjs';
+
+export const MODES = ['off', 'local', 'remote'];
+
+// Accept a few friendly spellings, incl. persistent-memory's `backend` values.
+export function normalizeMode(v) {
+  if (typeof v !== 'string') return null;
+  const s = v.trim().toLowerCase();
+  if (['off', 'disabled', 'none', 'false'].includes(s)) return 'off';
+  if (['local', 'markdown', 'file', 'files'].includes(s)) return 'local';
+  if (['remote', 'lorekit', 'mcp', 'hosted'].includes(s)) return 'remote';
+  return null;
+}
+
+function asList(v) {
+  if (Array.isArray(v)) return v;
+  if (typeof v === 'string') return v.split(',').map((s) => s.trim()).filter(Boolean);
+  return [];
+}
+
+// Pure resolver — no IO. Given the already-loaded config objects, decide.
+// Returns { mode, storeTarget, decidedBy, denies, connection }.
+export function resolveControl({
+  env = {},
+  userConfig = {},
+  repoConfig = {},
+  connection = {},
+  root = process.cwd(),
+  home = env.LOREKIT_HOME || null,
+} = {}) {
+  // 1. Denies — union, deny-wins, accumulate (never removable).
+  const denies = [];
+  const addDeny = (mode, source) => {
+    const m = normalizeMode(mode);
+    if ((m === 'remote' || m === 'local') && !denies.some((d) => d.mode === m)) {
+      denies.push({ mode: m, source });
+    }
+  };
+  for (const m of asList(env.LOREKIT_DENY)) addDeny(m, 'env LOREKIT_DENY');
+  for (const m of asList(userConfig.deny)) addDeny(m, 'user config (~/.lorekit/config.json)');
+  for (const m of asList(repoConfig.deny)) addDeny(m, 'repo (.lorekit.json)');
+  const denied = new Set(denies.map((d) => d.mode));
+
+  // 2. Candidate selections, highest precedence first. An explicit env/flag
+  //    outranks a user preference, which outranks the repo default, which
+  //    outranks the built-in default.
+  const candidates = [];
+  const push = (mode, source) => {
+    const m = normalizeMode(mode);
+    if (m) candidates.push({ mode: m, source });
+  };
+  push(env.LOREKIT_MODE, 'env LOREKIT_MODE');
+  push(userConfig.mode ?? userConfig.backend, 'user config (~/.lorekit/config.json)');
+  push(repoConfig.mode ?? repoConfig.backend, 'repo (.lorekit.json)');
+  // Built-in default is `remote`: it preserves the pre-control behaviour where
+  // reads stay silent until a connection is configured while the retrospective
+  // / failure nudges still fire (they are backend-agnostic reminders). `off`
+  // is reached only by an explicit selection, or when `remote` is denied.
+  push(
+    'remote',
+    connection.usable
+      ? 'default (remote connection configured)'
+      : 'default (remote — not yet configured)',
+  );
+  push('off', 'terminal fallback (all selections denied)');
+
+  // 3. First candidate that is allowed. `off` is never denied, so this always
+  //    resolves. A denied higher-precedence selection is silently capped.
+  const idx = candidates.findIndex((c) => c.mode === 'off' || !denied.has(c.mode));
+  const chosen = candidates[idx];
+  const cappedModes = [
+    ...new Set(candidates.slice(0, idx).filter((c) => denied.has(c.mode)).map((c) => c.mode)),
+  ];
+  const decidedBy = cappedModes.length
+    ? `${chosen.source} (after deny: ${cappedModes.join(', ')})`
+    : chosen.source;
+
+  // 4. Store target. Local mode is two-tier: { home, project }.
+  let storeTarget = null;
+  if (chosen.mode === 'local') {
+    storeTarget = { home: home || null, project: projectDirFrom({ env, userConfig, repoConfig, root }) };
+  } else if (chosen.mode === 'remote') {
+    storeTarget = connection.endpoint || null;
+  }
+
+  return { mode: chosen.mode, storeTarget, decidedBy, denies, connection };
+}
+
+// The per-repo project-tier directory: $LOREKIT_STORE, else a `store` override
+// in either config layer, else the default `.lorekit/` at the repo root.
+function projectDirFrom({ env, userConfig, repoConfig, root }) {
+  const raw = env.LOREKIT_STORE || userConfig.store || repoConfig.store || '.lorekit';
+  return path.isAbsolute(raw) ? raw : path.join(root, raw);
+}
+
+// Resolve both local-tier directories with IO (reads the config files for a
+// `store` override). Used by `migrate` so it works regardless of the active
+// mode. `home` is the per-user tier root; `project` is the opt-in repo tier.
+export function localStoreDirs(root = process.cwd(), env = process.env) {
+  const home = userConfigDir(env);
+  const userConfig = readJson(path.join(home, 'config.json'));
+  const repoConfig = readJson(path.join(root, '.lorekit.json'));
+  return { home, project: projectDirFrom({ env, userConfig, repoConfig, root }) };
+}
+
+// IO wrapper — load env + config files, derive the connection, then resolve.
+export function loadControl(root, { env = process.env } = {}) {
+  const home = userConfigDir(env);
+  const userConfig = readJson(path.join(home, 'config.json'));
+  const repoConfig = readJson(path.join(root, '.lorekit.json'));
+  const conn = resolveProjectConnection(root, splitEndpoint);
+  const usable = Boolean(
+    conn.endpoint && conn.token && !String(conn.endpoint).includes('<project-ref>'),
+  );
+  const connection = { endpoint: conn.endpoint, token: conn.token, usable };
+  return resolveControl({ env, userConfig, repoConfig, connection, root, home });
+}
+
+// The per-user home tier root (also holds config.json): $LOREKIT_HOME, default
+// `~/.lorekit`. Moved from the old `~/.agent-memory` location.
+function userConfigDir(env) {
+  return env.LOREKIT_HOME || path.join(os.homedir(), '.lorekit');
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8')) || {};
+  } catch {
+    return {};
+  }
+}

--- a/packages/cli/src/core/lessons.mjs
+++ b/packages/cli/src/core/lessons.mjs
@@ -1,37 +1,20 @@
 // Shared hook logic: fetch and format lessons; build the nudge text.
 // Framework-agnostic — adapters shape these strings into each tool's contract.
-import { mcpCall } from '../mcp.mjs';
+// Storage is reached through the resolved store (local | remote), never a
+// backend directly, so the same read path serves every mode.
 import { deriveScope } from '../scope.mjs';
 
 const MAX_LESSONS = 15;
 
-// Pull the JSON payload out of an MCP tools/call result envelope.
-// LoreKit returns tool output as { content: [{ type: 'text', text: '<json>' }] }.
-function unwrap(result) {
-  if (!result) return null;
-  if (Array.isArray(result.content)) {
-    const text = result.content.map((c) => (c && c.text) || '').join('');
-    try {
-      return JSON.parse(text);
-    } catch {
-      return null;
-    }
-  }
-  return result;
-}
-
-// Read lessons narrow-to-broad and merge; more specific scope wins on key.
-export async function fetchLessons(endpoint, token, cwd) {
+// Read lessons narrow-to-broad through the store and merge; more specific
+// scope wins on key. Any per-scope failure is skipped (memory is best-effort).
+export async function fetchLessons(store, cwd) {
   const scope = deriveScope(cwd);
   const byKey = new Map();
   for (const s of scope.readOrder) {
-    const res = await mcpCall(endpoint, token, 'tools/call', {
-      name: 'memory.list',
-      arguments: { scope: s, limit: 25 },
-    });
-    if (!res.ok) continue;
-    const payload = unwrap(res.result);
-    const entries = payload && Array.isArray(payload.entries) ? payload.entries : [];
+    const res = await store.list({ scope: s, limit: 25 });
+    if (!res || !res.ok) continue;
+    const entries = Array.isArray(res.entries) ? res.entries : [];
     for (const e of entries) {
       if (e && e.key && !byKey.has(e.key)) byKey.set(e.key, { ...e, scope: s });
     }

--- a/packages/cli/src/doctor.mjs
+++ b/packages/cli/src/doctor.mjs
@@ -1,18 +1,21 @@
-// `lorekit doctor` — verify the skill install and the LoreKit MCP connection.
+// `lorekit doctor` — verify the skill install and the resolved memory backend.
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import process from 'node:process';
+import { execFileSync } from 'node:child_process';
 import {
   SKILL_NAME,
   resolveProjectRoot,
   skillInstallDir,
   readLorekitServer,
   readMcpConfig,
-  resolveConnection,
   tokenKind,
 } from './config.mjs';
-import { splitEndpoint, mcpCall } from './mcp.mjs';
+import { splitEndpoint } from './mcp.mjs';
 import { deriveScope } from './scope.mjs';
+import { loadControl } from './control.mjs';
+import { createStore } from './store/index.mjs';
 import { log, heading, status, c } from './util.mjs';
 
 const AUTH_CODES = new Set([401, 403, -32001]);
@@ -32,7 +35,11 @@ export async function doctor(args) {
 
   // 1. Runtime.
   const major = Number(process.versions.node.split('.')[0]);
-  record(major >= 18 ? 'pass' : 'fail', 'node runtime', `v${process.versions.node}${major < 18 ? ' — need v18+ for fetch' : ''}`);
+  record(
+    major >= 18 ? 'pass' : 'fail',
+    'node runtime',
+    `v${process.versions.node}${major < 18 ? ' — need v18+ for fetch' : ''}`,
+  );
 
   // 2. Skill installed.
   const skillMd = path.join(skillInstallDir(root), 'SKILL.md');
@@ -42,21 +49,107 @@ export async function doctor(args) {
     record('fail', `skill ${SKILL_NAME}`, 'not found — run `lorekit install`');
   }
 
-  // 3. Connection config: prefer explicit flags/env, else .mcp.json.
-  const override = resolveConnection(args);
+  // 3. Resolved control model — which mode, and who decided it.
+  const control = loadControl(root, { env: withOverrides(args) });
+  record('info', 'memory mode', `${control.mode}  ${c.dim('— decided by ' + control.decidedBy)}`);
+  for (const d of control.denies) {
+    record('info', 'deny constraint', `${d.mode} forbidden by ${d.source}`);
+  }
+
+  // 4. Mode-specific checks.
+  if (control.mode === 'off') {
+    record('info', 'memory', 'disabled — hooks and the skill are silent no-ops');
+  } else if (control.mode === 'local') {
+    await checkLocal(control, root, args, record);
+  } else {
+    await checkRemote(control, root, args, record);
+  }
+
+  // 5. Scope.
+  const scope = deriveScope(root);
+  if (scope.hasRemote) {
+    record('info', 'read scope', scope.readOrder.join('  →  '));
+    record('info', 'write scope', `${scope.repoScope} (default for "went wrong" lessons)`);
+  } else {
+    record('warn', 'scope', 'no git remote here — lessons fall back to global');
+  }
+
+  // Summary.
+  heading('Summary');
+  if (failures === 0 && warnings === 0) {
+    log(`  ${c.green('All checks passed.')} LoreKit memory is ready.`);
+  } else {
+    log(
+      `  ${failures ? c.red(failures + ' failed') : c.green('0 failed')}, ${
+        warnings ? c.yellow(warnings + ' warning(s)') : '0 warnings'
+      }.`,
+    );
+  }
+  return failures === 0 ? 0 : 1;
+}
+
+// Merge doctor's --endpoint / --token flags into the env the resolver reads, so
+// an explicit connection flag is honoured without a separate resolution path.
+function withOverrides(args) {
+  const env = { ...process.env };
+  if (args.endpoint) env.LOREKIT_MCP_URL = args.endpoint;
+  if (args.token) env.LOREKIT_TOKEN = args.token;
+  if (args.mode) env.LOREKIT_MODE = args.mode;
+  if (args.store) env.LOREKIT_STORE = args.store;
+  return env;
+}
+
+// Abbreviate the user's home directory to `~` for readable paths.
+function prettyPath(p) {
+  const home = os.homedir();
+  return p && home && p.startsWith(home) ? '~' + p.slice(home.length) : p;
+}
+
+async function checkLocal(control, root, args, record) {
+  const store = createStore(control);
+  const scope = deriveScope(root);
+  const scopes = [...new Set([...scope.readOrder, scope.branchScope, scope.repoScope])].filter(
+    Boolean,
+  );
+
+  // Home tier — per-user, cross-repo, always available.
+  record('pass', 'home store', prettyPath(store.homeDir));
+  record('info', 'home entries', `${await store.home.count(scopes)} lesson(s)`);
+
+  // Project tier — opt-in; active only when its directory exists.
+  const projRel = path.relative(root, store.projectDir) || store.projectDir;
+  if (store.projectActive()) {
+    const sharing = gitTracked(root, store.projectDir)
+      ? 'committed — shared with the team'
+      : 'gitignored — private to your checkout';
+    record('pass', 'project store', projRel);
+    record('info', 'project entries', `${await store.project.count(scopes)} lesson(s) — ${sharing}`);
+  } else {
+    record(
+      'info',
+      'project store',
+      `${projRel} — not opted-in (create it to persist repo/branch lessons here)`,
+    );
+  }
+
+  if (args.deep) await deepCheckLocal(store, scope, record);
+}
+
+async function checkRemote(control, root, args, record) {
+  const override = { endpoint: args.endpoint || null, token: args.token || null };
   const mcp = readMcpConfig(root);
   const configured = mcp.valid ? readLorekitServer(root) : null;
   const fromMcp = configured ? splitEndpoint(configured.url) : { endpoint: null, token: null };
 
-  const endpoint = override.endpoint || fromMcp.endpoint;
-  const token = override.token || fromMcp.token;
+  const endpoint = override.endpoint || fromMcp.endpoint || control.connection.endpoint;
+  const token = override.token || fromMcp.token || control.connection.token;
 
   if (mcp.present && !mcp.valid) {
     record('fail', '.mcp.json', 'invalid JSON — fix it or re-run `lorekit install`');
   } else if (configured) {
     record('pass', '.mcp.json', 'lorekit server configured');
   } else {
-    record('warn', '.mcp.json', 'no lorekit server entry — run `lorekit install`');
+    record('warn', '.mcp.json', 'no lorekit server entry — using env/flags');
   }
 
   if (!endpoint) {
@@ -73,9 +166,10 @@ export async function doctor(args) {
   else if (kind === 'unknown') record('warn', 'token', 'unrecognized prefix (expected lk_rw_* / lk_ro_*)');
   else record('pass', 'token', 'read+write (lk_rw_*)');
 
-  // 4. Connectivity.
+  // Connectivity, through the store.
+  const store = createStore({ mode: 'remote', connection: { endpoint, token } });
   if (endpoint && !endpoint.includes('<project-ref>') && token) {
-    const res = await mcpCall(endpoint, token, 'tools/list', {});
+    const res = await store.ping();
     if (res.networkError) {
       record('fail', 'connectivity', res.networkError);
     } else if (res.ok) {
@@ -84,67 +178,74 @@ export async function doctor(args) {
     } else if (res.error && AUTH_CODES.has(res.error.code)) {
       record('fail', 'connectivity', `auth rejected (${res.error.code}) — check your token`);
     } else if (res.error) {
-      // Reached the server and got a JSON-RPC envelope back; auth passed.
       record('warn', 'connectivity', `reachable, server said: ${res.error.message || res.error.code}`);
     } else {
       record('warn', 'connectivity', `unexpected response (HTTP ${res.httpStatus})`);
     }
 
-    // 5. Optional deep round-trip (write → read → clean up). Needs a rw token.
-    if (args.deep) {
-      await deepCheck(endpoint, token, root, record);
-    }
+    if (args.deep) await deepCheckRemote(store, root, record);
   } else {
     record('warn', 'connectivity', 'skipped — need a valid endpoint and token');
   }
-
-  // 6. Scope.
-  const scope = deriveScope(root);
-  if (scope.hasRemote) {
-    record('info', 'read scope', scope.readOrder.join('  →  '));
-    record('info', 'write scope', `${scope.repoScope} (default for "went wrong" lessons)`);
-  } else {
-    record('warn', 'scope', 'no git remote here — lessons fall back to global');
-  }
-
-  // Summary.
-  heading('Summary');
-  if (failures === 0 && warnings === 0) {
-    log(`  ${c.green('All checks passed.')} LoreKit memory is ready.`);
-  } else {
-    log(`  ${failures ? c.red(failures + ' failed') : c.green('0 failed')}, ${warnings ? c.yellow(warnings + ' warning(s)') : '0 warnings'}.`);
-  }
-  return failures === 0 ? 0 : 1;
 }
 
-async function deepCheck(endpoint, token, root, record) {
-  if (tokenKind(token) !== 'read-write') {
+async function deepCheckRemote(store, root, record) {
+  if (tokenKind(store.token) !== 'read-write') {
     record('warn', 'round-trip', 'skipped — needs a read+write token');
     return;
   }
   const scope = deriveScope(root);
   const writeScope = scope.repoScope || 'global';
   const key = 'lorekit-memory::doctor-check';
-  const value = 'LoreKit doctor round-trip check. Safe to delete.';
 
-  const w = await mcpCall(endpoint, token, 'tools/call', {
-    name: 'memory.write',
-    arguments: { scope: writeScope, key, value, tags: ['skill::lorekit-memory', 'source::doctor'], trigger: 'manual' },
+  const w = await store.write({
+    scope: writeScope,
+    key,
+    value: 'LoreKit doctor round-trip check. Safe to delete.',
+    tags: ['skill::lorekit-memory', 'source::doctor'],
+    trigger: 'manual',
   });
   if (!w.ok) {
     record('fail', 'round-trip', `write failed: ${w.error ? w.error.message || w.error.code : w.networkError}`);
     return;
   }
-  const r = await mcpCall(endpoint, token, 'tools/call', {
-    name: 'memory.read',
-    arguments: { scope: writeScope, key },
-  });
-  const readBack = r.ok && JSON.stringify(r.result || '').includes('round-trip');
-  record(readBack ? 'pass' : 'warn', 'round-trip', readBack ? `wrote + read back in ${writeScope}` : 'wrote, but read-back was inconclusive');
+  const r = await store.read({ scope: writeScope, key });
+  const readBack = r.ok && JSON.stringify(r.entry || '').includes('round-trip');
+  record(
+    readBack ? 'pass' : 'warn',
+    'round-trip',
+    readBack ? `wrote + read back in ${writeScope}` : 'wrote, but read-back was inconclusive',
+  );
+  await store.delete({ scope: writeScope, key, force: true });
+}
 
-  // Clean up.
-  await mcpCall(endpoint, token, 'tools/call', {
-    name: 'memory.delete',
-    arguments: { scope: writeScope, key, force: true },
+async function deepCheckLocal(store, scope, record) {
+  const writeScope = scope.repoScope || 'global';
+  const key = 'lorekit-memory::doctor-check';
+  const w = await store.write({
+    scope: writeScope,
+    key,
+    value: 'LoreKit doctor round-trip check. Safe to delete.',
+    tags: ['skill::lorekit-memory', 'source::doctor'],
+    trigger: 'manual',
   });
+  const r = await store.read({ scope: writeScope, key });
+  const readBack = w.ok && r.ok && r.entry && String(r.entry.value).includes('round-trip');
+  record(
+    readBack ? 'pass' : 'warn',
+    'round-trip',
+    readBack ? `wrote + read back in ${writeScope}` : 'write/read-back was inconclusive',
+  );
+  await store.delete({ scope: writeScope, key, force: true });
+}
+
+function gitTracked(root, dir) {
+  // Heuristic: is the store dir ignored by git? If `git check-ignore` names it,
+  // it is private; otherwise it will be committed (team-shared).
+  try {
+    execFileSync('git', ['check-ignore', '-q', dir], { cwd: root, stdio: 'ignore' });
+    return false; // ignored → private
+  } catch {
+    return true; // not ignored → tracked/committed
+  }
 }

--- a/packages/cli/src/hook.mjs
+++ b/packages/cli/src/hook.mjs
@@ -3,9 +3,10 @@
 // logic, and prints the framework-shaped injection on stdout. Always exits 0 —
 // a memory hook must never block or break the host agent.
 import process from 'node:process';
-import { resolveProjectRoot, resolveProjectConnection } from './config.mjs';
-import { splitEndpoint } from './mcp.mjs';
+import { resolveProjectRoot } from './config.mjs';
 import { deriveScope } from './scope.mjs';
+import { loadControl } from './control.mjs';
+import { createStore } from './store/index.mjs';
 import { fetchLessons, formatLessons, retrospectiveNudge, failureNudge } from './core/lessons.mjs';
 import { isFailure } from './core/failure.mjs';
 import { firstTimeThisSession } from './core/state.mjs';
@@ -68,15 +69,21 @@ async function run(args) {
     args.dir || process.env.CLAUDE_PROJECT_DIR || parsed.cwd || undefined,
   );
   const scope = deriveScope(root);
+
+  // Resolve the control model once. `off` disables every hook event — no read,
+  // no nudges — so memory can be turned off entirely without touching config.
+  const control = loadControl(root);
+  if (control.mode === 'off') return 0;
+
   const emit = (text) => {
     if (text) process.stdout.write(adapter.emit(event, text));
   };
 
   if (intent === 'read') {
     if (!firstTimeThisSession(parsed.sessionId, 'read')) return 0;
-    const { endpoint, token } = resolveProjectConnection(root, splitEndpoint);
-    if (!endpoint || !token) return 0; // memory not configured — stay silent
-    const { scope: readScope, lessons } = await fetchLessons(endpoint, token, root);
+    const store = createStore(control);
+    if (!store) return 0; // unconfigured/unusable — stay silent
+    const { scope: readScope, lessons } = await fetchLessons(store, root);
     emit(formatLessons(lessons, readScope));
     return 0;
   }

--- a/packages/cli/src/migrate.mjs
+++ b/packages/cli/src/migrate.mjs
@@ -1,0 +1,149 @@
+// `lorekit migrate --from <path> [--to home|project] [--yes|--apply]`
+//
+// Relocation / rename tool — NOT a persistent-memory importer. It reads a
+// LoreKit-format local store at <path> (e.g. an old `.lore/` directory, or a
+// store that was moved elsewhere) and re-writes its entries into the resolved
+// current-layout store(s), so lessons are never stranded by a rename or a move.
+//
+// Dry-run (preview) by default: it prints what would move, per scope, and
+// changes nothing. Only `--yes` (or `--apply`) mutates. Idempotent: entries are
+// upserted verbatim by scope+key, so a re-run is all NOOP.
+//
+// Out of scope: reading persistent-memory's `~/.agent-memory/<bucket>/INDEX.md`
+// + `entries/` format. This tool only understands LoreKit's own on-disk format.
+import fs from 'node:fs';
+import path from 'node:path';
+import { resolveProjectRoot } from './config.mjs';
+import { localStoreDirs } from './control.mjs';
+import { createLocalStore, createTwoTierStore } from './store/index.mjs';
+import { parseEntry } from './store/format.mjs';
+import { log, heading, status, err, c } from './util.mjs';
+
+// Recursively collect every parseable LoreKit entry under a base dir. The
+// canonical scope comes from each file's frontmatter, so the source layout does
+// not have to match the destination layout.
+function collectEntries(base) {
+  const out = [];
+  const walk = (dir) => {
+    let names;
+    try {
+      names = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of names) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        walk(p);
+      } else if (e.name.endsWith('.md')) {
+        try {
+          const entry = parseEntry(fs.readFileSync(p, 'utf8'));
+          if (entry && entry.scope && entry.key) out.push(entry);
+        } catch {
+          // Skip an unreadable / non-entry file rather than abort the migration.
+        }
+      }
+    }
+  };
+  walk(base);
+  return out;
+}
+
+// Full-field equality (ignoring nothing) so a re-run after apply is NOOP.
+function sameEntry(a, b) {
+  if (!a || !b) return false;
+  const norm = (e) =>
+    JSON.stringify({
+      tags: [...(e.tags || [])].sort(),
+      source_agent: e.source_agent ?? null,
+      trigger: e.trigger ?? null,
+      created: e.created ?? null,
+      updated: e.updated ?? null,
+      archived_at: e.archived_at ?? null,
+      value: e.value == null ? '' : String(e.value),
+    });
+  return norm(a) === norm(b);
+}
+
+export async function migrate(args) {
+  const root = resolveProjectRoot(args.dir);
+
+  const from = typeof args.from === 'string' ? args.from : null;
+  if (!from) {
+    err(`${c.red('migrate:')} --from <path> is required (the store to migrate from)`);
+    return 1;
+  }
+  const src = path.isAbsolute(from) ? from : path.join(root, from);
+  if (!fs.existsSync(src)) {
+    err(`${c.red('migrate:')} source not found: ${src}`);
+    return 1;
+  }
+
+  const to = typeof args.to === 'string' ? args.to.toLowerCase() : null;
+  if (to && to !== 'home' && to !== 'project') {
+    err(`${c.red('migrate:')} --to must be "home" or "project"`);
+    return 1;
+  }
+  const apply = Boolean(args.apply || args.yes);
+
+  const dirs = localStoreDirs(root);
+
+  // Resolve where each entry goes. `--to` forces a single tier; the default
+  // routes each entry by scope through the two-tier store (global → home,
+  // repo/branch → project when opted-in, else home).
+  let targetFor;
+  let destLabel;
+  if (to === 'home') {
+    const store = createLocalStore(dirs.home);
+    targetFor = () => store;
+    destLabel = `home (${dirs.home})`;
+  } else if (to === 'project') {
+    if (apply) fs.mkdirSync(dirs.project, { recursive: true }); // opt-in on apply
+    const store = createLocalStore(dirs.project);
+    targetFor = () => store;
+    destLabel = `project (${dirs.project})`;
+  } else {
+    const two = createTwoTierStore(dirs);
+    targetFor = (scope) => two.tierFor(scope);
+    destLabel = 'resolved layout (global→home, repo/branch→project-if-opted-in)';
+  }
+
+  const entries = collectEntries(src);
+
+  heading('LoreKit migrate');
+  log(`  from: ${c.dim(src)}`);
+  log(`  to:   ${c.dim(destLabel)}`);
+  log(`  mode: ${apply ? c.bold('apply') : 'dry-run — pass --yes to apply'}`);
+  log(`  found: ${entries.length} entr${entries.length === 1 ? 'y' : 'ies'}\n`);
+
+  const totals = { add: 0, update: 0, noop: 0 };
+  const byScope = new Map();
+  for (const entry of entries) {
+    const store = targetFor(entry.scope);
+    const current = store.getEntry({ scope: entry.scope, key: entry.key });
+    let verdict;
+    if (!current) verdict = 'add';
+    else if (sameEntry(current, entry)) verdict = 'noop';
+    else verdict = 'update';
+
+    totals[verdict]++;
+    const s = byScope.get(entry.scope) || { add: 0, update: 0, noop: 0 };
+    s[verdict]++;
+    byScope.set(entry.scope, s);
+
+    if (apply && verdict !== 'noop') await store.putEntry(entry);
+  }
+
+  for (const [scope, s] of byScope) {
+    status('info', scope, `${s.add} add, ${s.update} update, ${s.noop} unchanged`);
+  }
+
+  const moved = totals.add + totals.update;
+  heading('Summary');
+  log(
+    `  ${apply ? 'migrated' : 'would migrate'} ${moved} entr${moved === 1 ? 'y' : 'ies'} ` +
+      `(${totals.add} new, ${totals.update} updated), ${totals.noop} unchanged.`,
+  );
+  if (!apply && moved > 0) log(`  ${c.dim('Re-run with --yes to apply.')}`);
+  return 0;
+}

--- a/packages/cli/src/store/format.mjs
+++ b/packages/cli/src/store/format.mjs
@@ -1,0 +1,99 @@
+// On-disk entry format for the local file store.
+// Zero-dependency. An entry is a markdown file: a YAML frontmatter block whose
+// scalars are JSON-encoded (a strict subset of YAML, so the file stays valid
+// YAML and greppable) followed by the lesson body. This converges with the
+// persistent-memory entry format (frontmatter + body) so a `.lorekit/` directory
+// is interoperable — the frontmatter mirrors a LoreKit row's columns and the
+// body is the row's `value`.
+import path from 'node:path';
+
+// The frontmatter columns, in a stable order. `value` is the body, not a column.
+export const FIELDS = [
+  'scope',
+  'key',
+  'tags',
+  'source_agent',
+  'trigger',
+  'created',
+  'updated',
+  'archived_at',
+];
+
+// Serialize an entry ({ ...columns, value }) into file text.
+export function serializeEntry(entry) {
+  const fm = FIELDS.map((k) => `${k}: ${JSON.stringify(entry[k] ?? null)}`).join('\n');
+  const body = entry.value == null ? '' : String(entry.value);
+  return `---\n${fm}\n---\n${body}\n`;
+}
+
+// Parse file text back into an entry, or null when it has no frontmatter.
+// Values are JSON-decoded; a hand-edited non-JSON scalar falls back to raw text.
+export function parseEntry(text) {
+  const m = /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/.exec(text);
+  if (!m) return null;
+  const meta = {};
+  for (const line of m[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    if (!key) continue;
+    meta[key] = decode(line.slice(idx + 1).trim());
+  }
+  return { ...meta, value: m[2].replace(/\n$/, '') };
+}
+
+function decode(raw) {
+  if (raw === '') return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+// Filesystem-safe slug for a lesson key. The key stays authoritative in the
+// frontmatter, so the slug only needs to be safe and readable, not reversible.
+export function slugify(key) {
+  const s = String(key)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+  return s || 'entry';
+}
+
+// Sanitize a single path segment (owner, repo, branch part).
+function safeSeg(s) {
+  const cleaned = String(s == null ? '' : s)
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  // Neutralize dot-only segments ('.', '..', …): the char class above keeps
+  // dots (so `my.repo` survives), but a bare `..` segment would let a crafted
+  // scope traverse out of the store dir via path.join. Collapse those to '_'.
+  if (/^\.+$/.test(cleaned)) return '_';
+  return cleaned || '_';
+}
+
+// Map a canonical scope string to its directory under the store base.
+//   global                          → <base>/global
+//   project::{name}                 → <base>/project/{name}
+//   repo::{owner}/{repo}            → <base>/repo/{owner}/{repo}
+//   branch::{owner}/{repo}::{branch} → <base>/branch/{owner}/{repo}/{branch...}
+export function scopeToDir(baseDir, scope) {
+  const parts = String(scope).split('::');
+  const type = parts[0];
+  if (type === 'global') return path.join(baseDir, 'global');
+  if (type === 'project') return path.join(baseDir, 'project', safeSeg(parts[1]));
+  if (type === 'repo') {
+    const [owner, repo] = String(parts[1] || '').split('/');
+    return path.join(baseDir, 'repo', safeSeg(owner), safeSeg(repo));
+  }
+  if (type === 'branch') {
+    const [owner, repo] = String(parts[1] || '').split('/');
+    const branch = String(parts[2] || '')
+      .split('/')
+      .map(safeSeg);
+    return path.join(baseDir, 'branch', safeSeg(owner), safeSeg(repo), ...branch);
+  }
+  return path.join(baseDir, '_other', safeSeg(String(scope).replace(/::/g, '-')));
+}

--- a/packages/cli/src/store/index.mjs
+++ b/packages/cli/src/store/index.mjs
@@ -1,0 +1,18 @@
+// Store factory: build the store the resolved control model selects.
+// Returns null for `off` — callers short-circuit `off` before reaching here,
+// so a no-op store object is unnecessary.
+import { createLocalStore, createTwoTierStore } from './local.mjs';
+import { createRemoteStore } from './remote.mjs';
+
+export function createStore(control) {
+  if (!control || control.mode === 'off') return null;
+  // Local mode is two-tier: control.storeTarget is { home, project }.
+  if (control.mode === 'local') return createTwoTierStore(control.storeTarget);
+  if (control.mode === 'remote') {
+    const conn = control.connection || {};
+    return createRemoteStore({ endpoint: conn.endpoint, token: conn.token });
+  }
+  return null;
+}
+
+export { createLocalStore, createTwoTierStore, createRemoteStore };

--- a/packages/cli/src/store/local.mjs
+++ b/packages/cli/src/store/local.mjs
@@ -1,0 +1,313 @@
+// Local file store: markdown lessons under a store directory (default
+// `.lorekit/`). One file per scope+key. Implements the common store contract
+// over the filesystem. Zero-dependency (node built-ins only).
+//
+// A `TwoTierStore` (below) composes two `LocalStore`s — a per-user `home` tier
+// and an opt-in per-repo `project` tier — behind the same contract, so callers
+// (`core/lessons`, `hook`, `doctor`, `migrate`) keep talking to one interface.
+import fs from 'node:fs';
+import path from 'node:path';
+import { serializeEntry, parseEntry, slugify, scopeToDir } from './format.mjs';
+
+export function createLocalStore(baseDir) {
+  return new LocalStore(baseDir);
+}
+
+class LocalStore {
+  constructor(baseDir) {
+    this.baseDir = baseDir;
+    this.mode = 'local';
+  }
+
+  _dir(scope) {
+    return scopeToDir(this.baseDir, scope);
+  }
+
+  _files(scope) {
+    const dir = this._dir(scope);
+    let names;
+    try {
+      names = fs.readdirSync(dir);
+    } catch {
+      return [];
+    }
+    return names.filter((n) => n.endsWith('.md')).map((n) => path.join(dir, n));
+  }
+
+  _readAll(scope) {
+    const out = [];
+    for (const file of this._files(scope)) {
+      try {
+        const entry = parseEntry(fs.readFileSync(file, 'utf8'));
+        if (entry) out.push({ entry, file });
+      } catch {
+        // Skip an unreadable file rather than fail the whole listing.
+      }
+    }
+    return out;
+  }
+
+  _findByKey(scope, key) {
+    return this._readAll(scope).find((r) => r.entry.key === key) || null;
+  }
+
+  // Raw lookup by scope+key — returns the stored entry regardless of archived
+  // state (unlike read(), which hides archived). Synchronous; used by migrate
+  // to classify ADD / UPDATE / NOOP without reviving archived entries.
+  getEntry({ scope, key } = {}) {
+    const found = this._findByKey(scope, key);
+    return found ? found.entry : null;
+  }
+
+  // list({ scope, tags, limit }) → { ok, entries } — newest-first, tag-filtered,
+  // archived hidden.
+  async list({ scope, tags, limit } = {}) {
+    let rows = this._readAll(scope)
+      .map((r) => r.entry)
+      .filter((e) => !e.archived_at);
+    if (Array.isArray(tags) && tags.length) {
+      rows = rows.filter((e) => tags.every((t) => (e.tags || []).includes(t)));
+    }
+    rows.sort((a, b) => String(b.updated || '').localeCompare(String(a.updated || '')));
+    if (limit) rows = rows.slice(0, limit);
+    return { ok: true, entries: rows };
+  }
+
+  // read({ scope, key }) → { ok, entry } — null when absent or archived.
+  async read({ scope, key } = {}) {
+    const found = this._findByKey(scope, key);
+    const entry = found && !found.entry.archived_at ? found.entry : null;
+    return { ok: true, entry };
+  }
+
+  // write(...) → { ok, entry } — upsert by scope+key. Preserves `created` and
+  // refreshes `updated`; writing an archived key revives it.
+  async write({ scope, key, value, tags, source_agent, trigger } = {}) {
+    const dir = this._dir(scope);
+    fs.mkdirSync(dir, { recursive: true });
+    const now = new Date().toISOString();
+    const existing = this._findByKey(scope, key);
+    const entry = {
+      scope,
+      key,
+      tags: Array.isArray(tags) ? tags : [],
+      source_agent: source_agent || null,
+      trigger: trigger || null,
+      created: existing ? existing.entry.created || now : now,
+      updated: now,
+      archived_at: null,
+      value: value == null ? '' : String(value),
+    };
+    const file = existing ? existing.file : this._freshPath(dir, key);
+    fs.writeFileSync(file, serializeEntry(entry));
+    return { ok: true, entry };
+  }
+
+  // putEntry(entry) — verbatim upsert by scope+key. Unlike write(), it does NOT
+  // synthesize timestamps or clear archived_at: every field of the given entry
+  // is preserved as-is. This is the lossless primitive migrate uses to relocate
+  // a store (including archived entries) idempotently.
+  async putEntry(entry = {}) {
+    const scope = entry.scope;
+    const dir = this._dir(scope);
+    fs.mkdirSync(dir, { recursive: true });
+    const now = new Date().toISOString();
+    const existing = this._findByKey(scope, entry.key);
+    const full = {
+      scope,
+      key: entry.key,
+      tags: Array.isArray(entry.tags) ? entry.tags : [],
+      source_agent: entry.source_agent ?? null,
+      trigger: entry.trigger ?? null,
+      created: entry.created ?? now,
+      updated: entry.updated ?? now,
+      archived_at: entry.archived_at ?? null,
+      value: entry.value == null ? '' : String(entry.value),
+    };
+    const file = existing ? existing.file : this._freshPath(dir, entry.key);
+    fs.writeFileSync(file, serializeEntry(full));
+    return { ok: true, entry: full };
+  }
+
+  _freshPath(dir, key) {
+    const base = slugify(key);
+    let name = `${base}.md`;
+    let i = 2;
+    while (fs.existsSync(path.join(dir, name))) name = `${base}-${i++}.md`;
+    return path.join(dir, name);
+  }
+
+  // delete({ scope, key, force }) — force removes the file; soft-delete archives.
+  async delete({ scope, key, force } = {}) {
+    const found = this._findByKey(scope, key);
+    if (!found) return { ok: true, deleted: false };
+    if (force) {
+      try {
+        fs.unlinkSync(found.file);
+      } catch {
+        // Already gone — treat as deleted.
+      }
+      return { ok: true, deleted: true };
+    }
+    return this.archive({ scope, key });
+  }
+
+  async archive({ scope, key } = {}) {
+    return this._setArchived(scope, key, new Date().toISOString());
+  }
+
+  async restore({ scope, key } = {}) {
+    return this._setArchived(scope, key, null);
+  }
+
+  _setArchived(scope, key, ts) {
+    const found = this._findByKey(scope, key);
+    if (!found) return { ok: true, archived: false };
+    const entry = { ...found.entry, archived_at: ts, updated: new Date().toISOString() };
+    fs.writeFileSync(found.file, serializeEntry(entry));
+    return { ok: true, archived: ts != null, entry };
+  }
+
+  // search({ q, scopes, tags }) → { ok, entries } — keyword over key/tags/body.
+  async search({ q, scopes, tags } = {}) {
+    const needle = String(q || '').toLowerCase();
+    const out = [];
+    for (const scope of scopes || []) {
+      const { entries } = await this.list({ scope, tags });
+      for (const e of entries) {
+        const hay = `${e.key}\n${(e.tags || []).join(' ')}\n${e.value || ''}`.toLowerCase();
+        if (!needle || hay.includes(needle)) out.push(e);
+      }
+    }
+    return { ok: true, entries: out };
+  }
+
+  // Total non-archived entries across the given scopes (doctor uses this).
+  async count(scopes) {
+    let n = 0;
+    for (const scope of scopes || []) n += (await this.list({ scope })).entries.length;
+    return n;
+  }
+}
+
+// A scope string is global when its type segment is `global`.
+function isGlobalScope(scope) {
+  return String(scope).split('::')[0] === 'global';
+}
+
+// Union two entry lists, keyed by `keyFn`. The first list (winners) shadows the
+// second (losers) on a key collision — so passing the project tier first makes
+// the closer scope win, mirroring the remote narrow→broad merge in fetchLessons.
+function mergeByKey(winners, losers, keyFn) {
+  const seen = new Set();
+  const out = [];
+  for (const list of [winners, losers]) {
+    for (const e of list) {
+      const k = keyFn(e);
+      if (seen.has(k)) continue;
+      seen.add(k);
+      out.push(e);
+    }
+  }
+  return out;
+}
+
+export function createTwoTierStore({ home, project } = {}) {
+  return new TwoTierStore({ home, project });
+}
+
+// Two-tier local store: a per-user `home` tier (always available) and an opt-in
+// per-repo `project` tier (active only when its directory exists). Presents the
+// same contract as a single LocalStore:
+//   - reads (list / read / search) union both tiers, project shadowing home;
+//   - writes route by scope — global → home, everything else → project when
+//     opted-in, else home;
+//   - delete / archive / restore act on the tier that holds the visible entry
+//     (project first, then home).
+class TwoTierStore {
+  constructor({ home, project } = {}) {
+    this.mode = 'local';
+    this.homeDir = home;
+    this.projectDir = project || null;
+    this.home = new LocalStore(home);
+    this.project = this.projectDir ? new LocalStore(this.projectDir) : null;
+  }
+
+  // The project tier is opted-in when its directory exists (checked live, so a
+  // freshly-created `.lorekit/` or a migrate --to project takes effect at once).
+  projectActive() {
+    return Boolean(this.project && this.projectDir && fs.existsSync(this.projectDir));
+  }
+
+  // The LocalStore a write for `scope` should target.
+  tierFor(scope) {
+    if (isGlobalScope(scope)) return this.home;
+    return this.projectActive() ? this.project : this.home;
+  }
+
+  async list({ scope, tags, limit } = {}) {
+    const homeRes = await this.home.list({ scope, tags });
+    const projRes = this.projectActive()
+      ? await this.project.list({ scope, tags })
+      : { entries: [] };
+    const merged = mergeByKey(projRes.entries, homeRes.entries, (e) => e.key);
+    merged.sort((a, b) => String(b.updated || '').localeCompare(String(a.updated || '')));
+    return { ok: true, entries: limit ? merged.slice(0, limit) : merged };
+  }
+
+  async read({ scope, key } = {}) {
+    if (this.projectActive()) {
+      const r = await this.project.read({ scope, key });
+      if (r.entry) return r;
+    }
+    return this.home.read({ scope, key });
+  }
+
+  async write(args = {}) {
+    return this.tierFor(args.scope).write(args);
+  }
+
+  async putEntry(entry = {}) {
+    return this.tierFor(entry.scope).putEntry(entry);
+  }
+
+  async delete({ scope, key, force } = {}) {
+    if (this.projectActive()) {
+      const r = await this.project.delete({ scope, key, force });
+      if (r.deleted || r.archived) return r;
+    }
+    return this.home.delete({ scope, key, force });
+  }
+
+  async archive({ scope, key } = {}) {
+    if (this.projectActive()) {
+      const r = await this.project.archive({ scope, key });
+      if (r.entry) return r;
+    }
+    return this.home.archive({ scope, key });
+  }
+
+  async restore({ scope, key } = {}) {
+    if (this.projectActive()) {
+      const r = await this.project.restore({ scope, key });
+      if (r.entry) return r;
+    }
+    return this.home.restore({ scope, key });
+  }
+
+  async search({ q, scopes, tags } = {}) {
+    const homeRes = await this.home.search({ q, scopes, tags });
+    const projRes = this.projectActive()
+      ? await this.project.search({ q, scopes, tags })
+      : { entries: [] };
+    const merged = mergeByKey(projRes.entries, homeRes.entries, (e) => `${e.scope} ${e.key}`);
+    return { ok: true, entries: merged };
+  }
+
+  // Merged, de-duplicated non-archived count across the given scopes.
+  async count(scopes) {
+    let n = 0;
+    for (const scope of scopes || []) n += (await this.list({ scope })).entries.length;
+    return n;
+  }
+}

--- a/packages/cli/src/store/remote.mjs
+++ b/packages/cli/src/store/remote.mjs
@@ -1,0 +1,90 @@
+// Remote store: wraps the LoreKit MCP `memory.*` tools behind the common store
+// contract. Behaviour is identical to the previous direct `mcpCall` usage —
+// this only relocates it behind the interface. Zero-dependency.
+import { mcpCall } from '../mcp.mjs';
+
+// LoreKit returns tool output as { content: [{ type:'text', text:'<json>' }] }.
+function unwrap(result) {
+  if (!result) return null;
+  if (Array.isArray(result.content)) {
+    const text = result.content.map((c) => (c && c.text) || '').join('');
+    try {
+      return JSON.parse(text);
+    } catch {
+      return null;
+    }
+  }
+  return result;
+}
+
+// Drop undefined/null args so the JSON-RPC payload matches the old direct calls
+// (e.g. `memory.list` with only { scope, limit }).
+function clean(obj) {
+  const out = {};
+  for (const [k, v] of Object.entries(obj || {})) if (v !== undefined && v !== null) out[k] = v;
+  return out;
+}
+
+export function createRemoteStore({ endpoint, token } = {}) {
+  return new RemoteStore(endpoint, token);
+}
+
+class RemoteStore {
+  constructor(endpoint, token) {
+    this.endpoint = endpoint;
+    this.token = token;
+    this.mode = 'remote';
+  }
+
+  usable() {
+    return Boolean(this.endpoint && this.token && !String(this.endpoint).includes('<project-ref>'));
+  }
+
+  async _call(name, args) {
+    if (!this.usable()) return { ok: false, unusable: true };
+    return mcpCall(this.endpoint, this.token, 'tools/call', { name, arguments: args });
+  }
+
+  _entries(res) {
+    if (!res.ok) return { ok: false, error: res.error, networkError: res.networkError };
+    const payload = unwrap(res.result);
+    const entries = payload && Array.isArray(payload.entries) ? payload.entries : [];
+    return { ok: true, entries };
+  }
+
+  async list({ scope, tags, limit } = {}) {
+    return this._entries(await this._call('memory.list', clean({ scope, tags, limit })));
+  }
+
+  async search({ q, scopes, tags } = {}) {
+    return this._entries(await this._call('memory.search', clean({ q, scopes, tags })));
+  }
+
+  async read({ scope, key } = {}) {
+    const res = await this._call('memory.read', { scope, key });
+    if (!res.ok) return { ok: false, error: res.error, networkError: res.networkError };
+    const payload = unwrap(res.result);
+    return { ok: true, entry: payload && payload.entry ? payload.entry : payload };
+  }
+
+  async write(args = {}) {
+    const res = await this._call('memory.write', clean(args));
+    return { ok: res.ok, error: res.error, networkError: res.networkError, result: res.result };
+  }
+
+  async delete({ scope, key, force } = {}) {
+    const res = await this._call('memory.delete', { scope, key, force: Boolean(force) });
+    return { ok: res.ok, error: res.error, networkError: res.networkError };
+  }
+
+  async archive({ scope, key } = {}) {
+    const res = await this._call('memory.archive', { scope, key });
+    return { ok: res.ok, error: res.error, networkError: res.networkError };
+  }
+
+  // Connectivity probe for doctor — a transport check, not a memory op.
+  async ping() {
+    if (!this.usable()) return { ok: false, unusable: true };
+    return mcpCall(this.endpoint, this.token, 'tools/list', {});
+  }
+}

--- a/packages/cli/test/control.test.mjs
+++ b/packages/cli/test/control.test.mjs
@@ -1,0 +1,159 @@
+// Control-model resolver tests: mode selection, precedence, and deny-wins.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { resolveControl, normalizeMode, loadControl } from '../src/control.mjs';
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'lk-ctl-'));
+}
+
+const USABLE = { usable: true, endpoint: 'https://ref.supabase.co/functions/v1/mcp', token: 'lk_rw_x' };
+const NO_CONN = { usable: false, endpoint: null, token: null };
+
+test('normalizeMode accepts friendly spellings incl. persistent-memory backends', () => {
+  assert.equal(normalizeMode('REMOTE'), 'remote');
+  assert.equal(normalizeMode('lorekit'), 'remote');
+  assert.equal(normalizeMode('markdown'), 'local');
+  assert.equal(normalizeMode('disabled'), 'off');
+  assert.equal(normalizeMode('nonsense'), null);
+});
+
+test('default is remote when a usable connection exists (backward compatible)', () => {
+  const r = resolveControl({ connection: USABLE });
+  assert.equal(r.mode, 'remote');
+  assert.match(r.decidedBy, /default \(remote connection/);
+  assert.equal(r.storeTarget, USABLE.endpoint);
+});
+
+test('default is remote when nothing is configured (nudges fire, reads silent until usable)', () => {
+  // Preserves pre-control behaviour: the mode is remote even before a
+  // connection exists, so the backend-agnostic nudges keep firing; reads are
+  // silent because the remote store is unusable. `off` is explicit-only.
+  const r = resolveControl({ connection: NO_CONN });
+  assert.equal(r.mode, 'remote');
+  assert.match(r.decidedBy, /not yet configured/);
+  assert.equal(r.storeTarget, null);
+});
+
+test('off mode: explicit env disables even with a usable connection', () => {
+  const r = resolveControl({ env: { LOREKIT_MODE: 'off' }, connection: USABLE });
+  assert.equal(r.mode, 'off');
+  assert.match(r.decidedBy, /env LOREKIT_MODE/);
+});
+
+test('precedence: env beats user, user beats repo', () => {
+  const repoLocalUserRemote = resolveControl({
+    userConfig: { mode: 'remote' },
+    repoConfig: { mode: 'local' },
+    connection: USABLE,
+  });
+  assert.equal(repoLocalUserRemote.mode, 'remote'); // user preference wins over repo default
+  assert.match(repoLocalUserRemote.decidedBy, /user config/);
+
+  const envWins = resolveControl({
+    env: { LOREKIT_MODE: 'local' },
+    userConfig: { mode: 'remote' },
+    connection: USABLE,
+    root: '/proj',
+  });
+  assert.equal(envWins.mode, 'local'); // env beats user
+});
+
+test('WORKED CASE — never-remote user in a remote-default repo resolves local, NOT remote', () => {
+  const r = resolveControl({
+    userConfig: { mode: 'local', deny: ['remote'] }, // privacy: never remote, prefer local
+    repoConfig: { mode: 'remote' }, // repo defaults remote
+    connection: USABLE,
+    root: '/proj',
+    home: '/home/.lorekit',
+  });
+  assert.equal(r.mode, 'local');
+  assert.notEqual(r.mode, 'remote');
+  assert.ok(r.denies.some((d) => d.mode === 'remote'));
+  assert.deepEqual(r.storeTarget, { home: '/home/.lorekit', project: '/proj/.lorekit' });
+});
+
+test('WORKED CASE — never-remote user with no positive selection falls to off (never remote)', () => {
+  const r = resolveControl({
+    userConfig: { deny: ['remote'] }, // only a deny, no mode
+    repoConfig: { mode: 'remote' }, // repo only offers remote
+    connection: USABLE,
+  });
+  assert.equal(r.mode, 'off'); // capped down from the denied remote selections
+  assert.notEqual(r.mode, 'remote');
+  assert.match(r.decidedBy, /after deny: remote/);
+});
+
+test('WORKED CASE — never-local CI: repo denies local, so an env local select is capped', () => {
+  const r = resolveControl({
+    env: { LOREKIT_MODE: 'local' }, // CI job tries local
+    repoConfig: { deny: ['local'] }, // repo/CI policy: no .lore in the tree
+    connection: USABLE,
+  });
+  assert.notEqual(r.mode, 'local');
+  assert.equal(r.mode, 'remote'); // falls through to the usable remote connection
+  assert.ok(r.denies.some((d) => d.mode === 'local'));
+  assert.match(r.decidedBy, /after deny: local/);
+});
+
+test('WORKED CASE — locked-down CI denying both modes resolves off', () => {
+  // Deny both local and remote → only the terminal `off` fallback remains.
+  const r = resolveControl({
+    env: { LOREKIT_MODE: 'local', LOREKIT_DENY: 'local,remote' },
+    connection: NO_CONN,
+  });
+  assert.equal(r.mode, 'off');
+  assert.notEqual(r.mode, 'local');
+  assert.match(r.decidedBy, /after deny/);
+});
+
+test('deny-wins: a repo cannot lift a user deny (union only accumulates)', () => {
+  const r = resolveControl({
+    userConfig: { deny: ['remote'] },
+    repoConfig: { mode: 'remote' }, // repo tries to force remote — must fail
+    userConfigMode: undefined,
+    connection: USABLE,
+  });
+  assert.notEqual(r.mode, 'remote');
+  assert.ok(r.denies.some((d) => d.mode === 'remote' && /user config/.test(d.source)));
+});
+
+test('user-vs-repo selection conflict within allowed: repo default used when user is silent', () => {
+  const r = resolveControl({ repoConfig: { mode: 'local' }, connection: USABLE, root: '/p' });
+  assert.equal(r.mode, 'local');
+  assert.match(r.decidedBy, /repo/);
+});
+
+test('local storeTarget is two-tier: home from LOREKIT_HOME, project defaults to <root>/.lorekit', () => {
+  const r = resolveControl({ env: { LOREKIT_MODE: 'local', LOREKIT_HOME: '/h/.lorekit' }, root: '/p' });
+  assert.deepEqual(r.storeTarget, { home: '/h/.lorekit', project: '/p/.lorekit' });
+});
+
+test('LOREKIT_STORE / config store dir override the default .lorekit project path', () => {
+  const abs = resolveControl({
+    env: { LOREKIT_MODE: 'local', LOREKIT_HOME: '/h', LOREKIT_STORE: '/abs/lore' },
+    root: '/p',
+  });
+  assert.deepEqual(abs.storeTarget, { home: '/h', project: '/abs/lore' });
+  const rel = resolveControl({
+    env: { LOREKIT_MODE: 'local', LOREKIT_HOME: '/h', LOREKIT_STORE: 'mem' },
+    root: '/p',
+  });
+  assert.deepEqual(rel.storeTarget, { home: '/h', project: '/p/mem' });
+});
+
+test('user config is read from $LOREKIT_HOME/config.json (the ~/.lorekit move)', () => {
+  const home = tmpDir();
+  const root = tmpDir();
+  fs.writeFileSync(
+    path.join(home, 'config.json'),
+    JSON.stringify({ mode: 'local', deny: ['remote'] }),
+  );
+  const r = loadControl(root, { env: { LOREKIT_HOME: home } });
+  assert.equal(r.mode, 'local');
+  assert.ok(r.denies.some((d) => d.mode === 'remote' && /\.lorekit\/config\.json/.test(d.source)));
+  assert.deepEqual(r.storeTarget, { home, project: path.join(root, '.lorekit') });
+});

--- a/packages/cli/test/migrate.test.mjs
+++ b/packages/cli/test/migrate.test.mjs
@@ -1,0 +1,112 @@
+// `lorekit migrate` — dry-run/apply/idempotency and scope routing.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { migrate } from '../src/migrate.mjs';
+import { createLocalStore } from '../src/store/local.mjs';
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'lk-mig-'));
+}
+
+// Silence migrate's stdout/stderr for the duration of `fn`.
+async function quiet(fn) {
+  const out = process.stdout.write.bind(process.stdout);
+  const errw = process.stderr.write.bind(process.stderr);
+  process.stdout.write = () => true;
+  process.stderr.write = () => true;
+  try {
+    return await fn();
+  } finally {
+    process.stdout.write = out;
+    process.stderr.write = errw;
+  }
+}
+
+// Seed a source store with two entries across two scopes.
+function seedSource() {
+  const src = tmpDir();
+  const s = createLocalStore(src);
+  return Promise.all([
+    s.write({ scope: 'global', key: 'g1', value: 'gv', tags: ['x'] }),
+    s.write({ scope: 'repo::o/r', key: 'r1', value: 'rv', tags: ['y'] }),
+  ]).then(() => src);
+}
+
+function withHome(home, fn) {
+  const prev = process.env.LOREKIT_HOME;
+  const prevStore = process.env.LOREKIT_STORE;
+  process.env.LOREKIT_HOME = home;
+  delete process.env.LOREKIT_STORE;
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      if (prev === undefined) delete process.env.LOREKIT_HOME;
+      else process.env.LOREKIT_HOME = prev;
+      if (prevStore === undefined) delete process.env.LOREKIT_STORE;
+      else process.env.LOREKIT_STORE = prevStore;
+    });
+}
+
+test('migrate --to home: dry-run writes nothing, --yes applies, re-run is idempotent', async () => {
+  const src = await seedSource();
+  const home = tmpDir();
+  const root = tmpDir();
+
+  await withHome(home, async () => {
+    // Dry-run: no writes.
+    await quiet(() => migrate({ from: src, to: 'home', dir: root }));
+    assert.equal(createLocalStore(home).getEntry({ scope: 'global', key: 'g1' }), null);
+
+    // Apply.
+    await quiet(() => migrate({ from: src, to: 'home', apply: true, dir: root }));
+    const dest = createLocalStore(home);
+    assert.equal(dest.getEntry({ scope: 'global', key: 'g1' }).value, 'gv');
+    assert.equal(dest.getEntry({ scope: 'repo::o/r', key: 'r1' }).value, 'rv');
+
+    // Idempotent: a second apply leaves the entries byte-identical.
+    const before = dest.getEntry({ scope: 'global', key: 'g1' });
+    await quiet(() => migrate({ from: src, to: 'home', apply: true, dir: root }));
+    const after = createLocalStore(home).getEntry({ scope: 'global', key: 'g1' });
+    assert.deepEqual(after, before);
+    assert.equal((await createLocalStore(home).list({ scope: 'global' })).entries.length, 1);
+  });
+});
+
+test('migrate default routing: global→home; repo→home when project not opted-in', async () => {
+  const src = await seedSource();
+  const home = tmpDir();
+  const root = tmpDir(); // no .lorekit/ under root → project tier not opted-in
+
+  await withHome(home, async () => {
+    await quiet(() => migrate({ from: src, apply: true, dir: root }));
+    const dest = createLocalStore(home);
+    assert.equal(dest.getEntry({ scope: 'global', key: 'g1' }).value, 'gv');
+    assert.equal(dest.getEntry({ scope: 'repo::o/r', key: 'r1' }).value, 'rv');
+    // Nothing landed in a project dir (it does not exist).
+    assert.equal(fs.existsSync(path.join(root, '.lorekit')), false);
+  });
+});
+
+test('migrate --to project creates the opted-in project dir on apply', async () => {
+  const src = await seedSource();
+  const home = tmpDir();
+  const root = tmpDir();
+
+  await withHome(home, async () => {
+    await quiet(() => migrate({ from: src, to: 'project', apply: true, dir: root }));
+    const proj = createLocalStore(path.join(root, '.lorekit'));
+    assert.equal(proj.getEntry({ scope: 'repo::o/r', key: 'r1' }).value, 'rv');
+    assert.equal(proj.getEntry({ scope: 'global', key: 'g1' }).value, 'gv');
+  });
+});
+
+test('migrate errors when --from is missing or does not exist', async () => {
+  const home = tmpDir();
+  await withHome(home, async () => {
+    assert.equal(await quiet(() => migrate({ dir: tmpDir() })), 1);
+    assert.equal(await quiet(() => migrate({ from: '/no/such/store', dir: tmpDir() })), 1);
+  });
+});

--- a/packages/cli/test/store.test.mjs
+++ b/packages/cli/test/store.test.mjs
@@ -1,0 +1,255 @@
+// Local file store + on-disk format tests.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { serializeEntry, parseEntry, slugify, scopeToDir } from '../src/store/format.mjs';
+import { createLocalStore, createTwoTierStore } from '../src/store/local.mjs';
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'lk-store-'));
+}
+
+test('serializeEntry / parseEntry round-trip', () => {
+  const entry = {
+    scope: 'repo::mthines/lorekit',
+    key: 'aw-lessons::foo-bar',
+    tags: ['skill::aw-lessons', 'type::procedural'],
+    source_agent: 'aw',
+    trigger: 'stuck-loop',
+    created: '2026-07-24T10:00:00.000Z',
+    updated: '2026-07-24T10:00:00.000Z',
+    archived_at: null,
+    value: 'First line of the lesson.\nSecond line with details.',
+  };
+  const parsed = parseEntry(serializeEntry(entry));
+  assert.deepEqual(parsed, entry);
+});
+
+test('serialized frontmatter is JSON-valued (greppable / YAML-subset)', () => {
+  const text = serializeEntry({
+    scope: 'global',
+    key: 'k',
+    tags: ['a'],
+    source_agent: null,
+    trigger: null,
+    created: '2026-07-24T00:00:00.000Z',
+    updated: '2026-07-24T00:00:00.000Z',
+    archived_at: null,
+    value: 'body',
+  });
+  assert.match(text, /^---\n/);
+  assert.match(text, /\nkey: "k"\n/);
+  assert.match(text, /\ntags: \["a"\]\n/);
+  assert.match(text, /\narchived_at: null\n/);
+  assert.match(text, /\n---\nbody\n$/);
+});
+
+test('parseEntry returns null when there is no frontmatter', () => {
+  assert.equal(parseEntry('just some text'), null);
+});
+
+test('slugify is filesystem-safe and bounded', () => {
+  assert.equal(slugify('aw-lessons::Foo Bar!'), 'aw-lessons-foo-bar');
+  assert.equal(slugify('::::'), 'entry');
+  assert.equal(slugify('a'.repeat(200)).length, 80);
+});
+
+test('scopeToDir maps each canonical scope to its layout', () => {
+  const base = '/store';
+  assert.equal(scopeToDir(base, 'global'), path.join(base, 'global'));
+  assert.equal(scopeToDir(base, 'repo::mthines/lorekit'), path.join(base, 'repo', 'mthines', 'lorekit'));
+  assert.equal(
+    scopeToDir(base, 'branch::mthines/lorekit::feat/x'),
+    path.join(base, 'branch', 'mthines', 'lorekit', 'feat', 'x'),
+  );
+});
+
+test('scopeToDir neutralizes ".." segments so a crafted scope cannot escape the store', () => {
+  const base = path.join('/store', '.lorekit');
+  const escapes = [
+    'repo::../../etc/x',
+    'branch::../..::../..',
+    'branch::o/r::../../../evil',
+    'project::..',
+  ];
+  for (const scope of escapes) {
+    const dir = scopeToDir(base, scope);
+    const rel = path.relative(base, dir);
+    assert.ok(!rel.startsWith('..') && !path.isAbsolute(rel), `${scope} escaped: ${dir}`);
+  }
+});
+
+test('write is an upsert by scope+key that preserves created and refreshes updated', async () => {
+  const store = createLocalStore(tmpDir());
+  const scope = 'global';
+  const a = await store.write({ scope, key: 'k1', value: 'v1', tags: ['t'] });
+  assert.equal(a.ok, true);
+  await new Promise((r) => setTimeout(r, 5));
+  const b = await store.write({ scope, key: 'k1', value: 'v2' });
+  assert.equal(b.entry.created, a.entry.created); // created preserved
+  assert.notEqual(b.entry.updated, a.entry.created); // updated moved forward
+
+  const { entries } = await store.list({ scope });
+  assert.equal(entries.length, 1); // upsert, not append
+  assert.equal(entries[0].value, 'v2');
+});
+
+test('list is newest-first and filters by tag; archived is hidden', async () => {
+  const store = createLocalStore(tmpDir());
+  const scope = 'repo::o/r';
+  await store.write({ scope, key: 'old', value: 'a', tags: ['x'] });
+  await new Promise((r) => setTimeout(r, 5));
+  await store.write({ scope, key: 'new', value: 'b', tags: ['x', 'y'] });
+
+  const all = await store.list({ scope });
+  assert.deepEqual(all.entries.map((e) => e.key), ['new', 'old']); // newest first
+
+  const tagged = await store.list({ scope, tags: ['y'] });
+  assert.deepEqual(tagged.entries.map((e) => e.key), ['new']);
+
+  await store.archive({ scope, key: 'new' });
+  const afterArchive = await store.list({ scope });
+  assert.deepEqual(afterArchive.entries.map((e) => e.key), ['old']);
+  assert.equal((await store.read({ scope, key: 'new' })).entry, null); // hidden from read
+});
+
+test('delete force removes the file; soft delete archives and restore revives', async () => {
+  const store = createLocalStore(tmpDir());
+  const scope = 'global';
+  await store.write({ scope, key: 'k', value: 'v' });
+
+  await store.delete({ scope, key: 'k' }); // soft
+  assert.equal((await store.read({ scope, key: 'k' })).entry, null);
+  await store.restore({ scope, key: 'k' });
+  assert.equal((await store.read({ scope, key: 'k' })).entry.value, 'v');
+
+  const del = await store.delete({ scope, key: 'k', force: true });
+  assert.equal(del.deleted, true);
+  assert.deepEqual((await store.list({ scope })).entries, []);
+});
+
+test('search matches key, tags, and body across scopes', async () => {
+  const store = createLocalStore(tmpDir());
+  await store.write({ scope: 'global', key: 'auth-note', value: 'tokens expire', tags: ['security'] });
+  await store.write({ scope: 'repo::o/r', key: 'db', value: 'use one batched query', tags: ['perf'] });
+
+  const byBody = await store.search({ q: 'batched', scopes: ['global', 'repo::o/r'] });
+  assert.deepEqual(byBody.entries.map((e) => e.key), ['db']);
+
+  const byTag = await store.search({ q: 'security', scopes: ['global', 'repo::o/r'] });
+  assert.deepEqual(byTag.entries.map((e) => e.key), ['auth-note']);
+
+  const empty = await store.search({ q: '', scopes: ['global'] });
+  assert.equal(empty.entries.length, 1); // empty query returns all in scope
+});
+
+test('the store writes into the canonical-scope directory layout', async () => {
+  const base = tmpDir();
+  const store = createLocalStore(base);
+  await store.write({ scope: 'branch::mthines/lorekit::feat/x', key: 'k', value: 'v' });
+  const dir = path.join(base, 'branch', 'mthines', 'lorekit', 'feat', 'x');
+  assert.ok(fs.existsSync(dir));
+  assert.equal(fs.readdirSync(dir).filter((n) => n.endsWith('.md')).length, 1);
+});
+
+test('putEntry upserts verbatim by scope+key, preserving created/updated/archived_at', async () => {
+  const store = createLocalStore(tmpDir());
+  const entry = {
+    scope: 'repo::o/r',
+    key: 'k',
+    tags: ['t'],
+    source_agent: 'aw',
+    trigger: 'stuck-loop',
+    created: '2026-01-01T00:00:00.000Z',
+    updated: '2026-02-02T00:00:00.000Z',
+    archived_at: '2026-03-03T00:00:00.000Z',
+    value: 'preserved body',
+  };
+  await store.putEntry(entry);
+  const back = store.getEntry({ scope: 'repo::o/r', key: 'k' });
+  assert.deepEqual(back, entry); // every field verbatim, archived not revived
+  // getEntry sees archived; read() hides it.
+  assert.equal((await store.read({ scope: 'repo::o/r', key: 'k' })).entry, null);
+});
+
+test('two-tier read merges both tiers; project wins on key collision', async () => {
+  const home = tmpDir();
+  const project = tmpDir(); // exists → opted-in
+  const hStore = createLocalStore(home);
+  const pStore = createLocalStore(project);
+  await hStore.write({ scope: 'repo::o/r', key: 'shared', value: 'home-val' });
+  await hStore.write({ scope: 'repo::o/r', key: 'home-only', value: 'h' });
+  await pStore.write({ scope: 'repo::o/r', key: 'shared', value: 'project-val' });
+  await pStore.write({ scope: 'repo::o/r', key: 'proj-only', value: 'p' });
+
+  const store = createTwoTierStore({ home, project });
+  const { entries } = await store.list({ scope: 'repo::o/r' });
+  const map = Object.fromEntries(entries.map((e) => [e.key, e.value]));
+  assert.equal(entries.length, 3);
+  assert.equal(map.shared, 'project-val'); // project shadows home
+  assert.equal(map['home-only'], 'h');
+  assert.equal(map['proj-only'], 'p');
+  assert.equal((await store.read({ scope: 'repo::o/r', key: 'shared' })).entry.value, 'project-val');
+});
+
+test('two-tier write-routing: global→home; repo→project when opted-in, else home', async () => {
+  const home = tmpDir();
+  const project = path.join(tmpDir(), '.lorekit'); // does NOT exist yet → not opted-in
+  const store = createTwoTierStore({ home, project });
+  assert.equal(store.projectActive(), false);
+
+  // Not opted-in: a repo write lands in home.
+  await store.write({ scope: 'repo::o/r', key: 'k1', value: 'v1' });
+  assert.equal(createLocalStore(home).getEntry({ scope: 'repo::o/r', key: 'k1' }).value, 'v1');
+  // global always → home.
+  await store.write({ scope: 'global', key: 'g1', value: 'gv1' });
+  assert.equal(createLocalStore(home).getEntry({ scope: 'global', key: 'g1' }).value, 'gv1');
+
+  // Opt in by creating the project dir → repo writes now land in project.
+  fs.mkdirSync(project, { recursive: true });
+  assert.equal(store.projectActive(), true);
+  await store.write({ scope: 'repo::o/r', key: 'k2', value: 'v2' });
+  assert.equal(createLocalStore(project).getEntry({ scope: 'repo::o/r', key: 'k2' }).value, 'v2');
+  assert.equal(createLocalStore(home).getEntry({ scope: 'repo::o/r', key: 'k2' }), null);
+  // global still → home even when opted-in.
+  await store.write({ scope: 'global', key: 'g2', value: 'gv2' });
+  assert.equal(createLocalStore(home).getEntry({ scope: 'global', key: 'g2' }).value, 'gv2');
+});
+
+test('two-tier delete/archive peels the project shadow first, revealing the home copy', async () => {
+  // A key present in BOTH tiers is an overlay: the project copy shadows home.
+  // delete/archive act on the visible (project) copy only, so one op reveals the
+  // home copy rather than destroying it; a second op then removes the home copy.
+  // This is conservative by design — a single delete never reaches through and
+  // erases the broader, cross-repo home lesson.
+  const seed = async () => {
+    const home = tmpDir();
+    const project = tmpDir(); // exists → opted-in
+    await createLocalStore(home).write({ scope: 'repo::o/r', key: 'k', value: 'home-val' });
+    await createLocalStore(project).write({ scope: 'repo::o/r', key: 'k', value: 'project-val' });
+    return { store: createTwoTierStore({ home, project }), home };
+  };
+
+  // Force delete: peel project, reveal home, then delete home.
+  {
+    const { store, home } = await seed();
+    assert.equal((await store.read({ scope: 'repo::o/r', key: 'k' })).entry.value, 'project-val');
+    await store.delete({ scope: 'repo::o/r', key: 'k', force: true });
+    assert.equal((await store.read({ scope: 'repo::o/r', key: 'k' })).entry.value, 'home-val');
+    // Home copy is untouched by the first delete.
+    assert.equal(createLocalStore(home).getEntry({ scope: 'repo::o/r', key: 'k' }).value, 'home-val');
+    await store.delete({ scope: 'repo::o/r', key: 'k', force: true });
+    assert.equal((await store.read({ scope: 'repo::o/r', key: 'k' })).entry, null);
+  }
+
+  // Soft archive: same peel-back — archiving the project copy reveals home.
+  {
+    const { store } = await seed();
+    await store.archive({ scope: 'repo::o/r', key: 'k' });
+    assert.equal((await store.read({ scope: 'repo::o/r', key: 'k' })).entry.value, 'home-val');
+    const { entries } = await store.list({ scope: 'repo::o/r' });
+    assert.deepEqual(entries.map((e) => e.value), ['home-val']); // list mirrors read
+  }
+});

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -39,6 +39,13 @@ Set `LOREKIT_MCP_URL` and `LOREKIT_TOKEN` in your environment, or run
 `npx @lorekit/cli install` in the project to write a `.mcp.json`. Then
 `npx @lorekit/cli doctor` to verify.
 
+> **Local mode.** No hosted server needed — set `LOREKIT_MODE=local` and lessons
+> live in markdown files in two tiers: a per-user home tier at `~/.lorekit/` and
+> an opt-in per-repo project tier at `<repo>/.lorekit/` (created when you want to
+> commit or gitignore repo/branch lessons). See the
+> [`@lorekit/cli` README](../packages/cli/README.md#memory-modes--the-control-model)
+> for the control model and the two-tier merge / write-routing rules.
+
 ## Cursor / Codex
 
 See each bundle's README for copy-in instructions:

--- a/plugins/lorekit-claude/skills/lorekit-memory/SKILL.md
+++ b/plugins/lorekit-claude/skills/lorekit-memory/SKILL.md
@@ -46,6 +46,17 @@ Both jobs run through LoreKit's `memory.*` MCP tools.
 If those tools are not connected, this skill is a no-op — say so once and
 continue the task; never block work because memory is unavailable.
 
+> **Modes.** Memory has a controllable backend (`lorekit doctor` shows the
+> resolved one): `remote` (the hosted LoreKit server — the default), `local`
+> (markdown files in two tiers — a per-user **home** tier at `~/.lorekit/` and
+> an opt-in per-repo **project** tier at `<repo>/.lorekit/`), or `off`
+> (disabled). **`local` means _not_ on the hosted website** — local lessons stay
+> on disk and never sync to the LoreKit dashboard. `global` lessons go to home;
+> `repo`/`branch` lessons go to the project tier once you create `<repo>/.lorekit/`
+> (commit it to share with your team, or gitignore it to keep it private), else
+> home. See the `@lorekit/cli` README for the control model, the two-tier merge,
+> and precedence/deny rules.
+
 ---
 
 ## When to read (intake)


### PR DESCRIPTION
**Stacked on #46** (base branch `claude/lorekit-skill-cli-memory-0yfpil`). Phase 2 of the plan.

Gives users control over *where* lessons live, with the privacy cases enforceable — not just defaults.

## Store abstraction (`src/store/`)
A common contract — `list / read / write / delete / archive / search` — with two drivers:
- **`remote`** — wraps the existing MCP `mcpCall` (`memory.*`). Behavior unchanged.
- **`local`** — markdown files under a `.lore/` dir, foldered by canonical scope (`global/`, `repo/<owner>/<repo>/`, `branch/<owner>/<repo>/<branch>/`), YAML frontmatter + body — converged with `persistent-memory`'s entry format (greppable, git-friendly). Commit `.lore/` for team sharing; gitignore it for private.

## Control model (`src/control.mjs`)
Modes **`off | local | remote`** (no `both`/sync — explicit non-goal). Config from env (`LOREKIT_MODE/STORE/DENY`, `LOREKIT_MCP_URL/TOKEN`), user `~/.agent-memory/config.json`, and repo `.lorekit.json`.

- **Selection precedence:** `env → user → repo → default(remote)`.
- **Deny-wins (the crux):** `deny` is a **union across all sources that only accumulates**. A user's `"deny":["remote"]` is a **ceiling no repo or env can lift** (privacy/compliance); a repo/CI `"deny":["local"]` makes local unselectable (no stray `.lore/`). `off` is never deniable — the terminal fallback.
- `doctor` is mode-aware: prints the resolved mode, **which source decided it**, active denies, and (local) the store path + entry count.

`off` disables every hook event; the hook engine stays exit-0 / best-effort; zero runtime deps preserved.

## Security
Reviewer found and fixed a **path-traversal** in the local store's scope→dir mapping (a crafted scope could escape the store base and write arbitrary files). Dot-only path segments are now collapsed; regression test added.

## Verification
- `node --test packages/cli/test/*.test.mjs` → **61/61** (store ops + deny-wins resolver: never-remote user in remote-default repo → local; never-local CI → capped to remote; deny-both → off; user-vs-repo conflict; path-traversal).
- `node scripts/sync-plugin-skill.mjs --check` → in sync.
- optimize-approach (plan mode): 93% confidence.

## Non-blocking follow-ups (not applied)
1. `doctor` should warn when an env/config `LOREKIT_MODE` is unrecognized (currently a typo silently falls back to `remote`).
2. Optionally constrain `..` in operator-supplied `LOREKIT_STORE` paths, for symmetry with the scope hardening.

## Open question for the maintainer
`.lore/` is **committed-by-default** (git-native team sharing). Say the word if you'd prefer private-by-default (gitignored) for this repo.

Next in the stack: a local stdio MCP server so the model-facing `memory.*` tool path works against the local store offline.

---
_Generated by [Claude Code](https://claude.ai/code/session_019PMqhJr8ADx9gsSif6L8vm)_