### PR TITLE
feat(cli): `lorekit mcp` — local stdio MCP server for the offline model path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ lets humans browse, search, and manage those lessons.
 | `@lorekit/core` | `packages/mcp-core/` | Scope validator, DB client, 5 tool handlers, OTel tracer/meter |
 | `@lorekit/server` | `packages/mcp-server/` | Node.js HTTP server for Fly.io (OTel SDK init, auth, webhook) |
 | `@lorekit/web` | `packages/web/` | Next.js 15 dashboard (Vercel) |
-| `@lorekit/cli` | `packages/cli/` | Zero-dep Node CLI: `install` (scaffolds the `lorekit-memory` skill + `.mcp.json`), `doctor` (connectivity/token/scope health checks), and `hook` (the shared hook engine behind the plugins). Ships the skill under `skill/lorekit-memory/`. Verified by its own `node:test` suite; excluded from the NX TS lint gate. |
+| `@lorekit/cli` | `packages/cli/` | Zero-dep Node CLI: `install` (scaffolds the `lorekit-memory` skill + `.mcp.json`), `doctor` (connectivity/token/scope health checks), `hook` (the shared hook engine behind the plugins), and `mcp` (a hand-rolled local stdio MCP server exposing `memory.*` from the resolved store — lets `.mcp.json` point at the CLI instead of `mcp-remote`, for offline local-mode tool calls). Ships the skill under `skill/lorekit-memory/`. Verified by its own `node:test` suite; excluded from the NX TS lint gate. |
 | `plugins/` | `plugins/` | Per-framework deterministic bundles: `lorekit-claude` (marketplace plugin: skill + hooks + MCP), `lorekit-cursor` (rule + `stop` hook), `lorekit-codex` (feature-flagged hooks + `AGENTS.md` fallback, experimental). Root `.claude-plugin/marketplace.json` lists the Claude plugin. |
 | `supabase` | `supabase/` | Edge Functions (production MCP server), migrations, NX targets |
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -72,6 +72,41 @@ lorekit hook --adapter <claude|cursor|codex> --event <SessionStart|Stop|…>
 One engine serves all three hosts; each `--adapter` only reshapes input/output
 to that host's contract. See [`plugins/`](../../plugins/) for the bundles.
 
+### `lorekit mcp`
+
+A **local stdio MCP server**. It exposes LoreKit's `memory.*` tools backed by
+the store the [control model](#memory-modes--the-control-model) resolves, so an
+agent's `.mcp.json` can point at the CLI instead of `mcp-remote <url>` — giving
+the model discoverable, autonomous `memory.*` tool calls **offline against the
+local `.lorekit/` store** (no network, Bash-restricted contexts included).
+
+```bash
+lorekit mcp                 # serve on stdin/stdout using the resolved mode
+lorekit mcp --mode local --store .lorekit
+```
+
+It speaks JSON-RPC 2.0 over newline-delimited stdin/stdout (the MCP stdio
+transport, hand-rolled — zero dependencies) and is **not run by hand**: only
+JSON-RPC frames reach stdout. It serves whatever mode resolves — `local` serves
+the `.lorekit/` files directly, `remote` passes calls through to the hosted
+endpoint, and `off` advertises no tools. Tools advertised: `memory.write`,
+`memory.read`, `memory.list`, `memory.search`, `memory.delete`,
+`memory.archive`.
+
+Wire it into `.mcp.json` as an alternative to the `mcp-remote <url>` transport —
+this variant needs no endpoint or token for local mode:
+
+```jsonc
+{
+  "mcpServers": {
+    "lorekit": {
+      "command": "npx",
+      "args": ["-y", "@lorekit/cli", "mcp"]
+    }
+  }
+}
+```
+
 ## Memory modes & the control model
 
 Memory has a controllable backend. Three **modes**:

--- a/packages/cli/bin/lorekit.mjs
+++ b/packages/cli/bin/lorekit.mjs
@@ -6,6 +6,7 @@ import { install } from '../src/install.mjs';
 import { doctor } from '../src/doctor.mjs';
 import { hook } from '../src/hook.mjs';
 import { migrate } from '../src/migrate.mjs';
+import { mcpServer } from '../src/mcp-server.mjs';
 
 const VERSION = '1.0.0';
 
@@ -23,6 +24,10 @@ ${c.bold('Commands')}
   hook        Hook engine for Claude Code / Cursor / Codex. Reads the host's
               JSON on stdin and injects lessons or a retrospective nudge.
               Not run by hand — wired into a plugin's hook config.
+  mcp         Local stdio MCP server. Exposes the memory.* tools backed by the
+              resolved store (local .lorekit/ offline, or remote passthrough) so
+              .mcp.json can point at the CLI instead of mcp-remote. Speaks
+              JSON-RPC on stdin/stdout — not run by hand.
 
 ${c.bold('Options')}
   -d, --dir <path>        Target project root (default: current directory)
@@ -70,6 +75,12 @@ async function main() {
   // help/usage branch and always resolve to exit 0.
   if (args._[0] === 'hook') {
     return hook(args);
+  }
+
+  // `mcp` is machine-facing too: only JSON-RPC frames may reach stdout, so it
+  // must bypass the help/usage branch. It serves stdio until the client closes.
+  if (args._[0] === 'mcp') {
+    return mcpServer(args);
   }
 
   if (args.version) {

--- a/packages/cli/src/mcp-server.mjs
+++ b/packages/cli/src/mcp-server.mjs
@@ -1,0 +1,233 @@
+// `lorekit mcp` — a zero-dependency local MCP stdio server.
+//
+// Speaks JSON-RPC 2.0 over newline-delimited stdin/stdout (the MCP stdio
+// transport) and serves LoreKit's memory.* tools from the store the control
+// model resolves. This makes `lorekit mcp` a uniform local entrypoint for
+// every mode, so an agent's `.mcp.json` can point at the local CLI instead of
+// `mcp-remote <url>`:
+//
+//   local  → serve the `.lorekit/` file store directly (offline, no network)
+//   remote → pass tool calls through to the hosted HTTP endpoint
+//   off    → advertise no tools; a call reports "disabled"
+//
+// Machine-facing: ONLY JSON-RPC frames go to stdout — any diagnostics go to
+// stderr. The server never throws on malformed or partial input; a bad frame
+// yields a JSON-RPC parse error and the loop keeps serving.
+//
+// The transport is hand-rolled (no MCP SDK) to keep the CLI dependency-free.
+import process from 'node:process';
+import { resolveProjectRoot } from './config.mjs';
+import { loadControl } from './control.mjs';
+import { createStore } from './store/index.mjs';
+
+const PROTOCOL_VERSION = '2024-11-05';
+const SERVER_INFO = { name: 'lorekit-local', version: '1.0.0' };
+
+// Tool advertisements — names + input schemas mirror the production MCP server
+// (supabase/functions/mcp/mcp-handler.ts) so a client sees the same contract
+// whether it points at the hosted endpoint or this local server.
+export const TOOL_DEFS = [
+  {
+    name: 'memory.write',
+    description: 'Store or update a lesson',
+    inputSchema: { type: 'object', required: ['scope', 'key', 'value'] },
+  },
+  {
+    name: 'memory.read',
+    description: 'Read a lesson by scope and key',
+    inputSchema: { type: 'object', required: ['scope', 'key'] },
+  },
+  {
+    name: 'memory.list',
+    description: 'List lessons for a scope',
+    inputSchema: { type: 'object', required: ['scope'] },
+  },
+  {
+    name: 'memory.search',
+    description: 'Keyword search across lessons',
+    inputSchema: { type: 'object', required: ['q'] },
+  },
+  {
+    name: 'memory.delete',
+    description:
+      'Soft-archive a lesson (default) or hard-delete it (force: true). ' +
+      'Archived lessons are hidden from reads but can be restored.',
+    inputSchema: {
+      type: 'object',
+      required: ['scope', 'key'],
+      properties: {
+        scope: { type: 'string' },
+        key: { type: 'string' },
+        force: { type: 'boolean' },
+      },
+    },
+  },
+  {
+    name: 'memory.archive',
+    description: 'Soft-archive a lesson. Hidden from reads but restorable.',
+    inputSchema: { type: 'object', required: ['scope', 'key'] },
+  },
+];
+
+// tool name → (store, args) → store result. The store destructures the args it
+// needs, so the raw `arguments` object is passed straight through.
+const DISPATCH = {
+  'memory.write': (store, a) => store.write(a),
+  'memory.read': (store, a) => store.read(a),
+  'memory.list': (store, a) => store.list(a),
+  'memory.search': (store, a) => store.search(a),
+  'memory.delete': (store, a) => store.delete(a),
+  'memory.archive': (store, a) => store.archive(a),
+};
+
+function reply(id, result) {
+  return { jsonrpc: '2.0', id, result };
+}
+
+function errorReply(id, code, message) {
+  return { jsonrpc: '2.0', id, error: { code, message } };
+}
+
+// Wrap a store result in the MCP tools/call result shape. `ok: false` from the
+// store surfaces as a tool-level error (isError) rather than a protocol error,
+// so the model sees the failure payload instead of a broken transport.
+function toolResult(id, payload) {
+  const isError = payload && payload.ok === false;
+  return reply(id, {
+    content: [{ type: 'text', text: JSON.stringify(payload) }],
+    ...(isError ? { isError: true } : {}),
+  });
+}
+
+// Build the per-message handler over a resolved control model. `store` is null
+// when mode is `off`, in which case no tools are advertised.
+export function createHandler(control) {
+  const store = createStore(control);
+  const tools = store ? TOOL_DEFS : [];
+
+  // Returns a JSON-RPC response object, or null for a notification (no reply).
+  return async function handle(msg) {
+    const id = msg && Object.prototype.hasOwnProperty.call(msg, 'id') ? msg.id : null;
+    const isNotification = id === null || id === undefined;
+    const method = msg && msg.method;
+
+    if (method === 'initialize') {
+      return reply(id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: SERVER_INFO,
+      });
+    }
+
+    // Notifications (initialized, cancelled, …) never get a response.
+    if (typeof method === 'string' && method.startsWith('notifications/')) {
+      return null;
+    }
+
+    if (method === 'tools/list') {
+      return reply(id, { tools });
+    }
+
+    if (method === 'tools/call') {
+      const params = (msg && msg.params) || {};
+      const name = params.name;
+      const args = params.arguments || {};
+
+      if (!store) {
+        return toolResult(id, { ok: false, error: `memory is disabled (mode: ${control.mode})` });
+      }
+
+      const fn = DISPATCH[name];
+      if (!fn) return errorReply(id, -32601, `Unknown tool: ${name}`);
+
+      const result = await fn(store, args);
+      return toolResult(id, result);
+    }
+
+    // Unknown or missing method. A notification gets silence; a request gets
+    // a proper JSON-RPC "method not found".
+    if (isNotification) return null;
+    return errorReply(id, -32601, `Method not found: ${method}`);
+  };
+}
+
+// The stdio read/write loop. Split out from the process streams so it can be
+// driven by any duplex-ish pair in tests. Frames are newline-delimited JSON;
+// responses are serialized single-line + '\n' and written in arrival order.
+export function runStdio(handle, input, output) {
+  return new Promise((resolve) => {
+    let buffer = '';
+    let chain = Promise.resolve();
+
+    const writeMsg = (obj) => {
+      if (obj != null) output.write(`${JSON.stringify(obj)}\n`);
+    };
+
+    const handleOne = (m) =>
+      Promise.resolve()
+        .then(() => handle(m))
+        .then(writeMsg)
+        .catch((e) => {
+          // A handler fault must not take the server down; report it and go on.
+          const id = m && Object.prototype.hasOwnProperty.call(m, 'id') ? m.id : null;
+          writeMsg(errorReply(id ?? null, -32603, String(e && e.message ? e.message : e)));
+        });
+
+    const processLine = (line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      let msg;
+      try {
+        msg = JSON.parse(trimmed);
+      } catch {
+        // Malformed frame: we cannot know the id, so reply with null id and
+        // keep serving. This is the "never crash on bad input" guarantee.
+        writeMsg(errorReply(null, -32700, 'Parse error'));
+        return;
+      }
+      // Serialize so responses are written in the order frames arrived. A batch
+      // (JSON-RPC array) is handled element-wise rather than crashing.
+      chain = chain.then(() =>
+        Array.isArray(msg) ? Promise.all(msg.map(handleOne)) : handleOne(msg),
+      );
+    };
+
+    input.setEncoding('utf8');
+    input.on('data', (chunk) => {
+      buffer += chunk;
+      let idx;
+      while ((idx = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, idx);
+        buffer = buffer.slice(idx + 1);
+        processLine(line);
+      }
+    });
+    input.on('end', () => {
+      if (buffer) processLine(buffer);
+      buffer = '';
+      chain.then(resolve, resolve);
+    });
+    input.on('error', () => {
+      chain.then(resolve, resolve);
+    });
+  });
+}
+
+function withOverrides(args, env) {
+  const out = { ...env };
+  if (args.store) out.LOREKIT_STORE = args.store;
+  if (args.mode) out.LOREKIT_MODE = args.mode;
+  if (args.endpoint) out.LOREKIT_MCP_URL = args.endpoint;
+  if (args.token) out.LOREKIT_TOKEN = args.token;
+  return out;
+}
+
+// Entrypoint for `lorekit mcp`. Resolves the store once, then serves stdio
+// until the client closes stdin. Always resolves to exit code 0.
+export async function mcpServer(args = {}, { env = process.env, input = process.stdin, output = process.stdout } = {}) {
+  const root = resolveProjectRoot(args.dir);
+  const control = loadControl(root, { env: withOverrides(args, env) });
+  const handle = createHandler(control);
+  await runStdio(handle, input, output);
+  return 0;
+}

--- a/packages/cli/test/mcp-server.test.mjs
+++ b/packages/cli/test/mcp-server.test.mjs
@@ -1,0 +1,145 @@
+// Spawns the real `lorekit mcp` stdio server as a child process and drives the
+// MCP handshake (initialize → tools/list → tools/call) over newline-delimited
+// JSON-RPC, asserting a memory.write → read/list round-trip against a temp
+// `.lore/` store, plus the error and robustness contracts.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const BIN = fileURLToPath(new URL('../bin/lorekit.mjs', import.meta.url));
+
+function tmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'lk-mcp-'));
+}
+
+// Spawn the server, feed it `raw` (verbatim) followed by the JSON-encoded
+// `frames`, then close stdin so it exits. Resolve with the parsed responses.
+function serve(frames, { store, home = tmpDir(), mode = 'local', raw = '' } = {}) {
+  return new Promise((resolve, reject) => {
+    // Isolate BOTH tiers into temp dirs so a global-scoped write (which routes
+    // to the home tier) never touches the real ~/.lorekit.
+    const child = spawn(process.execPath, [BIN, 'mcp'], {
+      env: { ...process.env, LOREKIT_MODE: mode, LOREKIT_STORE: store, LOREKIT_HOME: home, NO_COLOR: '1' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let out = '';
+    let err = '';
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (d) => (out += d));
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', (d) => (err += d));
+    child.on('error', reject);
+    child.on('close', () => {
+      const messages = out
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .map((l) => JSON.parse(l));
+      resolve({ messages, err, out, home, store });
+    });
+    const payload = raw + frames.map((f) => JSON.stringify(f)).join('\n') + (frames.length ? '\n' : '');
+    child.stdin.write(payload);
+    child.stdin.end();
+  });
+}
+
+const byId = (messages) => new Map(messages.filter((m) => m.id !== null && m.id !== undefined).map((m) => [m.id, m]));
+
+test('initialize → tools/list → write/read/list round-trip over stdio', async () => {
+  const store = tmpDir();
+  const { messages, home } = await serve(
+    [
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'memory.write', arguments: { scope: 'global', key: 'k1', value: 'hello', tags: ['t'] } },
+      },
+      { jsonrpc: '2.0', id: 4, method: 'tools/call', params: { name: 'memory.read', arguments: { scope: 'global', key: 'k1' } } },
+      { jsonrpc: '2.0', id: 5, method: 'tools/call', params: { name: 'memory.list', arguments: { scope: 'global' } } },
+    ],
+    { store },
+  );
+
+  const m = byId(messages);
+
+  const init = m.get(1);
+  assert.equal(init.result.protocolVersion, '2024-11-05');
+  assert.equal(init.result.serverInfo.name, 'lorekit-local');
+  assert.deepEqual(init.result.capabilities, { tools: {} });
+
+  const list = m.get(2);
+  assert.equal(list.result.tools.length, 6);
+  assert.ok(list.result.tools.some((t) => t.name === 'memory.write'));
+  assert.ok(list.result.tools.some((t) => t.name === 'memory.archive'));
+
+  // The notification produced no response — only ids 1..5 came back.
+  assert.deepEqual([...m.keys()].sort((a, b) => a - b), [1, 2, 3, 4, 5]);
+
+  const written = JSON.parse(m.get(3).result.content[0].text);
+  assert.equal(written.ok, true);
+
+  const read = JSON.parse(m.get(4).result.content[0].text);
+  assert.equal(read.entry.value, 'hello');
+
+  const listed = JSON.parse(m.get(5).result.content[0].text);
+  assert.deepEqual(listed.entries.map((e) => e.key), ['k1']);
+
+  // The write actually hit disk. A `global`-scoped write routes to the HOME
+  // tier (two-tier model), not the project store dir.
+  assert.ok(fs.existsSync(path.join(home, 'global')));
+});
+
+test('unknown method returns a JSON-RPC method-not-found error', async () => {
+  const store = tmpDir();
+  const { messages } = await serve([{ jsonrpc: '2.0', id: 1, method: 'does/not/exist', params: {} }], { store });
+  const m = byId(messages).get(1);
+  assert.equal(m.error.code, -32601);
+  assert.match(m.error.message, /Method not found/);
+});
+
+test('unknown tool returns a JSON-RPC error, not a crash', async () => {
+  const store = tmpDir();
+  const { messages } = await serve(
+    [{ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'memory.nope', arguments: {} } }],
+    { store },
+  );
+  const m = byId(messages).get(1);
+  assert.equal(m.error.code, -32601);
+  assert.match(m.error.message, /Unknown tool/);
+});
+
+test('a malformed frame does not crash the server; later frames still work', async () => {
+  const store = tmpDir();
+  const { messages } = await serve([{ jsonrpc: '2.0', id: 7, method: 'initialize', params: {} }], {
+    store,
+    raw: 'this is not json\n{ also bad\n',
+  });
+  // Each garbage line yielded a parse error (id null), and the valid initialize
+  // that followed still got its response.
+  assert.ok(messages.some((x) => x.error && x.error.code === -32700 && x.id === null));
+  assert.ok(messages.some((x) => x.id === 7 && x.result && x.result.protocolVersion === '2024-11-05'));
+});
+
+test('off mode advertises no tools and reports disabled on a call', async () => {
+  const store = tmpDir();
+  const { messages } = await serve(
+    [
+      { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} },
+      { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'memory.list', arguments: { scope: 'global' } } },
+    ],
+    { store, mode: 'off' },
+  );
+  const m = byId(messages);
+  assert.deepEqual(m.get(1).result.tools, []);
+  const call = m.get(2);
+  assert.equal(call.result.isError, true);
+  assert.match(JSON.parse(call.result.content[0].text).error, /disabled/);
+});

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -39,12 +39,28 @@ Set `LOREKIT_MCP_URL` and `LOREKIT_TOKEN` in your environment, or run
 `npx @lorekit/cli install` in the project to write a `.mcp.json`. Then
 `npx @lorekit/cli doctor` to verify.
 
-> **Local mode.** No hosted server needed — set `LOREKIT_MODE=local` and lessons
-> live in markdown files in two tiers: a per-user home tier at `~/.lorekit/` and
-> an opt-in per-repo project tier at `<repo>/.lorekit/` (created when you want to
-> commit or gitignore repo/branch lessons). See the
-> [`@lorekit/cli` README](../packages/cli/README.md#memory-modes--the-control-model)
-> for the control model and the two-tier merge / write-routing rules.
+### Local mode (offline, no hosted server)
+
+Set `LOREKIT_MODE=local` and lessons live in markdown files in two tiers: a
+per-user home tier at `~/.lorekit/` and an opt-in per-repo project tier at
+`<repo>/.lorekit/` (commit or gitignore it to share or keep private). See the
+[`@lorekit/cli` README](../packages/cli/README.md#memory-modes--the-control-model)
+for the two-tier merge / write-routing / control model.
+
+To give the **model** `memory.*` tool calls against that local store (offline,
+Bash-restricted contexts included) instead of the hosted endpoint, point the
+`lorekit` MCP server at the CLI's own stdio server rather than `mcp-remote`:
+
+```jsonc
+{
+  "mcpServers": {
+    "lorekit": { "command": "npx", "args": ["-y", "@lorekit/cli", "mcp"] }
+  }
+}
+```
+
+`lorekit mcp` resolves the same control model, so `LOREKIT_MODE=local` (or a
+`.lorekit.json`) serves the `.lorekit/` files with no network.
 
 ## Cursor / Codex
 


### PR DESCRIPTION
**Stacked on #47** (base branch `claude/lorekit-local-backend`). Phase 3 — the top of the stack.

Gives the **model-facing** `memory.*` tool path a zero-dependency local server, so an agent gets discoverable, autonomous memory tool calls against the local `.lore/` store **with no network** — the Bash-restricted / offline model path.

## What's added
- **`src/mcp-server.mjs`** — a hand-rolled MCP **stdio server** (JSON-RPC 2.0, newline-delimited over stdin/stdout, zero deps):
  - `initialize` / `notifications/*` / `tools/list` / `tools/call`.
  - Robust: partial frames buffered until newline; malformed frame → `-32700` (id null, no crash); unknown method/tool → `-32601`; handler fault → `-32603` and the loop continues; **only JSON-RPC frames reach stdout** (machine-clean, like `hook`).
  - Store resolved once via Phase 2's `loadControl` + `createStore`: `local` serves `.lore/` offline, `remote` passes through, `off` advertises no tools. Results in MCP shape `{content:[{type:'text',text}]}`.
- **`bin/lorekit.mjs`** — `mcp` command (machine-facing, dispatched early).
- **Docs** — `lorekit mcp` section + local-mode `.mcp.json` wiring (`command: npx, args: ["-y","@lorekit/cli","mcp"]`) in the CLI + plugins READMEs; CLAUDE.md package-map row.

## Verification
- `node --test packages/cli/test/*.test.mjs` → **66/66** (adds: spawns the real server for an `initialize`→`tools/list`→`tools/call` write/read round-trip; unknown-method; unknown-tool; malformed-frame-no-crash; off-mode-no-tools).
- `node scripts/sync-plugin-skill.mjs --check` → in sync.
- optimize-approach: `optimal` (quiet early-exit, no proposals).

## Follow-ups surfaced by review (not in this PR)
1. **F1 (Phase 2 store):** remote-mode `memory.write` double-wraps its result (`RemoteStore.write` should `unwrap` like `read()` does). Confirmed real; affects only remote-write's return shape — reads/lists and **all of local mode are unaffected**. Belongs in a Phase 2 follow-up (store layer), not the server layer.
2. **F2:** add a split-frame buffering test and a remote-passthrough test (transport is correct by inspection but those two paths are untested).
3. **F3 (nit):** the local store doesn't reject missing required tool args (stores `''`) where the hosted server would 400 — parity nit, no crash.

---
_Generated by [Claude Code](https://claude.ai/code/session_019PMqhJr8ADx9gsSif6L8vm)_