### PR TITLE
fix(ci): link project before db push (latest Supabase CLI dropped --project-ref)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,8 +76,11 @@ jobs:
             VCS_REPOSITORY_NAME="${{ github.repository }}" \
             --project-ref "$PROJECT_REF"
 
+      - name: Link the Supabase project
+        run: supabase link --project-ref "$PROJECT_REF"
+
       - name: Push database migrations
-        run: supabase db push --project-ref "$PROJECT_REF"
+        run: supabase db push
 
       - name: Deploy edge functions (mcp + health)
         run: supabase functions deploy --no-verify-jwt --project-ref "$PROJECT_REF"
@@ -152,8 +155,11 @@ jobs:
             VCS_REPOSITORY_NAME="${{ github.repository }}" \
             --project-ref "$PROJECT_REF"
 
+      - name: Link the Supabase project
+        run: supabase link --project-ref "$PROJECT_REF"
+
       - name: Push database migrations
-        run: supabase db push --project-ref "$PROJECT_REF"
+        run: supabase db push
 
       - name: Deploy edge functions (mcp + health)
         run: supabase functions deploy --no-verify-jwt --project-ref "$PROJECT_REF"


### PR DESCRIPTION
The first correctly-configured Deploy run got past secrets + Dash0 tagging (the `preview` env now resolves, and `rollback-production` correctly **skipped** on the pre-prod failure), then failed at `Push database migrations`:

```
ERROR: Unrecognized flag: --project-ref in command supabase db push
```

The latest Supabase CLI removed `--project-ref` from `db push`. Switch to the documented pattern: `supabase link --project-ref <ref>` (non-interactive via `SUPABASE_DB_PASSWORD`) then `supabase db push`. `secrets set` / `functions deploy` still accept `--project-ref`, so they're unchanged. Applied to both preview and production deploy jobs.

Deploy-only change (no API paths) → `Integration smoke` will skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018fnd7MsvqAp3L7Kf58qoid)_