### PR TITLE
ci: publish @lorekit/cli to npm via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -242,3 +242,72 @@ jobs:
           echo "Inspect the failing job above and, if a migration is at fault, restore via PITR." >> "$GITHUB_STEP_SUMMARY"
           echo "::error::Production deploy failed — functions rolled back to the previous commit."
           exit 1
+
+  # ── 6. Publish @lorekit/cli to npm (independent of the Supabase pipeline) ─────
+  #    Runs in parallel with the deploy jobs — the CLI is a standalone npm
+  #    package with no Supabase dependency, so it neither gates nor is gated by
+  #    the edge-function deploy. Publishes only when packages/cli actually
+  #    changed in the merged commit AND the package.json version is new, so a
+  #    merge that leaves the CLI untouched (or forgets to bump) is a clean no-op
+  #    rather than an error. Bump packages/cli/package.json version to release.
+  publish-cli:
+    name: Publish @lorekit/cli to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository (with previous commit)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Did the CLI project change?
+        id: changed
+        run: |
+          if git diff --name-only HEAD^ HEAD -- packages/cli | grep -q .; then
+            echo "cli=true" >> "$GITHUB_OUTPUT"
+            echo "packages/cli changed in this commit."
+          else
+            echo "cli=false" >> "$GITHUB_OUTPUT"
+            echo "packages/cli unchanged — skipping publish."
+          fi
+
+      - name: Set up Node
+        if: steps.changed.outputs.cli == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Is this version already published?
+        if: steps.changed.outputs.cli == 'true'
+        id: ver
+        working-directory: packages/cli
+        run: |
+          V="$(node -p "require('./package.json').version")"
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          if npm view "@lorekit/cli@$V" version >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "@lorekit/cli@$V already on npm — skipping (bump the version to release)."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "@lorekit/cli@$V is new — will test and publish."
+          fi
+
+      - name: Test
+        if: steps.changed.outputs.cli == 'true' && steps.ver.outputs.exists == 'false'
+        working-directory: packages/cli
+        run: node --test test/*.test.mjs
+
+      - name: Publish
+        if: steps.changed.outputs.cli == 'true' && steps.ver.outputs.exists == 'false'
+        working-directory: packages/cli
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Report publish
+        if: steps.changed.outputs.cli == 'true' && steps.ver.outputs.exists == 'false'
+        run: |
+          echo "### 📦 Published @lorekit/cli@${{ steps.ver.outputs.version }} to npm" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`npx @lorekit/cli@${{ steps.ver.outputs.version }} install\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -282,16 +282,19 @@ jobs:
             echo "packages/cli unchanged — skipping publish."
           fi
 
-      - name: Set up Node
+      - name: Set up Node.js
         if: steps.changed.outputs.cli == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
+      # Pinned, not @latest: Trusted Publishing landed in 11.5.1, and a pinned
+      # version keeps the publish step reproducible — @latest would silently
+      # move on every run and could change the OIDC flow out from under us.
       - name: Upgrade npm for Trusted Publishing (needs >= 11.5.1)
         if: steps.changed.outputs.cli == 'true'
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.5.1
 
       - name: Is this version already published?
         if: steps.changed.outputs.cli == 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -250,11 +250,21 @@ jobs:
   #    changed in the merged commit AND the package.json version is new, so a
   #    merge that leaves the CLI untouched (or forgets to bump) is a clean no-op
   #    rather than an error. Bump packages/cli/package.json version to release.
+  #
+  #    Auth is npm Trusted Publishing (OIDC) — no long-lived NPM_TOKEN secret.
+  #    Each run mints a short-lived OIDC token from `id-token: write`, and npm
+  #    trades it for publish rights based on the trusted publisher configured on
+  #    the package (npmjs.com ▸ @lorekit/cli ▸ Settings ▸ Trusted Publisher:
+  #    GitHub Actions, repo mthines/lorekit, workflow deploy.yml). Provenance is
+  #    attached automatically. One-time prerequisite: the package must already
+  #    exist on npm (do the first publish by hand), then add the trusted
+  #    publisher — after that every release here is token-free.
   publish-cli:
     name: Publish @lorekit/cli to npm
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # mint the OIDC token npm trades for publish rights
     steps:
       - name: Checkout repository (with previous commit)
         uses: actions/checkout@v4
@@ -279,6 +289,10 @@ jobs:
           node-version: 20
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for Trusted Publishing (needs >= 11.5.1)
+        if: steps.changed.outputs.cli == 'true'
+        run: npm install -g npm@latest
+
       - name: Is this version already published?
         if: steps.changed.outputs.cli == 'true'
         id: ver
@@ -299,12 +313,13 @@ jobs:
         working-directory: packages/cli
         run: node --test test/*.test.mjs
 
-      - name: Publish
+      # No NODE_AUTH_TOKEN: npm detects the Actions OIDC environment and
+      # authenticates via the trusted publisher. --provenance is implied by
+      # trusted publishing; passed explicitly for clarity.
+      - name: Publish (Trusted Publishing / OIDC)
         if: steps.changed.outputs.cli == 'true' && steps.ver.outputs.exists == 'false'
         working-directory: packages/cli
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
 
       - name: Report publish
         if: steps.changed.outputs.cli == 'true' && steps.ver.outputs.exists == 'false'


### PR DESCRIPTION
## What

Adds a `publish-cli` job to `.github/workflows/deploy.yml` that publishes `@lorekit/cli` to npm automatically when the CLI project changes on a merge to `main`. Auth is **npm Trusted Publishing (OIDC)** — no long-lived token.

## How it works

Runs **in parallel** with the Supabase deploy jobs — the CLI is a zero-dependency npm package with no Supabase dependency, so it neither gates nor is gated by the edge-function deploy. Doubly guarded so an unrelated merge is a clean no-op:

1. **Change gate** — publishes only when `packages/cli` changed in the merged commit (`git diff HEAD^ HEAD -- packages/cli`).
2. **Version gate** — skips when the current `package.json` version is already on npm (`npm view`), so touching the CLI without a version bump doesn't fail.

When both pass it runs `node --test`, then `npm publish --access public --provenance`.

## Auth: Trusted Publishing, not a token

Instead of an `NPM_TOKEN` secret (npm automation tokens expire in ≤ 90 days and must be rotated), the job authenticates via OIDC:

- `permissions: id-token: write` mints a short-lived OIDC token per run.
- npm trades it for publish rights based on the **trusted publisher** configured on the package.
- Provenance is attached automatically.
- Node 20 ships npm 10.x, so a step upgrades npm to latest (Trusted Publishing needs ≥ 11.5.1).

## One-time setup (owner)

1. **Create the free `lorekit` npm org** and do the **first publish by hand** (`cd packages/cli && npm publish --access public`) to create the package — a trusted publisher can only be attached to a package that already exists.
2. On npmjs.com → **@lorekit/cli → Settings → Trusted Publisher → GitHub Actions**, set: repository `mthines/lorekit`, workflow `deploy.yml` (optionally environment). 
3. Done — every release after that is token-free.

**To cut a release:** bump `packages/cli/package.json` `version` in a PR; the merge tests and publishes.

## Notes

- Rebased onto current `main` (the preview-first `deploy.yml`); the job is appended after `rollback-production` and touches nothing in the existing pipeline.
- `publishConfig.access: "public"` is redundant here since the job passes `--access public`; #50 still adds it for manual publishes.
- Draft — won't merge without your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)