### PR TITLE
fix(write): partial-index-aware RPC for memory.write (broken since 00003)

### DIFF
--- a/packages/mcp-core/src/tools/write.spec.ts
+++ b/packages/mcp-core/src/tools/write.spec.ts
@@ -20,12 +20,8 @@ function makeDb(
   error: null | { message: string; code?: string } = null,
 ) {
   return {
-    from: vi.fn().mockReturnValue({
-      upsert: vi.fn().mockReturnValue({
-        select: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({ data, error }),
-        }),
-      }),
+    rpc: vi.fn().mockReturnValue({
+      single: vi.fn().mockResolvedValue({ data, error }),
     }),
   } as unknown as SupabaseClient;
 }
@@ -39,7 +35,7 @@ describe('write', () => {
     expect(result).toEqual(fakeResult);
   });
 
-  it('passes optional tags, source_agent and trigger to upsert', async () => {
+  it('passes optional tags, source_agent and trigger to the write RPC', async () => {
     const db = makeDb(fakeResult);
     await write(db, {
       scope: 'global',
@@ -49,7 +45,7 @@ describe('write', () => {
       source_agent: 'aw-executor',
       trigger: 'stuck-loop',
     });
-    // upsert was called — just verify no error thrown
+    // the RPC was called — just verify no error thrown
   });
 
   it('defaults tags to empty array when not provided', async () => {

--- a/packages/mcp-core/src/tools/write.ts
+++ b/packages/mcp-core/src/tools/write.ts
@@ -39,21 +39,19 @@ export async function write(
       if (input.trigger) span.setAttribute('lorekit.trigger', input.trigger);
 
       try {
+        // 00003 replaced the plain unique constraint with PARTIAL indexes
+        // (WHERE archived_at IS NULL), which `.upsert(onConflict)` cannot target.
+        // Writes go through the memory_write RPC (00007) instead.
         const { data, error } = await db
-          .from('memories')
-          .upsert(
-            {
-              scope: input.scope,
-              key: input.key,
-              value: input.value,
-              tags: input.tags,
-              source_agent: input.source_agent ?? null,
-              trigger: input.trigger ?? null,
-              updated_at: new Date().toISOString(),
-            },
-            { onConflict: 'user_id,scope,key' },
-          )
-          .select('id,created_at')
+          .rpc('memory_write', {
+            p_user_id: null,
+            p_scope: input.scope,
+            p_key: input.key,
+            p_value: input.value,
+            p_tags: input.tags,
+            p_source_agent: input.source_agent ?? null,
+            p_trigger: input.trigger ?? null,
+          })
           .single();
 
         if (error) throw translateCapError(error);

--- a/supabase/functions/mcp/tools.ts
+++ b/supabase/functions/mcp/tools.ts
@@ -35,20 +35,21 @@ export async function toolWrite(
     ...(trigger ? { 'lorekit.trigger': trigger } : {}),
   });
 
+  // 00003 replaced the plain unique constraint with PARTIAL indexes
+  // (WHERE archived_at IS NULL), which `.upsert(onConflict)` cannot target.
+  // The memory_write RPC (00007) performs the correct partial-index upsert,
+  // branching on whether user_id is null.
   const tracedDb = createTracedClient(db, span);
   const { data, error } = await tracedDb
-    .from('memories')
-    .upsert(
-      {
-        ...(userId ? { user_id: userId } : {}),
-        scope, key, value, tags,
-        source_agent: source_agent ?? null,
-        trigger: trigger ?? null,
-        updated_at: new Date().toISOString(),
-      },
-      { onConflict: 'user_id,scope,key' },
-    )
-    .select('id,created_at')
+    .rpc('memory_write', {
+      p_user_id: userId,
+      p_scope: scope,
+      p_key: key,
+      p_value: value,
+      p_tags: tags,
+      p_source_agent: source_agent ?? null,
+      p_trigger: trigger ?? null,
+    })
     .single();
   if (error) {
     const translated = translateCapError(error);

--- a/supabase/migrations/00007_memory_write_rpc.sql
+++ b/supabase/migrations/00007_memory_write_rpc.sql
@@ -1,0 +1,64 @@
+-- Fix memory.write against the partial unique indexes introduced in 00003.
+--
+-- 00003 dropped the plain `memories_user_scope_key_unique` constraint and
+-- replaced it with two PARTIAL unique indexes (WHERE archived_at IS NULL):
+--   • memories_user_scope_key_active_unique      (user_id, scope, key)
+--   • memories_null_user_scope_key_active_unique  (scope, key) WHERE user_id IS NULL
+--
+-- A plain `.upsert(..., { onConflict: 'user_id,scope,key' })` cannot target a
+-- partial index — Postgres raises "there is no unique or exclusion constraint
+-- matching the ON CONFLICT specification", so every write failed. `supabase-js`
+-- can't express a partial-index arbiter, so writes go through this RPC, which
+-- branches on whether user_id is null and names the matching partial index
+-- predicate in ON CONFLICT.
+--
+-- Behaviour preserved: the BEFORE INSERT memory-cap trigger still fires on the
+-- insert path (not on conflict-update); archived rows are excluded, so a
+-- (user_id, scope, key) can be re-created after it is archived.
+
+create or replace function memory_write(
+  p_user_id      uuid,
+  p_scope        text,
+  p_key          text,
+  p_value        text,
+  p_tags         text[] default '{}',
+  p_source_agent text   default null,
+  p_trigger      text   default null
+)
+returns table (id uuid, created_at timestamptz)
+language plpgsql
+set search_path = public
+as $$
+begin
+  if p_user_id is null then
+    -- service-role / CI writes: (scope, key) partial index for null user_id
+    return query
+    insert into memories (user_id, scope, key, value, tags, source_agent, trigger, updated_at)
+    values (null, p_scope, p_key, p_value, p_tags, p_source_agent, p_trigger, now())
+    on conflict (scope, key) where user_id is null and archived_at is null
+    do update set
+      value        = excluded.value,
+      tags         = excluded.tags,
+      source_agent = excluded.source_agent,
+      trigger      = excluded.trigger,
+      updated_at   = now()
+    returning memories.id, memories.created_at;
+  else
+    -- user-scoped writes (api_key / user): (user_id, scope, key) partial index
+    return query
+    insert into memories (user_id, scope, key, value, tags, source_agent, trigger, updated_at)
+    values (p_user_id, p_scope, p_key, p_value, p_tags, p_source_agent, p_trigger, now())
+    on conflict (user_id, scope, key) where archived_at is null
+    do update set
+      value        = excluded.value,
+      tags         = excluded.tags,
+      source_agent = excluded.source_agent,
+      trigger      = excluded.trigger,
+      updated_at   = now()
+    returning memories.id, memories.created_at;
+  end if;
+end;
+$$;
+
+grant execute on function memory_write(uuid, text, text, text, text[], text, text)
+  to anon, authenticated, service_role;


### PR DESCRIPTION
The preview smoke test caught a real, pre-existing bug: **`memory.write` has been broken since migration `00003`.**

## Root cause
`00003_archive.sql` dropped the plain `UNIQUE (user_id, scope, key)` constraint and replaced it with two **partial** unique indexes (`WHERE archived_at IS NULL`):
- `memories_user_scope_key_active_unique` — `(user_id, scope, key)`
- `memories_null_user_scope_key_active_unique` — `(scope, key) WHERE user_id IS NULL`

But `toolWrite` still did `.upsert(..., { onConflict: 'user_id,scope,key' })`. Postgres can't match `ON CONFLICT (user_id, scope, key)` to a **partial** index → `there is no unique or exclusion constraint matching the ON CONFLICT specification`. Every write failed, on every environment. `supabase-js` can't express a partial-index arbiter.

## Fix
New **`memory_write` RPC** (`00007`) that does the correct partial-index upsert, branching on whether `user_id` is null and naming the matching index predicate in `ON CONFLICT`. Both handlers call it instead of `.upsert()`:
- `supabase/functions/mcp/tools.ts` (deployed edge function)
- `packages/mcp-core/src/tools/write.ts` (Node variant) + updated mock

Behaviour preserved: the `BEFORE INSERT` memory-cap trigger still fires on the insert path; archived rows stay excluded so a key can be re-created after archive.

## Validation
- `check` → mcp-core unit tests (updated mock).
- `integration` → boots local Supabase, applies `00007`.
- Once merged + deployed, `smoke-preview` runs the full write/read/list/search/delete round-trip against the preview project — the one that was failing — and should go green, promoting to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018fnd7MsvqAp3L7Kf58qoid)_