### PR TITLE
fix(edge): forward count on traced update so memory.delete reports success

### DIFF
--- a/packages/mcp-server/src/smoke.integration.spec.ts
+++ b/packages/mcp-server/src/smoke.integration.spec.ts
@@ -170,10 +170,13 @@ describe.skipIf(SKIP)('LoreKit MCP smoke tests (integration)', () => {
       'memory.delete',
       { scope: SCOPE, key: KEY_A },
     );
+    // memory.delete defaults to a soft-delete (archive), which reports
+    // { deleted: false, archived: true }. Accept any of the success shapes.
     const deleted =
       result === true ||
       (result as { deleted?: boolean })?.deleted === true ||
-      (result as { ok?: boolean })?.ok === true;
+      (result as { ok?: boolean })?.ok === true ||
+      (result as { archived?: boolean })?.archived === true;
     expect(deleted, `expected delete success; got: ${JSON.stringify(result)}`).toBe(true);
   });
 

--- a/supabase/functions/_shared/otel.ts
+++ b/supabase/functions/_shared/otel.ts
@@ -419,10 +419,12 @@ export class TracedQuery<T = any> {
     return this;
   }
   // deno-lint-ignore no-explicit-any
-  update(data: any): this {
+  update(data: any, opts?: { count?: 'exact' | 'planned' | 'estimated' }): this {
     this.state.op = 'UPDATE';
     this.state.columns = Object.keys(data).join(', ');
-    this.state.qb = this.state.qb.update(data);
+    // Forward opts (e.g. { count: 'exact' }) — without this the row count is
+    // dropped, so soft-delete/archive report archived:false even on success.
+    this.state.qb = this.state.qb.update(data, opts);
     return this;
   }
   // deno-lint-ignore no-explicit-any


### PR DESCRIPTION
After the write fix (#58), the preview smoke went from 1/9 → **8/9**. The last failure is `memory.delete`, and it's two small real bugs:

1. **`TracedQuery.update()` dropped its options.** Its signature was `update(data)`, so `.update(payload, { count: 'exact' })` lost the count. `toolDelete`'s soft-delete (and `toolArchive`) then read `count = undefined` and reported `archived:false` **even though the archive succeeded** — proven by the very next test (`read deleted key → absent`) passing. Now forwards opts to the query builder.
2. **The smoke test only accepted `deleted`/`ok`** as delete success. `memory.delete` defaults to a soft-delete returning `{ deleted:false, archived:true }`; the test now accepts `archived:true` too.

Deployed edge function + smoke spec only. Once merged + deployed, `smoke-preview` should be 9/9 and promote to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018fnd7MsvqAp3L7Kf58qoid)_