### PR TITLE
docs(cli): recommend global install; keep npx as the alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,21 @@ gotcha, a costly wrong assumption). It mirrors the read-on-start /
 write-on-failure loop of the `aw` autonomous-workflow agent.
 
 ```bash
+# Install the CLI globally (recommended — pinned version, always on PATH,
+# so the plugin hooks fire instantly instead of re-fetching via npx each time)
+npm install -g @lorekit/cli
+
 # Scaffold the lorekit-memory skill into .claude/skills and wire .mcp.json
-npx @lorekit/cli install \
+lorekit install \
   --endpoint https://pqokxlhvnosogizsjztg.supabase.co/functions/v1/mcp \
   --token    lk_rw_<your-token>
 
 # Verify connectivity, token permission, and the git-derived scopes
-npx @lorekit/cli doctor
+lorekit doctor
 ```
+
+> No global install? Swap `lorekit` for `npx @lorekit/cli` in the commands
+> above to run it on demand instead.
 
 → See [packages/cli/README.md](./packages/cli/README.md) for all commands and
 flags, and the installed skill's `SKILL.md` for the read/write protocol.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -9,12 +9,29 @@ CI included. This CLI wires an agent up to it in two commands.
 
 ## Install
 
+Install it globally — recommended. You get one pinned version, the `lorekit`
+command stays on your `PATH`, and the plugin hooks (which call `lorekit hook`
+on every lifecycle event) fire instantly instead of paying an `npx` resolution
+cost each time:
+
+```bash
+npm install -g @lorekit/cli
+lorekit install
+lorekit doctor
+```
+
+Upgrade later with `npm install -g @lorekit/cli@latest`.
+
+Prefer not to install anything? Run it on demand with `npx` — same commands,
+always the latest version, fetched and cached per use:
+
 ```bash
 npx @lorekit/cli install
 npx @lorekit/cli doctor
 ```
 
-Requires Node 18+ (for the built-in `fetch`). No dependencies.
+Requires Node 18+ (for the built-in `fetch`). No dependencies. Works on macOS,
+Linux, and Windows (npm creates the `lorekit` shim on every platform).
 
 ## Commands
 


### PR DESCRIPTION
## What

Leads the install docs with **`npm install -g @lorekit/cli`** instead of `npx`, keeping the npx one-liner as the zero-install alternative. Touches `packages/cli/README.md` (the npm package page) and the root `README.md`.

## Why

Two rough edges with npx-first docs, both hit during first-time setup:

1. **Registry propagation window.** Right after the very first publish of a new package, the CDN edge can serve the package document before its version list has propagated — so `npx @lorekit/cli` / `npm i -g @lorekit/cli` briefly fail with `ENOVERSIONS` / "No versions available" (and npx surfaces it as `sh: lorekit: command not found`). It self-heals in a few minutes, but it's a confusing first impression. (Not a package defect — verified the tarball ships `bin/lorekit.mjs` with its shebang and that a global install links the `lorekit` shim correctly.)
2. **Hook latency.** The plugins call `lorekit hook` on *every* host lifecycle event. With npx each call pays a resolution/cache cost; a global binary is immediate.

Global install also gives a **pinned version** (npx silently tracks `latest`) and a persistent `lorekit` on `PATH`.

## Notes

- npm creates the `lorekit` bin shim cross-platform (macOS/Linux/Windows), so the global path works everywhere.
- Left the `npx @lorekit/cli doctor` "verify" lines in the plugin/skill docs as-is — one-off verification via npx is fine. Happy to sweep those too if you'd prefer full consistency.
- Draft — no code changes, docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019PMqhJr8ADx9gsSif6L8vm)_