### PR TITLE
refactor(web): shared ScopeBadge + MemoryCard components

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,14 +30,14 @@ Vercel bits are only needed when you touch those pieces.
 
 ## Repo layout
 
-| Path | What |
-|------|------|
-| `packages/mcp-core/` | Scope validator, DB client, tool handlers, OTel |
-| `packages/mcp-server/` | Node.js MCP server (Fly.io variant) |
-| `packages/web/` | Next.js dashboard (Vercel) |
-| `packages/cli/` | Zero-dep `@lorekit/cli` — `install` / `doctor` / `hook` / `migrate` / `mcp` |
-| `plugins/` | Per-framework bundles (Claude / Cursor / Codex) |
-| `supabase/` | Edge Functions (production MCP server), migrations |
+| Path                   | What                                                                        |
+| ---------------------- | --------------------------------------------------------------------------- |
+| `packages/mcp-core/`   | Scope validator, DB client, tool handlers, OTel                             |
+| `packages/mcp-server/` | Node.js MCP server (Fly.io variant)                                         |
+| `packages/web/`        | Next.js dashboard (Vercel)                                                  |
+| `packages/cli/`        | Zero-dep `@lorekit/cli` — `install` / `doctor` / `hook` / `migrate` / `mcp` |
+| `plugins/`             | Per-framework bundles (Claude / Cursor / Codex)                             |
+| `supabase/`            | Edge Functions (production MCP server), migrations                          |
 
 See [CLAUDE.md](./CLAUDE.md) for the full package map and key decisions.
 
@@ -66,7 +66,7 @@ command against your working copy.
 
 ```bash
 cd packages/cli
-npm link
+pnpm link --global
 ```
 
 This creates a global `lorekit` that points at `packages/cli/bin/lorekit.mjs` in
@@ -86,7 +86,7 @@ lorekit doctor       # run it against the current directory
 ### Remove the symlink
 
 ```bash
-npm rm -g @lorekit/cli     # or: npm unlink -g @lorekit/cli
+pnpm unlink --global @lorekit/cli
 ```
 
 ### Run it without linking

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ git clone https://github.com/mthines/lorekit && cd lorekit
 pnpm install
 
 # Link to your Supabase project and apply migrations
-supabase link --project-ref <your-project-ref>
+supabase link --project-ref pqokxlhvnosogizsjztg
 pnpm nx deploy supabase
 ```
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -39,7 +39,7 @@ supabase secrets set \
   OTEL_EXPORTER_OTLP_ENDPOINT=https://ingress.europe-west4.gcp.dash0-dev.com \
   OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <dash0-token>" \
   VERCEL_ENV=production \
-  --project-ref <your-project-ref>
+  --project-ref pqokxlhvnosogizsjztg
 ```
 
 ---
@@ -50,7 +50,7 @@ supabase secrets set \
 
 ```bash
 # 1. Link Supabase project
-supabase link --project-ref <your-project-ref>
+supabase link --project-ref pqokxlhvnosogizsjztg
 
 # 2. Apply migrations + deploy functions
 pnpm nx deploy supabase

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -118,7 +118,7 @@ the sole gate that keeps unverified (or migration-breaking) code off `main`.
 ## 1. Link to your Supabase project
 
 ```bash
-supabase link --project-ref <your-project-ref>
+supabase link --project-ref pqokxlhvnosogizsjztg
 ```
 
 Your project ref is the subdomain of your Supabase URL: `https://pqokxlhvnosogizsjztg.supabase.co`.
@@ -130,7 +130,7 @@ Your project ref is the subdomain of your Supabase URL: `https://pqokxlhvnosogiz
 ```bash
 pnpm nx db:push supabase
 # or directly:
-supabase db push --project-ref <your-project-ref>
+supabase db push --project-ref pqokxlhvnosogizsjztg
 ```
 
 This applies:
@@ -158,7 +158,7 @@ supabase secrets set \
   OTEL_EXPORTER_OTLP_ENDPOINT=https://ingress.europe-west4.gcp.dash0-dev.com \
   OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <DASH0_AUTH_TOKEN>" \
   VERCEL_ENV=production \
-  --project-ref <your-project-ref>
+  --project-ref pqokxlhvnosogizsjztg
 ```
 
 ---
@@ -170,8 +170,8 @@ supabase secrets set \
 pnpm nx fn:deploy supabase
 
 # Or directly:
-supabase functions deploy mcp --project-ref <your-project-ref>
-supabase functions deploy health --no-verify-jwt --project-ref <your-project-ref>
+supabase functions deploy mcp --project-ref pqokxlhvnosogizsjztg
+supabase functions deploy health --no-verify-jwt --project-ref pqokxlhvnosogizsjztg
 ```
 
 **Note:** `health` is deployed with `--no-verify-jwt` so uptime monitors can call it without authentication.

--- a/docs/install.md
+++ b/docs/install.md
@@ -34,13 +34,13 @@ pnpm install
 Your project ref is the subdomain of your Supabase URL: `https://pqokxlhvnosogizsjztg.supabase.co`
 
 ```bash
-supabase link --project-ref <your-project-ref>
+supabase link --project-ref pqokxlhvnosogizsjztg
 ```
 
 Create a `.env.local` file in the repo root (needed for NX targets):
 
 ```bash
-echo "SUPABASE_PROJECT_REF=<your-project-ref>" > .env.local
+echo "SUPABASE_PROJECT_REF=pqokxlhvnosogizsjztg" > .env.local
 ```
 
 ---
@@ -79,7 +79,7 @@ supabase secrets set \
   OTEL_EXPORTER_OTLP_ENDPOINT=https://ingress.europe-west4.gcp.dash0-dev.com \
   OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <dash0-token>" \
   VERCEL_ENV=production \
-  --project-ref <your-project-ref>
+  --project-ref pqokxlhvnosogizsjztg
 ```
 
 Find the Supabase keys in: Supabase dashboard → Project Settings → API

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -69,7 +69,7 @@ Add two Supabase secrets:
 supabase secrets set \
   OTEL_EXPORTER_OTLP_ENDPOINT=https://ingress.europe-west4.gcp.dash0-dev.com \
   OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer <DASH0_AUTH_TOKEN> \
-  --project-ref <your-project-ref>
+  --project-ref pqokxlhvnosogizsjztg
 ```
 
 Then redeploy: `pnpm nx fn:deploy supabase`
@@ -92,7 +92,7 @@ Add to Vercel → Environment Variables (all environments):
 ```
 NEXT_PUBLIC_DASH0_OTLP_ENDPOINT   https://ingress.europe-west4.gcp.dash0-dev.com
 NEXT_PUBLIC_DASH0_AUTH_TOKEN      <ingesting-only-token>
-NEXT_PUBLIC_SUPABASE_PROJECT_REF  <your-project-ref>
+NEXT_PUBLIC_SUPABASE_PROJECT_REF  pqokxlhvnosogizsjztg
 ```
 
 > **Security:** `NEXT_PUBLIC_DASH0_AUTH_TOKEN` is embedded in the browser bundle. Create a **separate** auth token in Dash0 with **Ingesting only** permissions, scoped to the `lorekit` dataset.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.1.0",
     "@eslint/js": "^9.8.0",
     "@nx/eslint": "22.4.0",
     "@nx/eslint-plugin": "22.4.0",
@@ -46,7 +47,10 @@
     ],
     "overrides": {
       "baseline-browser-mapping": "2.11.0",
-      "brace-expansion": "5.0.7",
+      "brace-expansion@1": "1.1.12",
+      "brace-expansion@2": "2.0.2",
+      "brace-expansion@3": "3.0.1",
+      "brace-expansion@4": "4.0.1",
       "flatted": "3.4.2",
       "postcss": "8.4.30",
       "less": "4.7.0",

--- a/packages/web/eslint.config.mjs
+++ b/packages/web/eslint.config.mjs
@@ -1,4 +1,5 @@
 import { FlatCompat } from '@eslint/eslintrc';
+import reactHooks from 'eslint-plugin-react-hooks';
 import baseConfig from '../../eslint.config.mjs';
 
 const compat = new FlatCompat({ baseDirectory: import.meta.dirname });
@@ -6,6 +7,17 @@ const compat = new FlatCompat({ baseDirectory: import.meta.dirname });
 export default [
   ...baseConfig,
   ...compat.extends('plugin:@next/next/recommended'),
+  {
+    // Register the react-hooks plugin so its rules resolve — several source
+    // files carry `// eslint-disable-next-line react-hooks/exhaustive-deps`
+    // directives that error out ("rule not found") when the plugin is absent.
+    files: ['**/*.{ts,tsx}'],
+    plugins: { 'react-hooks': reactHooks },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+    },
+  },
   {
     ignores: ['.next/**', 'node_modules/**'],
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,7 +22,9 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@next/eslint-plugin-next": "^15.3.8",
     "@nx/next": "22.4.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "@types/node": "20.19.9",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/packages/web/public/llms.txt
+++ b/packages/web/public/llms.txt
@@ -9,7 +9,7 @@ LoreKit gives any MCP-compatible agent a `memory.write / memory.read / memory.li
 ## Quick start (5 minutes)
 
 1. Clone and install: `git clone https://github.com/mthines/lorekit && cd lorekit && pnpm install`
-2. Deploy to your own Supabase project: `supabase link --project-ref <ref> && pnpm nx deploy supabase`
+2. Deploy to your own Supabase project: `supabase link --project-ref pqokxlhvnosogizsjztg && pnpm nx deploy supabase`
 3. Generate a token in the web dashboard: Overview → Step 2 → Generate new token
 4. Add the MCP config to your agent — see the Installation Guide below
 

--- a/packages/web/src/components/activity/ActivityFeed.tsx
+++ b/packages/web/src/components/activity/ActivityFeed.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useMemo } from 'react';
-import { motion } from 'motion/react';
-import { Bot, Zap, GitBranch, Globe, FolderGit2, Layers, Webhook } from 'lucide-react';
-import { Badge } from '@/components/ui/Badge';
+import { Bot, Zap, Webhook } from 'lucide-react';
+import { MemoryCard, memoryFromEvent } from '@/components/memory/MemoryCard';
+import { scopeLabel } from '@/components/memory/scope-meta';
 import { useMemorySidebar } from '@/components/providers/MemorySidebarProvider';
 import { useUrlState } from '@/lib/hooks/useUrlState';
 import { DateRangePicker, type DateRange } from '@/components/ui/DateRangePicker';
@@ -21,29 +21,11 @@ export interface ActivityEvent {
   created_at: string;
 }
 
-const SCOPE_ICONS: Record<ScopePrefix, typeof Globe> = {
-  global: Globe,
-  project: Layers,
-  repo: FolderGit2,
-  branch: GitBranch,
-};
-
 const TRIGGER_ICONS: Record<string, typeof Bot> = {
   'stuck-loop': Zap,
   'pr-webhook': Webhook,
   'manual': Bot,
 };
-
-function formatDateTime(iso: string) {
-  const date = new Date(iso);
-  const now = new Date();
-  const diff = now.getTime() - date.getTime();
-  const minutes = Math.floor(diff / 60_000);
-
-  if (minutes < 60) return `${minutes}m ago`;
-  if (minutes < 1440) return `${Math.floor(minutes / 60)}h ago`;
-  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
-}
 
 function groupByDate(events: ActivityEvent[]): Map<string, ActivityEvent[]> {
   const groups = new Map<string, ActivityEvent[]>();
@@ -83,65 +65,17 @@ interface ActivityEventRowProps {
 }
 
 function ActivityEventRow({ event, index, selected, onSelect }: ActivityEventRowProps) {
-  const ScopeIcon = SCOPE_ICONS[event.scope_type];
   const TriggerIcon = event.trigger ? (TRIGGER_ICONS[event.trigger] ?? Bot) : Bot;
 
   return (
-    <motion.button
-      type="button"
+    <MemoryCard
+      memory={memoryFromEvent(event)}
+      layout="row"
+      index={index}
+      selected={selected}
       onClick={() => onSelect({ scope: event.scope, key: event.key })}
-      aria-pressed={selected}
-      initial={{ opacity: 0, x: -8 }}
-      animate={{ opacity: 1, x: 0 }}
-      transition={{ delay: index * 0.03, duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
-      className={[
-        'flex w-full gap-3 rounded-lg border p-3 text-left transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]',
-        selected
-          ? 'border-[var(--color-accent)] bg-[var(--color-accent-subtle)]'
-          : 'border-[var(--color-border)] bg-[var(--color-bg-raised)] hover:bg-[var(--color-bg-elevated)]',
-      ].join(' ')}
-    >
-      {/* Icon */}
-      <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)]">
-        <TriggerIcon className="size-3.5 text-[var(--color-content-tertiary)]" aria-hidden />
-      </div>
-
-      {/* Content */}
-      <div className="min-w-0 flex-1">
-        <div className="mb-1 flex flex-wrap items-center gap-1.5">
-          <Badge variant={event.scope_type}>
-            <ScopeIcon className="mr-1 inline size-2.5" aria-hidden />
-            {event.scope_type}
-          </Badge>
-          <code className="truncate font-mono text-xs text-[var(--color-content-primary)]">
-            {event.key}
-          </code>
-          <span className="ml-auto shrink-0 text-xs text-[var(--color-content-tertiary)]">
-            {formatDateTime(event.created_at)}
-          </span>
-        </div>
-
-        <p className="mb-1.5 line-clamp-1 text-xs text-[var(--color-content-secondary)]">
-          {event.value_preview}
-        </p>
-
-        <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--color-content-tertiary)]">
-          {event.source_agent && (
-            <span className="flex items-center gap-1">
-              <Bot className="size-3" aria-hidden />
-              {event.source_agent}
-            </span>
-          )}
-          {event.trigger && (
-            <span className="flex items-center gap-1">
-              <Zap className="size-3" aria-hidden />
-              {event.trigger}
-            </span>
-          )}
-          <code className="ml-auto truncate opacity-50">{event.scope}</code>
-        </div>
-      </div>
-    </motion.button>
+      leadingIcon={<TriggerIcon className="size-3.5 text-[var(--color-content-tertiary)]" aria-hidden />}
+    />
   );
 }
 
@@ -150,11 +84,6 @@ interface ActivityFeedProps {
   /** Selected date range (UTC day strings), or null for all time. */
   range: DateRange | null;
   onRangeChange: (range: DateRange | null) => void;
-}
-
-/** Friendly label for a scope filter pill — last segment, matching the Lore Explorer. */
-function scopeLabel(scope: string): string {
-  return scope.split('::').pop() ?? scope;
 }
 
 export function ActivityFeed({ events, range, onRangeChange }: ActivityFeedProps) {

--- a/packages/web/src/components/activity/ActivityFeed.tsx
+++ b/packages/web/src/components/activity/ActivityFeed.tsx
@@ -140,6 +140,7 @@ export function ActivityFeed({ events, range, onRangeChange }: ActivityFeedProps
             {['all', ...scopeFilters].map((f) => (
               <button
                 key={f}
+                type="button"
                 onClick={() => setFilter(f)}
                 aria-pressed={filter === f}
                 title={f === 'all' ? undefined : f}

--- a/packages/web/src/components/activity/ContributionHeatmap.tsx
+++ b/packages/web/src/components/activity/ContributionHeatmap.tsx
@@ -68,7 +68,7 @@ export function ContributionHeatmap({
     // Build week columns
     const cols: Array<Array<{ date: string; count: number }>> = [];
     const months: Array<{ label: string; col: number }> = [];
-    let seenMonths = new Set<string>();
+    const seenMonths = new Set<string>();
 
     for (let w = 0; w < weeks; w++) {
       const week: Array<{ date: string; count: number }> = [];

--- a/packages/web/src/components/dashboard/ScopeHealthCard.tsx
+++ b/packages/web/src/components/dashboard/ScopeHealthCard.tsx
@@ -2,8 +2,9 @@
 
 import { motion } from 'motion/react';
 import Link from 'next/link';
-import { FolderGit2, GitBranch, Globe, Layers, ArrowRight, BookOpen } from 'lucide-react';
-import { Badge } from '@/components/ui/Badge';
+import { ArrowRight, BookOpen } from 'lucide-react';
+import { ScopeBadge } from '@/components/memory/ScopeBadge';
+import { scopeIcon } from '@/components/memory/scope-meta';
 import type { ScopePrefix } from '@/lib/scope';
 
 export interface ScopeHealth {
@@ -13,13 +14,6 @@ export interface ScopeHealth {
   total: number;
   lastActivity: string | null; // ISO date
 }
-
-const SCOPE_ICONS: Record<ScopePrefix, typeof Globe> = {
-  global: Globe,
-  project: Layers,
-  repo: FolderGit2,
-  branch: GitBranch,
-};
 
 function freshnessLabel(lastActivity: string | null): { label: string; color: string } {
   if (!lastActivity) return { label: 'No activity', color: 'text-[var(--color-content-tertiary)]' };
@@ -36,7 +30,7 @@ interface ScopeHealthCardProps {
 }
 
 export function ScopeHealthCard({ health, index }: ScopeHealthCardProps) {
-  const Icon = SCOPE_ICONS[health.type];
+  const Icon = scopeIcon(health.type);
   const freshness = freshnessLabel(health.lastActivity);
 
   return (
@@ -59,7 +53,8 @@ export function ScopeHealthCard({ health, index }: ScopeHealthCardProps) {
             <div className="flex size-8 items-center justify-center rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)] transition-colors duration-200 group-hover:border-[var(--color-accent-glow)] group-hover:bg-[var(--color-accent-subtle)]">
               <Icon className="size-4 text-[var(--color-content-secondary)] transition-colors duration-200 group-hover:text-[var(--color-accent)]" aria-hidden />
             </div>
-            <Badge variant={health.type}>{health.type}</Badge>
+            {/* Icon already shown in the box above, so the pill omits it. */}
+            <ScopeBadge scope={health.scope} type={health.type} showIcon={false} />
           </div>
           <ArrowRight className="size-4 shrink-0 text-[var(--color-content-tertiary)] opacity-0 transition-all duration-200 group-hover:translate-x-0.5 group-hover:opacity-100" aria-hidden />
         </div>

--- a/packages/web/src/components/lore/LessonCard.tsx
+++ b/packages/web/src/components/lore/LessonCard.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { memo } from 'react';
-import { motion, useReducedMotion } from 'motion/react';
-import { Clock, Bot, Zap } from 'lucide-react';
-import { Badge } from '@/components/ui/Badge';
+import { MemoryCard, memoryFromLesson } from '@/components/memory/MemoryCard';
 import type { ScopePrefix } from '@/lib/scope';
 
+/**
+ * Canonical shape of a memory as stored/queried. Kept here as the app's shared
+ * lesson type (imported across the lore, activity, and dashboard queries); the
+ * visual rendering is delegated to the shared {@link MemoryCard}.
+ */
 export interface LessonEntry {
   key: string;
   value: string;
@@ -18,16 +20,6 @@ export interface LessonEntry {
   scope_type: ScopePrefix;
 }
 
-function relativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const minutes = Math.floor(diff / 60_000);
-  if (minutes < 1) return 'just now';
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  return `${Math.floor(hours / 24)}d ago`;
-}
-
 interface LessonCardProps {
   lesson: LessonEntry;
   selected: boolean;
@@ -35,90 +27,14 @@ interface LessonCardProps {
   index: number;
 }
 
-export const LessonCard = memo(function LessonCard({
-  lesson,
-  selected,
-  onClick,
-  index,
-}: LessonCardProps) {
-  const preview = lesson.value.slice(0, 160).replace(/\n/g, ' ');
-  const truncated = lesson.value.length > 160;
-  const reduceMotion = useReducedMotion();
-
+export function LessonCard({ lesson, selected, onClick, index }: LessonCardProps) {
   return (
-    <motion.button
+    <MemoryCard
+      memory={memoryFromLesson(lesson)}
+      layout="card"
+      selected={selected}
       onClick={onClick}
-      // Subtle fade + 4px rise. Uses a plain ease-out (not a front-loaded expo
-      // curve) so opacity and position settle together — otherwise the card
-      // reads as "appears, then slides up". Reduced-motion → pure fade, no rise.
-      initial={{ opacity: 0, y: reduceMotion ? 0 : 4 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ delay: index * 0.03, duration: 0.25, ease: 'easeOut' }}
-      className={[
-        'group w-full rounded-xl border p-4 text-left transition-all duration-150',
-        selected
-          ? 'border-[var(--color-accent)] bg-[var(--color-accent-subtle)]'
-          : 'border-[var(--color-border)] bg-[var(--color-bg-raised)] hover:border-[var(--color-border)] hover:bg-[var(--color-bg-elevated)]',
-      ].join(' ')}
-      aria-pressed={selected}
-    >
-      {/* Key */}
-      <div className="mb-2 flex items-start justify-between gap-2">
-        <code
-          className={[
-            'truncate font-mono text-xs font-medium',
-            selected ? 'text-[var(--color-accent)]' : 'text-[var(--color-content-primary)]',
-          ].join(' ')}
-        >
-          {lesson.key}
-        </code>
-        <Badge variant={lesson.scope_type}>{lesson.scope_type}</Badge>
-      </div>
-
-      {/* Value preview */}
-      <p className="mb-3 line-clamp-2 text-xs text-[var(--color-content-secondary)]">
-        {preview}
-        {truncated && '…'}
-      </p>
-
-      {/* Footer */}
-      <div className="flex flex-wrap items-center gap-2">
-        {lesson.source_agent && (
-          <span className="flex items-center gap-1 text-xs text-[var(--color-content-tertiary)]">
-            <Bot className="size-3" aria-hidden />
-            {lesson.source_agent}
-          </span>
-        )}
-        {lesson.trigger && (
-          <span className="flex items-center gap-1 text-xs text-[var(--color-content-tertiary)]">
-            <Zap className="size-3" aria-hidden />
-            {lesson.trigger}
-          </span>
-        )}
-        <span className="ml-auto flex items-center gap-1 text-xs text-[var(--color-content-tertiary)]">
-          <Clock className="size-3" aria-hidden />
-          {relativeTime(lesson.updated_at)}
-        </span>
-      </div>
-
-      {/* Tags */}
-      {lesson.tags.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1">
-          {lesson.tags.slice(0, 4).map((tag) => (
-            <span
-              key={tag}
-              className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-bg)] px-1.5 py-0.5 font-mono text-xs text-[var(--color-content-tertiary)]"
-            >
-              {tag}
-            </span>
-          ))}
-          {lesson.tags.length > 4 && (
-            <span className="rounded-md px-1.5 py-0.5 text-xs text-[var(--color-content-tertiary)]">
-              +{lesson.tags.length - 4}
-            </span>
-          )}
-        </div>
-      )}
-    </motion.button>
+      index={index}
+    />
   );
-});
+}

--- a/packages/web/src/components/lore/LessonDetailSheet.tsx
+++ b/packages/web/src/components/lore/LessonDetailSheet.tsx
@@ -100,6 +100,7 @@ export function LessonDetailSheet({ lesson, onClose, onMutated }: LessonDetailSh
               </div>
               <button
                 ref={closeRef}
+                type="button"
                 onClick={onClose}
                 aria-label="Close detail panel"
                 className="flex size-11 shrink-0 items-center justify-center rounded-lg text-[var(--color-content-tertiary)] transition-all duration-150 hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-content-secondary)]"
@@ -190,6 +191,7 @@ export function LessonDetailSheet({ lesson, onClose, onMutated }: LessonDetailSh
                 <p className="text-xs text-red-500">{actionError}</p>
               )}
               <button
+                type="button"
                 onClick={handleArchive}
                 disabled={isPending}
                 className={[

--- a/packages/web/src/components/lore/LessonDetailSheet.tsx
+++ b/packages/web/src/components/lore/LessonDetailSheet.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState, useTransition } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import { X, Bot, Zap, Tag, Clock, Archive, RotateCcw } from 'lucide-react';
-import { Badge } from '@/components/ui/Badge';
+import { ScopeBadge } from '@/components/memory/ScopeBadge';
 import type { LessonEntry } from './LessonCard';
 import { archiveLesson, restoreLesson } from '@/lib/lore';
 
@@ -87,15 +87,12 @@ export function LessonDetailSheet({ lesson, onClose, onMutated }: LessonDetailSh
             <div className="flex items-start justify-between gap-3 border-b border-[var(--color-border)] p-5">
               <div className="flex flex-col gap-1.5">
                 <div className="flex items-center gap-2">
-                  <Badge variant={lesson.scope_type}>{lesson.scope_type}</Badge>
+                  <ScopeBadge scope={lesson.scope} type={lesson.scope_type} showPath />
                   {isArchived && (
                     <span className="rounded-full bg-[var(--color-bg-elevated)] px-2 py-0.5 text-xs text-[var(--color-content-tertiary)]">
                       archived
                     </span>
                   )}
-                  <code className="text-xs text-[var(--color-content-tertiary)]">
-                    {lesson.scope}
-                  </code>
                 </div>
                 <code className="font-mono text-sm font-medium text-[var(--color-content-primary)]">
                   {lesson.key}

--- a/packages/web/src/components/lore/MemoryExpandButton.tsx
+++ b/packages/web/src/components/lore/MemoryExpandButton.tsx
@@ -16,6 +16,7 @@ import { BookOpen, ChevronDown } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useLoreData } from '@/lib/queries/lore';
 import { useMemorySidebar } from '@/components/providers/MemorySidebarProvider';
+import { MemoryCard, memoryFromLesson } from '@/components/memory/MemoryCard';
 import type { LessonEntry } from '@/components/lore/LessonCard';
 
 interface MemoryExpandButtonProps {
@@ -131,8 +132,10 @@ export function MemoryExpandButton({
                     openLesson?.key === lesson.key && openLesson?.scope === lesson.scope;
                   return (
                     <li key={`${lesson.scope}::${lesson.key}`} role="option" aria-selected={isSelected}>
-                      <button
-                        type="button"
+                      <MemoryCard
+                        memory={memoryFromLesson(lesson)}
+                        density="compact"
+                        selected={isSelected}
                         onClick={() => {
                           if (isSelected) {
                             closeLesson();
@@ -141,28 +144,7 @@ export function MemoryExpandButton({
                           }
                           setIsDropdownOpen(false);
                         }}
-                        className={[
-                          'flex w-full flex-col gap-0.5 px-4 py-2.5 text-left transition-colors duration-100',
-                          isSelected
-                            ? 'bg-[var(--color-accent-subtle)]'
-                            : 'hover:bg-[var(--color-bg-elevated)]',
-                        ].join(' ')}
-                      >
-                        <code
-                          className={[
-                            'truncate font-mono text-xs font-medium',
-                            isSelected
-                              ? 'text-[var(--color-accent)]'
-                              : 'text-[var(--color-content-primary)]',
-                          ].join(' ')}
-                        >
-                          {lesson.key}
-                        </code>
-                        <span className="line-clamp-1 text-xs text-[var(--color-content-tertiary)]">
-                          {lesson.value.slice(0, 80)}
-                          {lesson.value.length > 80 ? '…' : ''}
-                        </span>
-                      </button>
+                      />
                     </li>
                   );
                 })}

--- a/packages/web/src/components/lore/MemoryExpandButton.tsx
+++ b/packages/web/src/components/lore/MemoryExpandButton.tsx
@@ -56,12 +56,13 @@ export function MemoryExpandButton({
 
   // Close on Escape.
   useEffect(() => {
+    if (!isDropdownOpen) return;
     function onKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') setIsDropdownOpen(false);
     }
     document.addEventListener('keydown', onKeyDown);
     return () => document.removeEventListener('keydown', onKeyDown);
-  }, []);
+  }, [isDropdownOpen]);
 
   const lessons = useMemo<LessonEntry[]>(() => {
     if (!data?.lessons) return [];

--- a/packages/web/src/components/lore/ScopeTree.tsx
+++ b/packages/web/src/components/lore/ScopeTree.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { ChevronRight, Globe, FolderGit2, GitBranch, Layers } from 'lucide-react';
+import { ChevronRight } from 'lucide-react';
+import { scopeIcon } from '@/components/memory/scope-meta';
 import type { ScopePrefix } from '@/lib/scope';
 
 export interface ScopeNode {
@@ -12,13 +13,6 @@ export interface ScopeNode {
   children?: ScopeNode[];
 }
 
-const SCOPE_ICONS: Record<ScopePrefix, typeof Globe> = {
-  global: Globe,
-  project: Layers,
-  repo: FolderGit2,
-  branch: GitBranch,
-};
-
 interface ScopeTreeItemProps {
   node: ScopeNode;
   depth: number;
@@ -28,7 +22,7 @@ interface ScopeTreeItemProps {
 
 function ScopeTreeItem({ node, depth, selected, onSelect }: ScopeTreeItemProps) {
   const [expanded, setExpanded] = useState(depth === 0);
-  const Icon = SCOPE_ICONS[node.type];
+  const Icon = scopeIcon(node.type);
   const hasChildren = (node.children?.length ?? 0) > 0;
   const isSelected = selected === node.scope;
 

--- a/packages/web/src/components/lore/ScopeTree.tsx
+++ b/packages/web/src/components/lore/ScopeTree.tsx
@@ -29,6 +29,7 @@ function ScopeTreeItem({ node, depth, selected, onSelect }: ScopeTreeItemProps) 
   return (
     <li>
       <button
+        type="button"
         onClick={() => {
           onSelect(node.scope);
           if (hasChildren) setExpanded((v) => !v);
@@ -41,7 +42,7 @@ function ScopeTreeItem({ node, depth, selected, onSelect }: ScopeTreeItemProps) 
         ].join(' ')}
         style={{ paddingLeft: `${(depth + 1) * 12}px` }}
         aria-expanded={hasChildren ? expanded : undefined}
-        aria-current={isSelected ? 'true' : undefined}
+        aria-selected={isSelected}
       >
         {hasChildren ? (
           <ChevronRight

--- a/packages/web/src/components/memory/MemoryCard.tsx
+++ b/packages/web/src/components/memory/MemoryCard.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+/**
+ * MemoryCard — the one component for rendering a memory (lesson).
+ *
+ * Every surface that shows a memory renders it through here so the key, scope
+ * pill, value preview, agent/trigger metadata, timestamp, and tags stay
+ * visually identical:
+ *   - the Lore Explorer list        → `layout="card"`   (vertical, full detail)
+ *   - the Activity feed rows        → `layout="row"`     (horizontal, leading icon)
+ *   - the "N memories" dropdown     → `density="compact"` (key + one-line preview)
+ *
+ * Callers pass a normalised {@link MemoryCardModel}. Two adapters are provided
+ * for the app's two source shapes; build one inline for anything else.
+ */
+
+import type { ReactNode } from 'react';
+import { memo } from 'react';
+import { motion, useReducedMotion } from 'motion/react';
+import { Clock, Bot, Zap } from 'lucide-react';
+import { ScopeBadge } from './ScopeBadge';
+import type { ScopePrefix } from './scope-meta';
+
+// ── Model ───────────────────────────────────────────────────────────────────
+
+/** Layout-agnostic shape every memory surface maps onto. */
+export interface MemoryCardModel {
+  scope: string;
+  scopeType?: ScopePrefix;
+  /** The lesson key (rendered as the title). */
+  memoryKey: string;
+  /** Full or already-truncated value text; the card clamps it visually. */
+  preview: string;
+  sourceAgent?: string | null;
+  trigger?: string | null;
+  tags?: string[];
+  /** ISO timestamp shown as relative time. */
+  timestamp?: string | null;
+  archived?: boolean;
+}
+
+/** Adapt a Lore Explorer lesson (LessonEntry-shaped) into the card model. */
+export function memoryFromLesson(lesson: {
+  scope: string;
+  scope_type: ScopePrefix;
+  key: string;
+  value: string;
+  tags?: string[];
+  updated_at: string;
+  source_agent?: string | null;
+  trigger?: string | null;
+  archived_at?: string | null;
+}): MemoryCardModel {
+  return {
+    scope: lesson.scope,
+    scopeType: lesson.scope_type,
+    memoryKey: lesson.key,
+    preview: lesson.value,
+    sourceAgent: lesson.source_agent,
+    trigger: lesson.trigger,
+    tags: lesson.tags,
+    timestamp: lesson.updated_at,
+    archived: Boolean(lesson.archived_at),
+  };
+}
+
+/** Adapt an Activity event into the card model. */
+export function memoryFromEvent(event: {
+  scope: string;
+  scope_type: ScopePrefix;
+  key: string;
+  value_preview: string;
+  tags?: string[];
+  created_at: string;
+  source_agent?: string | null;
+  trigger?: string | null;
+}): MemoryCardModel {
+  return {
+    scope: event.scope,
+    scopeType: event.scope_type,
+    memoryKey: event.key,
+    preview: event.value_preview,
+    sourceAgent: event.source_agent,
+    trigger: event.trigger,
+    tags: event.tags,
+    timestamp: event.created_at,
+  };
+}
+
+// ── Time ────────────────────────────────────────────────────────────────────
+
+/** Shared relative-time formatter used by every memory surface. */
+export function formatRelativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+// ── Shared pieces ───────────────────────────────────────────────────────────
+
+function MetaChip({ icon: Icon, children }: { icon: typeof Bot; children: ReactNode }) {
+  return (
+    <span className="flex items-center gap-1">
+      <Icon className="size-3" aria-hidden />
+      {children}
+    </span>
+  );
+}
+
+function Tags({ tags, max = 4 }: { tags: string[]; max?: number }) {
+  if (tags.length === 0) return null;
+  return (
+    <div className="mt-2 flex flex-wrap gap-1">
+      {tags.slice(0, max).map((tag) => (
+        <span
+          key={tag}
+          className="rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-bg)] px-1.5 py-0.5 font-mono text-xs text-[var(--color-content-tertiary)]"
+        >
+          {tag}
+        </span>
+      ))}
+      {tags.length > max && (
+        <span className="rounded-md px-1.5 py-0.5 text-xs text-[var(--color-content-tertiary)]">
+          +{tags.length - max}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ── Props ───────────────────────────────────────────────────────────────────
+
+export interface MemoryCardProps {
+  memory: MemoryCardModel;
+  /** Visual arrangement. @default 'card' */
+  layout?: 'card' | 'row';
+  /** `compact` collapses to key + one-line preview (dropdown rows). @default 'default' */
+  density?: 'default' | 'compact';
+  selected?: boolean;
+  onClick?: () => void;
+  /** Stagger index for the enter animation. */
+  index?: number;
+  /** Icon rendered in a bordered box before the content (row layout). */
+  leadingIcon?: ReactNode;
+  /** Scope pill. @default true (false in compact) */
+  showScope?: boolean;
+  /** Append the full canonical scope path in the footer. @default true in row layout */
+  showScopePath?: boolean;
+  /** Value preview. @default true */
+  showPreview?: boolean;
+  /** Agent / trigger metadata. @default true (false in compact) */
+  showMeta?: boolean;
+  /** Relative timestamp. @default true (false in compact) */
+  showTimestamp?: boolean;
+  /** Tag chips. @default true in card layout */
+  showTags?: boolean;
+  /** Enter animation. @default true (ignored in compact) */
+  animate?: boolean;
+  className?: string;
+}
+
+const SELECTED_CARD = 'border-[var(--color-accent)] bg-[var(--color-accent-subtle)]';
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export const MemoryCard = memo(function MemoryCard({
+  memory,
+  layout = 'card',
+  density = 'default',
+  selected = false,
+  onClick,
+  index = 0,
+  leadingIcon,
+  showScope = true,
+  showScopePath,
+  showPreview = true,
+  showMeta = true,
+  showTimestamp = true,
+  showTags = true,
+  animate = true,
+  className = '',
+}: MemoryCardProps) {
+  const reduceMotion = useReducedMotion();
+  const {
+    memoryKey,
+    scope,
+    scopeType: type,
+    preview,
+    sourceAgent,
+    trigger,
+    tags = [],
+    timestamp,
+  } = memory;
+
+  const keyCode = (
+    <code
+      className={[
+        'truncate font-mono text-xs font-medium',
+        selected ? 'text-[var(--color-accent)]' : 'text-[var(--color-content-primary)]',
+      ].join(' ')}
+    >
+      {memoryKey}
+    </code>
+  );
+
+  // ── Compact (dropdown row) ──────────────────────────────────────────────────
+  if (density === 'compact') {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        aria-pressed={selected}
+        className={[
+          'flex w-full flex-col gap-0.5 px-4 py-2.5 text-left transition-colors duration-100',
+          selected ? 'bg-[var(--color-accent-subtle)]' : 'hover:bg-[var(--color-bg-elevated)]',
+          className,
+        ].join(' ')}
+      >
+        {keyCode}
+        {showPreview && (
+          <span className="line-clamp-1 text-xs text-[var(--color-content-tertiary)]">
+            {preview}
+          </span>
+        )}
+      </button>
+    );
+  }
+
+  const timeEl = showTimestamp && timestamp && (
+    <span className="flex shrink-0 items-center gap-1 text-xs text-[var(--color-content-tertiary)]">
+      <Clock className="size-3" aria-hidden />
+      {formatRelativeTime(timestamp)}
+    </span>
+  );
+
+  const motionProps = animate
+    ? {
+        initial: { opacity: 0, y: reduceMotion ? 0 : 4 },
+        animate: { opacity: 1, y: 0 },
+        transition: { delay: index * 0.03, duration: 0.25, ease: 'easeOut' as const },
+      }
+    : {};
+
+  // ── Row (activity feed) ─────────────────────────────────────────────────────
+  if (layout === 'row') {
+    const withPath = showScopePath ?? true;
+    return (
+      <motion.button
+        type="button"
+        onClick={onClick}
+        aria-pressed={selected}
+        {...motionProps}
+        className={[
+          'flex w-full gap-3 rounded-lg border p-3 text-left transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]',
+          selected
+            ? SELECTED_CARD
+            : 'border-[var(--color-border)] bg-[var(--color-bg-raised)] hover:bg-[var(--color-bg-elevated)]',
+          className,
+        ].join(' ')}
+      >
+        {leadingIcon && (
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)]">
+            {leadingIcon}
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 flex flex-wrap items-center gap-1.5">
+            {showScope && <ScopeBadge scope={scope} type={type} />}
+            {keyCode}
+            {timeEl && <span className="ml-auto">{timeEl}</span>}
+          </div>
+          {showPreview && (
+            <p className="mb-1.5 line-clamp-1 text-xs text-[var(--color-content-secondary)]">
+              {preview}
+            </p>
+          )}
+          {(showMeta || withPath) && (
+            <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--color-content-tertiary)]">
+              {showMeta && sourceAgent && <MetaChip icon={Bot}>{sourceAgent}</MetaChip>}
+              {showMeta && trigger && <MetaChip icon={Zap}>{trigger}</MetaChip>}
+              {withPath && (
+                <ScopeBadge
+                  scope={scope}
+                  type={type}
+                  showBadge={false}
+                  showPath
+                  className="ml-auto min-w-0"
+                  pathClassName="opacity-50"
+                />
+              )}
+            </div>
+          )}
+        </div>
+      </motion.button>
+    );
+  }
+
+  // ── Card (lore explorer) ────────────────────────────────────────────────────
+  const withPath = showScopePath ?? false;
+  return (
+    <motion.button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      {...motionProps}
+      className={[
+        'group w-full rounded-xl border p-4 text-left transition-all duration-150',
+        selected
+          ? SELECTED_CARD
+          : 'border-[var(--color-border)] bg-[var(--color-bg-raised)] hover:bg-[var(--color-bg-elevated)]',
+        className,
+      ].join(' ')}
+    >
+      <div className="mb-2 flex items-start justify-between gap-2">
+        {keyCode}
+        {showScope && <ScopeBadge scope={scope} type={type} className="shrink-0" />}
+      </div>
+
+      {showPreview && (
+        <p className="mb-3 line-clamp-2 text-xs text-[var(--color-content-secondary)]">{preview}</p>
+      )}
+
+      {(showMeta || withPath || timeEl) && (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--color-content-tertiary)]">
+          {showMeta && sourceAgent && <MetaChip icon={Bot}>{sourceAgent}</MetaChip>}
+          {showMeta && trigger && <MetaChip icon={Zap}>{trigger}</MetaChip>}
+          {withPath && (
+            <ScopeBadge scope={scope} type={type} showBadge={false} showPath className="min-w-0" />
+          )}
+          {timeEl && <span className="ml-auto">{timeEl}</span>}
+        </div>
+      )}
+
+      {showTags && <Tags tags={tags} />}
+    </motion.button>
+  );
+});

--- a/packages/web/src/components/memory/MemoryCard.tsx
+++ b/packages/web/src/components/memory/MemoryCard.tsx
@@ -209,36 +209,46 @@ export const MemoryCard = memo(function MemoryCard({
     </code>
   );
 
-  // ── Compact (dropdown row) ──────────────────────────────────────────────────
-  // Selection is announced by the parent listbox option (aria-selected), so the
-  // inner button intentionally omits aria-pressed to avoid a double announcement.
-  if (density === 'compact') {
-    return (
-      <button
-        type="button"
-        onClick={onClick}
-        className={[
-          'flex w-full flex-col gap-0.5 px-4 py-2.5 text-left transition-colors duration-100',
-          selected ? 'bg-[var(--color-accent-subtle)]' : 'hover:bg-[var(--color-bg-elevated)]',
-          className,
-        ].join(' ')}
-      >
-        {keyCode}
-        {showPreview && (
-          <span className="line-clamp-1 text-xs text-[var(--color-content-tertiary)]">
-            {preview}
-          </span>
-        )}
-      </button>
-    );
-  }
-
   const timeEl = showTimestamp && timestamp && (
     <span className="flex shrink-0 items-center gap-1 text-xs text-[var(--color-content-tertiary)]">
       <Clock className="size-3" aria-hidden />
       {formatRelativeTime(timestamp)}
     </span>
   );
+
+  // ── Compact (dropdown row) ──────────────────────────────────────────────────
+  // Mirrors the card/row element set (scope pill + key + preview + timestamp) at
+  // list density. Selection is announced by the parent listbox option
+  // (aria-selected), so the inner button omits aria-pressed to avoid a double
+  // announcement.
+  if (density === 'compact') {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={[
+          'flex w-full flex-col gap-1 px-4 py-2.5 text-left transition-colors duration-100',
+          selected ? 'bg-[var(--color-accent-subtle)]' : 'hover:bg-[var(--color-bg-elevated)]',
+          className,
+        ].join(' ')}
+      >
+        <div className="flex items-center justify-between gap-2">
+          {keyCode}
+          {showScope && <ScopeBadge scope={scope} type={type} className="shrink-0" />}
+        </div>
+        {(showPreview || timeEl) && (
+          <div className="flex items-center justify-between gap-2">
+            {showPreview && (
+              <span className="min-w-0 flex-1 truncate text-xs text-[var(--color-content-tertiary)]">
+                {preview}
+              </span>
+            )}
+            {timeEl}
+          </div>
+        )}
+      </button>
+    );
+  }
 
   const motionProps = animate
     ? {
@@ -250,7 +260,10 @@ export const MemoryCard = memo(function MemoryCard({
 
   // ── Row (activity feed) ─────────────────────────────────────────────────────
   if (layout === 'row') {
-    const withPath = showScopePath ?? true;
+    // Scope is already shown as the pill in the header, so the canonical path is
+    // off by default — opt in with showScopePath when the extra detail is wanted.
+    const withPath = showScopePath ?? false;
+    const hasMeta = showMeta && Boolean(sourceAgent || trigger);
     return (
       <motion.button
         type="button"
@@ -281,7 +294,7 @@ export const MemoryCard = memo(function MemoryCard({
               {preview}
             </p>
           )}
-          {(showMeta || withPath) && (
+          {(hasMeta || withPath) && (
             <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--color-content-tertiary)]">
               {showMeta && sourceAgent && <MetaChip icon={Bot}>{sourceAgent}</MetaChip>}
               {showMeta && trigger && <MetaChip icon={Zap}>{trigger}</MetaChip>}

--- a/packages/web/src/components/memory/MemoryCard.tsx
+++ b/packages/web/src/components/memory/MemoryCard.tsx
@@ -210,12 +210,13 @@ export const MemoryCard = memo(function MemoryCard({
   );
 
   // ── Compact (dropdown row) ──────────────────────────────────────────────────
+  // Selection is announced by the parent listbox option (aria-selected), so the
+  // inner button intentionally omits aria-pressed to avoid a double announcement.
   if (density === 'compact') {
     return (
       <button
         type="button"
         onClick={onClick}
-        aria-pressed={selected}
         className={[
           'flex w-full flex-col gap-0.5 px-4 py-2.5 text-left transition-colors duration-100',
           selected ? 'bg-[var(--color-accent-subtle)]' : 'hover:bg-[var(--color-bg-elevated)]',

--- a/packages/web/src/components/memory/MemoryCard.tsx
+++ b/packages/web/src/components/memory/MemoryCard.tsx
@@ -91,7 +91,9 @@ export function memoryFromEvent(event: {
 
 /** Shared relative-time formatter used by every memory surface. */
 export function formatRelativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return '';
+  const diff = Date.now() - ts;
   const minutes = Math.floor(diff / 60_000);
   if (minutes < 1) return 'just now';
   if (minutes < 60) return `${minutes}m ago`;

--- a/packages/web/src/components/memory/MemoryCard.tsx
+++ b/packages/web/src/components/memory/MemoryCard.tsx
@@ -316,7 +316,10 @@ export const MemoryCard = memo(function MemoryCard({
   }
 
   // ── Card (lore explorer) ────────────────────────────────────────────────────
+  // Header mirrors the row layout — [scope pill] key … timestamp — so the card
+  // and the activity row read the same; only the leading icon and density differ.
   const withPath = showScopePath ?? false;
+  const hasMeta = showMeta && Boolean(sourceAgent || trigger);
   return (
     <motion.button
       type="button"
@@ -331,23 +334,23 @@ export const MemoryCard = memo(function MemoryCard({
         className,
       ].join(' ')}
     >
-      <div className="mb-2 flex items-start justify-between gap-2">
+      <div className="mb-2 flex flex-wrap items-center gap-1.5">
+        {showScope && <ScopeBadge scope={scope} type={type} />}
         {keyCode}
-        {showScope && <ScopeBadge scope={scope} type={type} className="shrink-0" />}
+        {timeEl && <span className="ml-auto">{timeEl}</span>}
       </div>
 
       {showPreview && (
         <p className="mb-3 line-clamp-2 text-xs text-[var(--color-content-secondary)]">{preview}</p>
       )}
 
-      {(showMeta || withPath || timeEl) && (
+      {(hasMeta || withPath) && (
         <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--color-content-tertiary)]">
           {showMeta && sourceAgent && <MetaChip icon={Bot}>{sourceAgent}</MetaChip>}
           {showMeta && trigger && <MetaChip icon={Zap}>{trigger}</MetaChip>}
           {withPath && (
             <ScopeBadge scope={scope} type={type} showBadge={false} showPath className="min-w-0" />
           )}
-          {timeEl && <span className="ml-auto">{timeEl}</span>}
         </div>
       )}
 

--- a/packages/web/src/components/memory/MemoryCard.tsx
+++ b/packages/web/src/components/memory/MemoryCard.tsx
@@ -236,7 +236,7 @@ export const MemoryCard = memo(function MemoryCard({
       >
         <div className="flex items-center justify-between gap-2">
           {keyCode}
-          {showScope && <ScopeBadge scope={scope} type={type} className="shrink-0" />}
+          {showScope && <ScopeBadge scope={scope} type={type} label className="shrink-0" />}
         </div>
         {(showPreview || timeEl) && (
           <div className="flex items-center justify-between gap-2">
@@ -287,7 +287,7 @@ export const MemoryCard = memo(function MemoryCard({
         )}
         <div className="min-w-0 flex-1">
           <div className="mb-1 flex flex-wrap items-center gap-1.5">
-            {showScope && <ScopeBadge scope={scope} type={type} />}
+            {showScope && <ScopeBadge scope={scope} type={type} label />}
             {keyCode}
             {timeEl && <span className="ml-auto">{timeEl}</span>}
           </div>
@@ -337,7 +337,7 @@ export const MemoryCard = memo(function MemoryCard({
       ].join(' ')}
     >
       <div className="mb-2 flex flex-wrap items-center gap-1.5">
-        {showScope && <ScopeBadge scope={scope} type={type} />}
+        {showScope && <ScopeBadge scope={scope} type={type} label />}
         {keyCode}
         {timeEl && <span className="ml-auto">{timeEl}</span>}
       </div>

--- a/packages/web/src/components/memory/ScopeBadge.tsx
+++ b/packages/web/src/components/memory/ScopeBadge.tsx
@@ -51,7 +51,7 @@ export function ScopeBadge({
       {showBadge && (
         <Badge variant={resolvedType}>
           {showIcon && (
-            <Icon className={['size-2.5', showType ? 'mr-1' : '', 'inline shrink-0'].join(' ')} aria-hidden />
+            <Icon className={['size-2.5', showType ? 'mr-1' : '', 'inline shrink-0'].filter(Boolean).join(' ')} aria-hidden />
           )}
           {showType && resolvedType}
         </Badge>

--- a/packages/web/src/components/memory/ScopeBadge.tsx
+++ b/packages/web/src/components/memory/ScopeBadge.tsx
@@ -1,0 +1,75 @@
+/**
+ * ScopeBadge — the one component for rendering a scope.
+ *
+ * Every surface that shows a scope (activity rows, lesson cards, the detail
+ * sheet header, scope-health cards) renders it through here so the pill colour,
+ * icon, and canonical-path treatment stay identical. Props toggle the parts on
+ * or off for the surrounding context — a compact pill in a list, a pill + full
+ * path in a header, or just the dimmed path in a footer.
+ *
+ * This is a pure presentational component (no hooks / no client state) so it
+ * works in both server and client components.
+ */
+
+import { Badge } from '@/components/ui/Badge';
+import { scopeIcon, scopeType, type ScopePrefix } from './scope-meta';
+
+export interface ScopeBadgeProps {
+  /** Canonical scope string, e.g. `project::lorekit` or `global`. */
+  scope: string;
+  /** Override the derived scope type (when the caller already computed it). */
+  type?: ScopePrefix;
+  /** Render the coloured type pill. @default true */
+  showBadge?: boolean;
+  /** Show the scope-type icon inside the pill. @default true */
+  showIcon?: boolean;
+  /** Show the type label ("project") inside the pill. @default true */
+  showType?: boolean;
+  /** Append the full canonical scope string after the pill. @default false */
+  showPath?: boolean;
+  /** Pill sizing. @default 'sm' */
+  size?: 'sm' | 'md';
+  /** Class applied to the wrapper. */
+  className?: string;
+  /** Class applied to the canonical-path `<code>` (e.g. margins, colour). */
+  pathClassName?: string;
+}
+
+export function ScopeBadge({
+  scope,
+  type,
+  showBadge = true,
+  showIcon = true,
+  showType = true,
+  showPath = false,
+  size = 'sm',
+  className = '',
+  pathClassName = '',
+}: ScopeBadgeProps) {
+  const resolvedType = type ?? scopeType(scope);
+  const Icon = scopeIcon(resolvedType);
+  const iconSize = size === 'md' ? 'size-3' : 'size-2.5';
+
+  return (
+    <span className={['inline-flex min-w-0 items-center gap-1.5', className].join(' ')}>
+      {showBadge && (
+        <Badge variant={resolvedType}>
+          {showIcon && (
+            <Icon className={[iconSize, showType ? 'mr-1' : '', 'inline shrink-0'].join(' ')} aria-hidden />
+          )}
+          {showType && resolvedType}
+        </Badge>
+      )}
+      {showPath && (
+        <code
+          className={[
+            'min-w-0 truncate font-mono text-xs text-[var(--color-content-tertiary)]',
+            pathClassName,
+          ].join(' ')}
+        >
+          {scope}
+        </code>
+      )}
+    </span>
+  );
+}

--- a/packages/web/src/components/memory/ScopeBadge.tsx
+++ b/packages/web/src/components/memory/ScopeBadge.tsx
@@ -12,7 +12,7 @@
  */
 
 import { Badge } from '@/components/ui/Badge';
-import { scopeIcon, scopeType, type ScopePrefix } from './scope-meta';
+import { scopeIcon, scopeLabel, scopeType, type ScopePrefix } from './scope-meta';
 
 export interface ScopeBadgeProps {
   /** Canonical scope string, e.g. `project::lorekit` or `global`. */
@@ -25,6 +25,12 @@ export interface ScopeBadgeProps {
   showIcon?: boolean;
   /** Show the type label ("project") inside the pill. @default true */
   showType?: boolean;
+  /**
+   * Show the friendly scope label (last segment, e.g. `lorekit`) inside the pill
+   * instead of the type. Identifies the specific scope; takes precedence over
+   * `showType`. @default false
+   */
+  label?: boolean;
   /** Append the full canonical scope string after the pill. @default false */
   showPath?: boolean;
   /** Class applied to the wrapper. */
@@ -39,21 +45,23 @@ export function ScopeBadge({
   showBadge = true,
   showIcon = true,
   showType = true,
+  label = false,
   showPath = false,
   className = '',
   pathClassName = '',
 }: ScopeBadgeProps) {
   const resolvedType = type ?? scopeType(scope);
   const Icon = scopeIcon(resolvedType);
+  const pillText = label ? scopeLabel(scope) : showType ? resolvedType : null;
 
   return (
     <span className={['inline-flex min-w-0 items-center gap-1.5', className].join(' ')}>
       {showBadge && (
         <Badge variant={resolvedType}>
           {showIcon && (
-            <Icon className={['size-2.5', showType ? 'mr-1' : '', 'inline shrink-0'].filter(Boolean).join(' ')} aria-hidden />
+            <Icon className={['size-2.5', pillText ? 'mr-1' : '', 'inline shrink-0'].filter(Boolean).join(' ')} aria-hidden />
           )}
-          {showType && resolvedType}
+          {pillText}
         </Badge>
       )}
       {showPath && (

--- a/packages/web/src/components/memory/ScopeBadge.tsx
+++ b/packages/web/src/components/memory/ScopeBadge.tsx
@@ -27,8 +27,6 @@ export interface ScopeBadgeProps {
   showType?: boolean;
   /** Append the full canonical scope string after the pill. @default false */
   showPath?: boolean;
-  /** Pill sizing. @default 'sm' */
-  size?: 'sm' | 'md';
   /** Class applied to the wrapper. */
   className?: string;
   /** Class applied to the canonical-path `<code>` (e.g. margins, colour). */
@@ -42,20 +40,18 @@ export function ScopeBadge({
   showIcon = true,
   showType = true,
   showPath = false,
-  size = 'sm',
   className = '',
   pathClassName = '',
 }: ScopeBadgeProps) {
   const resolvedType = type ?? scopeType(scope);
   const Icon = scopeIcon(resolvedType);
-  const iconSize = size === 'md' ? 'size-3' : 'size-2.5';
 
   return (
     <span className={['inline-flex min-w-0 items-center gap-1.5', className].join(' ')}>
       {showBadge && (
         <Badge variant={resolvedType}>
           {showIcon && (
-            <Icon className={[iconSize, showType ? 'mr-1' : '', 'inline shrink-0'].join(' ')} aria-hidden />
+            <Icon className={['size-2.5', showType ? 'mr-1' : '', 'inline shrink-0'].join(' ')} aria-hidden />
           )}
           {showType && resolvedType}
         </Badge>

--- a/packages/web/src/components/memory/scope-meta.ts
+++ b/packages/web/src/components/memory/scope-meta.ts
@@ -11,8 +11,12 @@
 import { Globe, Layers, FolderGit2, GitBranch, type LucideIcon } from 'lucide-react';
 import { scopeType, type ScopePrefix } from '@/lib/scope';
 
-/** Icon per scope type. Previously duplicated across three components. */
-export const SCOPE_ICONS: Record<ScopePrefix, LucideIcon> = {
+/**
+ * Icon per scope type. Previously duplicated across three components.
+ * Internal — consumers use {@link scopeIcon}, so this stays unexported to keep
+ * the module's public surface to the two helpers.
+ */
+const SCOPE_ICONS: Record<ScopePrefix, LucideIcon> = {
   global: Globe,
   project: Layers,
   repo: FolderGit2,

--- a/packages/web/src/components/memory/scope-meta.ts
+++ b/packages/web/src/components/memory/scope-meta.ts
@@ -1,0 +1,36 @@
+/**
+ * Presentational metadata for scopes — the single source of truth for the
+ * icon and friendly label used wherever a scope is rendered.
+ *
+ * Colours live in the shared `Badge` variants (see components/ui/Badge.tsx),
+ * keyed by the same `ScopePrefix`. Keep this file free of layout so it can be
+ * imported by both the `ScopeBadge` pill and the `ScopeTree` / `ScopeHealthCard`
+ * custom layouts without dragging JSX along.
+ */
+
+import { Globe, Layers, FolderGit2, GitBranch, type LucideIcon } from 'lucide-react';
+import { scopeType, type ScopePrefix } from '@/lib/scope';
+
+/** Icon per scope type. Previously duplicated across three components. */
+export const SCOPE_ICONS: Record<ScopePrefix, LucideIcon> = {
+  global: Globe,
+  project: Layers,
+  repo: FolderGit2,
+  branch: GitBranch,
+};
+
+/** The icon for a scope type, falling back to the global icon defensively. */
+export function scopeIcon(type: ScopePrefix): LucideIcon {
+  return SCOPE_ICONS[type] ?? Globe;
+}
+
+/**
+ * Friendly, human-facing label for a scope — its last `::` segment.
+ * `project::lorekit` → `lorekit`, `global` → `global`.
+ */
+export function scopeLabel(scope: string): string {
+  return scope.split('::').pop() ?? scope;
+}
+
+export { scopeType };
+export type { ScopePrefix };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,10 @@ settings:
 
 overrides:
   baseline-browser-mapping: 2.11.0
-  brace-expansion: 5.0.7
+  brace-expansion@1: 1.1.12
+  brace-expansion@2: 2.0.2
+  brace-expansion@3: 3.0.1
+  brace-expansion@4: 4.0.1
   flatted: 3.4.2
   postcss: 8.4.30
   less: 4.7.0
@@ -19,6 +22,9 @@ importers:
 
   .:
     devDependencies:
+      '@eslint/eslintrc':
+        specifier: ^3.1.0
+        version: 3.3.6
       '@eslint/js':
         specifier: ^9.8.0
         version: 9.39.5
@@ -192,6 +198,9 @@ importers:
         specifier: ^19.0.0
         version: 19.2.8(react@19.2.8)
     devDependencies:
+      '@next/eslint-plugin-next':
+        specifier: ^15.3.8
+        version: 15.5.21
       '@nx/next':
         specifier: 22.4.0
         version: 22.4.0(@babel/core@7.29.7)(@babel/traverse@7.29.7)(@rspack/core@1.6.8(@swc/helpers@0.5.23))(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@zkochan/js-yaml@0.0.7)(eslint@8.57.1)(lightningcss@1.32.0)(next@15.5.21(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.69.0))(nx@22.4.0(@swc-node/register@1.9.2(@swc/core@1.5.29(@swc/helpers@0.5.23))(@swc/types@0.1.27)(typescript@5.9.3))(@swc/core@1.5.29(@swc/helpers@0.5.23)))(postcss@8.4.30)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.9)(jiti@2.7.0)(less@4.7.0)(lightningcss@1.32.0)(sass-embedded@1.100.0)(sass@1.69.0)(terser@5.49.0)(yaml@2.9.0))(vitest@4.0.9)(webpack@5.108.4(@swc/core@1.5.29(@swc/helpers@0.5.23))(lightningcss@1.32.0)(postcss@8.4.30))
@@ -207,6 +216,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.17)
+      eslint-plugin-react-hooks:
+        specifier: ^5.2.0
+        version: 5.2.0(eslint@8.57.1)
       tailwindcss:
         specifier: ^4.1.11
         version: 4.3.3
@@ -990,6 +1002,10 @@ packages:
     resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@eslint/eslintrc@3.3.6':
+    resolution: {integrity: sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   '@eslint/js@8.57.1':
     resolution: {integrity: sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1523,6 +1539,9 @@ packages:
 
   '@next/env@15.5.21':
     resolution: {integrity: sha512-hjJI/GfrjWHgNguRIBzItjRRu0m3Nrz17GhxsjuHfjIvg9hyg3239REd2dpI+bpMTFuVrVprHzEQ19m++cDtbw==}
+
+  '@next/eslint-plugin-next@15.5.21':
+    resolution: {integrity: sha512-5MoR9vO3dE1lU3LixogB54xrn7OhMGempTqk1q3WlvbKrT6cNt5mV2mMkX5sghAk0vZF6Nz1HxoTb9YmZv8wRg==}
 
   '@next/swc-darwin-arm64@15.5.21':
     resolution: {integrity: sha512-ZfjqPEdi6TRC/fWx7UDbwb1fbVgyh2uD5tVTRKIDZDlYM+UNuE/LafDG2fwuAoZilADpABh46OY/F5qf9JjqLQ==}
@@ -3498,6 +3517,9 @@ packages:
       '@babel/traverse':
         optional: true
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -3543,6 +3565,12 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
@@ -3700,6 +3728,9 @@ packages:
   compression@1.8.1:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-with-sourcemaps@1.1.0:
     resolution: {integrity: sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==}
@@ -4107,6 +4138,12 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-plugin-react-hooks@5.2.0:
+    resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -4119,6 +4156,10 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -4128,6 +4169,10 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -4210,6 +4255,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
+    engines: {node: '>=8.6.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -4460,6 +4509,10 @@ packages:
   globals@13.24.0:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
+
+  globals@14.0.0:
+    resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
+    engines: {node: '>=18'}
 
   globals@15.15.0:
     resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
@@ -7928,6 +7981,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@eslint/eslintrc@3.3.6':
+    dependencies:
+      ajv: 6.15.0
+      debug: 4.4.3
+      espree: 10.4.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.3.0
+      minimatch: 3.1.5
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@eslint/js@8.57.1': {}
 
   '@eslint/js@9.39.5': {}
@@ -8572,6 +8639,10 @@ snapshots:
     optional: true
 
   '@next/env@15.5.21': {}
+
+  '@next/eslint-plugin-next@15.5.21':
+    dependencies:
+      fast-glob: 3.3.1
 
   '@next/swc-darwin-arm64@15.5.21':
     optional: true
@@ -11247,6 +11318,8 @@ snapshots:
     optionalDependencies:
       '@babel/traverse': 7.29.7
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -11308,6 +11381,15 @@ snapshots:
       multicast-dns: 7.2.5
 
   boolbase@1.0.0: {}
+
+  brace-expansion@1.1.12:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.7:
     dependencies:
@@ -11463,6 +11545,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  concat-map@0.0.1: {}
 
   concat-with-sourcemaps@1.1.0:
     dependencies:
@@ -11859,6 +11943,10 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-plugin-react-hooks@5.2.0(eslint@8.57.1):
+    dependencies:
+      eslint: 8.57.1
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -11870,6 +11958,8 @@ snapshots:
       estraverse: 5.3.0
 
   eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.1: {}
 
   eslint-visitor-keys@5.0.1: {}
 
@@ -11915,6 +12005,12 @@ snapshots:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
     dependencies:
@@ -12042,6 +12138,14 @@ snapshots:
   extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-glob@3.3.1:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
 
   fast-glob@3.3.3:
     dependencies:
@@ -12334,6 +12438,8 @@ snapshots:
   globals@13.24.0:
     dependencies:
       type-fest: 0.20.2
+
+  globals@14.0.0: {}
 
   globals@15.15.0: {}
 
@@ -13030,11 +13136,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 1.1.12
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,5 +1,5 @@
 # Supabase local development configuration.
-# Run `supabase link --project-ref <ref>` to link to your remote project.
+# Run `supabase link --project-ref pqokxlhvnosogizsjztg` to link to your remote project.
 # This file is used by the Supabase CLI for local development.
 # See: https://supabase.com/docs/guides/cli/config
 

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -11,7 +11,7 @@
  *   traceRequest()           wraps each request in a root span
  *   createTracedClient()     creates child spans per Postgres query (in tools.ts)
  *
- * Required secrets (supabase secrets set --project-ref <ref>):
+ * Required secrets (supabase secrets set --project-ref pqokxlhvnosogizsjztg):
  *   SUPABASE_URL
  *   SUPABASE_ANON_KEY
  *   SUPABASE_SERVICE_ROLE_KEY


### PR DESCRIPTION
## Why

The dashboard rendered scopes and memories many different ways — the scope-icon map was copy-pasted across three components, the scope pill was hand-rolled in four, and a lesson had three near-duplicate renderings (Explorer card, Activity row, memories dropdown). Inconsistent to look at and painful to change.

## What changed

- Add `ScopeBadge` — the one scope renderer (coloured type pill + optional icon / type label / canonical path)
- Add `MemoryCard` — the one memory renderer with `card` / `row` / `compact` modes and per-context toggles
- Add `scope-meta.ts` as the single source for the scope icon + label; refactor all six consumers onto the shared components (net −187 lines)
- Point the remaining `<project-ref>` / `<ref>` placeholders in the deploy / link / secrets docs at the prod project ref

## How to verify

- `pnpm nx typecheck web` (passes); eyeball Overview, Explorer, Activity, and the memories dropdown — scope pills and memory rows render consistently

## Notes for reviewers

Behaviour is unchanged apart from now-uniform styling; the one real delta is activity-row timestamps adopting the shared relative-time buckets ("just now" / "Nd ago"). Also bundles a `DEVELOPMENT.md` doc edit already committed to this branch.