### PR TITLE
ci: smoke-test Claude plugin install on plugin changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
       contents: read
     outputs:
       api: ${{ steps.filter.outputs.api }}
+      plugin: ${{ steps.filter.outputs.plugin }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -61,6 +62,13 @@ jobs:
             echo "api=true" >> "$GITHUB_OUTPUT"
           else
             echo "api=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Plugin smoke gate: the Claude marketplace bundle, its vendored skill
+          # source, the hook engine it shells out to, and the sync/smoke scripts.
+          if printf '%s\n' "$CHANGED" | grep -qE '^(plugins/|\.claude-plugin/|packages/cli/skill/|packages/cli/src/|packages/cli/bin/|scripts/sync-plugin-skill\.mjs|scripts/smoke-plugin\.sh|\.github/workflows/ci\.yml)'; then
+            echo "plugin=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "plugin=false" >> "$GITHUB_OUTPUT"
           fi
 
   # ── Typecheck + Test + Lint (only affected packages) ─────────────────────────
@@ -92,6 +100,35 @@ jobs:
         env:
           NX_BASE: ${{ github.event.pull_request.base.sha || 'HEAD~1' }}
           NX_HEAD: ${{ github.sha }}
+
+  # ── Plugin smoke — the Claude marketplace plugin installs + enables ──────────
+  #    Runs the real `claude` CLI install flow end-to-end (validate → marketplace
+  #    add → install → assert enabled → hook engine smoke) via
+  #    scripts/smoke-plugin.sh. Gated on plugin-relevant paths so unrelated PRs
+  #    skip it; a skipped required check is treated as passing by branch
+  #    protection. The frameworks unit test only *validates* the manifest (and
+  #    skips when the CLI is absent) — this job proves an actual install works.
+  plugin:
+    name: Plugin smoke (install + enable)
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.plugin == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      - name: Install the Claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Plugin install smoke
+        run: bash scripts/smoke-plugin.sh
 
   # ── Integration smoke — live stack wiring on a local Supabase ────────────────
   #    Boots a full local stack (migrations applied → serves the real Edge

--- a/scripts/smoke-plugin.sh
+++ b/scripts/smoke-plugin.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────────────────────
+# Plugin install smoke test.
+#
+# Proves the lorekit-claude marketplace plugin installs and enables end-to-end
+# via the real `claude` CLI — the same flow a user runs locally:
+#
+#   1. `claude plugin validate`        manifest is well-formed
+#   2. skill sync --check              vendored skill matches its source
+#   3. marketplace add → install       the marketplace resolves + installs
+#   4. `claude plugin list`            the plugin is present AND enabled
+#   5. hook engine smoke               the SessionStart hook exits 0 (fail-open)
+#
+# Requires the `claude` CLI on PATH (CI installs @anthropic-ai/claude-code).
+# Idempotent: cleans up the marketplace/plugin it registered, even on failure.
+# Run from the repo root:  bash scripts/smoke-plugin.sh
+# ─────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PLUGIN="lorekit-memory"
+MARKETPLACE="lorekit"
+REF="${PLUGIN}@${MARKETPLACE}"
+
+cleanup() {
+  # Best-effort teardown so the runner's user config is left as we found it and
+  # local re-runs start clean. Never let cleanup mask the real exit status.
+  claude plugin uninstall "$REF" >/dev/null 2>&1 || true
+  claude plugin marketplace remove "$MARKETPLACE" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "::error::claude CLI not found on PATH — cannot run the plugin smoke test"
+  exit 1
+fi
+echo "claude CLI: $(claude --version)"
+
+# 1. Manifest validation.
+echo "── validate manifest ─────────────────────────────────────────"
+claude plugin validate ./plugins/lorekit-claude
+
+# 2. Vendored skill matches its single source of truth.
+echo "── skill sync (--check) ──────────────────────────────────────"
+node scripts/sync-plugin-skill.mjs --check
+
+# 3. Register the repo as a marketplace and install from it.
+#    Remove any stale registration first so a re-run is deterministic.
+echo "── marketplace add + install ─────────────────────────────────"
+claude plugin marketplace remove "$MARKETPLACE" >/dev/null 2>&1 || true
+claude plugin marketplace add "$ROOT"
+claude plugin install "$REF"
+
+# 4. Assert the plugin is installed AND enabled.
+echo "── verify installed + enabled ────────────────────────────────"
+LIST="$(claude plugin list 2>&1)"
+echo "$LIST"
+if ! printf '%s\n' "$LIST" | grep -q "$REF"; then
+  echo "::error::$REF not found in \`claude plugin list\`"
+  exit 1
+fi
+# The enabled marker line ("Status: <mark> enabled") follows the plugin entry.
+if ! printf '%s\n' "$LIST" | grep -qi 'enabled'; then
+  echo "::error::$REF installed but not reported as enabled"
+  exit 1
+fi
+
+# 5. The SessionStart hook engine runs and fails open (exit 0) with no token.
+echo "── hook engine smoke (SessionStart) ─────────────────────────"
+echo '{}' | node packages/cli/bin/lorekit.mjs hook --adapter claude --event SessionStart --dir "$ROOT"
+
+echo "✓ plugin smoke passed: $REF installs, enables, and the hook engine runs"


### PR DESCRIPTION
## What

Adds a CI smoke test that installs the `lorekit-memory` Claude marketplace plugin end-to-end via the real `claude` CLI whenever plugin-related files change.

- **`scripts/smoke-plugin.sh`** — reusable script that runs the full install flow and cleans up after itself:
  1. `claude plugin validate` — manifest is well-formed
  2. `sync-plugin-skill --check` — the vendored skill matches its single source
  3. `marketplace add` → `install` — the repo's marketplace resolves and installs
  4. `claude plugin list` — asserts the plugin is present **and** reported `enabled`
  5. hook engine smoke — `SessionStart` exits 0 (fail-open with no token)
- **`.github/workflows/ci.yml`** — new path-gated `plugin` job:
  - The `changes` job emits a `plugin` output covering `plugins/`, `.claude-plugin/`, the vendored skill source (`packages/cli/skill/`), the hook engine (`packages/cli/src|bin/`), and the sync/smoke scripts.
  - The job installs `@anthropic-ai/claude-code`, then runs the script.

## Why

The existing `packages/cli/test/frameworks.test.mjs` only *validates* the plugin manifest, and it **skips entirely when the `claude` CLI is absent** — which it is in CI. So nothing currently exercises an actual install. This job proves the marketplace add → install → enable flow works, catching regressions in the manifest, the marketplace entry, the vendored skill sync, or the hook engine before they ship.

## Reviewer notes

- **Gating matches the existing `integration` job**: it only runs on relevant path changes, and a skipped required check is treated as passing by branch protection — so docs/web-only PRs won't run it.
- To make it blocking, add **`Plugin smoke (install + enable)`** to the required status checks in branch protection (alongside `check` + `integration`). Safe to require since it self-skips on non-plugin PRs.
- The script is idempotent — a `trap` removes the marketplace/plugin it registers even on failure, so it's safe to run locally (`bash scripts/smoke-plugin.sh`).

Verified locally: the smoke script passes green, the CI YAML parses, job wiring (`needs`/`if`) resolves, and the path filter classifies plugin/skill/CLI paths as `plugin=true` and docs/web paths as `plugin=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UqwhAZnsYeEhpk6qV98Ywk)_