### PR TITLE
fix(edge): keep last_used_at write alive with EdgeRuntime.waitUntil

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,7 +115,7 @@ Unique constraint: `(user_id, scope, key)`.
 | `token_prefix` | text | First 12 chars + `...` for display (e.g. `lk_rw_aBcD1...`) |
 | `token_hash` | text | SHA-256 of the full token — never stored in plain text |
 | `permissions` | text[] | `["read", "write"]`, `["read"]`, or `["write"]` |
-| `last_used_at` | timestamptz | Updated fire-and-forget on auth |
+| `last_used_at` | timestamptz | Updated on auth via `EdgeRuntime.waitUntil` (survives isolate teardown; non-blocking) |
 
 ### `audit_log` table
 

--- a/supabase/functions/mcp/auth.ts
+++ b/supabase/functions/mcp/auth.ts
@@ -64,7 +64,7 @@ export async function resolveAuth(authHeader: string | null, queryToken: string 
         .from('api_tokens')
         .update({ last_used_at: new Date().toISOString() })
         .eq('token_hash', hash),
-    ).then(() => {}, () => { /* swallow — timestamp is best-effort */ });
+    ).catch(() => { /* swallow — timestamp is best-effort */ });
     const edgeRuntime = (globalThis as {
       EdgeRuntime?: { waitUntil?: (p: Promise<unknown>) => void };
     }).EdgeRuntime;

--- a/supabase/functions/mcp/auth.ts
+++ b/supabase/functions/mcp/auth.ts
@@ -54,11 +54,25 @@ export async function resolveAuth(authHeader: string | null, queryToken: string 
       .eq('token_hash', hash)
       .maybeSingle();
     if (!data) return null;
-    // Fire-and-forget — don't block the response for a timestamp update
-    void serviceDb
-      .from('api_tokens')
-      .update({ last_used_at: new Date().toISOString() })
-      .eq('token_hash', hash);
+    // Best-effort last_used_at bump — don't block the response on it, but hand
+    // it to EdgeRuntime.waitUntil so the isolate stays alive until the write
+    // commits. A bare fire-and-forget is dropped when the isolate freezes right
+    // after the response returns, so the timestamp never lands (same reason the
+    // OTel flush in _shared/otel.ts uses waitUntil).
+    const lastUsedUpdate = Promise.resolve(
+      serviceDb
+        .from('api_tokens')
+        .update({ last_used_at: new Date().toISOString() })
+        .eq('token_hash', hash),
+    ).then(() => {}, () => { /* swallow — timestamp is best-effort */ });
+    const edgeRuntime = (globalThis as {
+      EdgeRuntime?: { waitUntil?: (p: Promise<unknown>) => void };
+    }).EdgeRuntime;
+    if (typeof edgeRuntime?.waitUntil === 'function') {
+      edgeRuntime.waitUntil(lastUsedUpdate);
+    } else {
+      void lastUsedUpdate;
+    }
     return {
       type: 'api_key',
       userId: data.user_id as string,


### PR DESCRIPTION
## Why

`api_tokens.last_used_at` was updated as a bare fire-and-forget (`void serviceDb.update()`) right before the MCP response returned. On Supabase Edge Functions the isolate can freeze the moment the response is sent, so that background write was silently dropped — which is why the dashboard's "Last used" line never appeared for tokens that had actually been used.

## What changed

- Adopt the Supabase update into a real promise and hand it to `EdgeRuntime.waitUntil` when available, so the isolate stays alive until the write commits — mirroring the OTel flush in `_shared/otel.ts`
- Fall back to `void` locally (where `EdgeRuntime` is absent), preserving the previous non-blocking behavior; rejections are swallowed either way (best-effort timestamp)
- Update the `last_used_at` row in the architecture doc to describe the `waitUntil` mechanism

## How to verify

- CI `integration` job boots the local edge runtime and type-checks the function. Behaviorally: authenticate with a token against the deployed MCP endpoint, then confirm `api_tokens.last_used_at` advances and the dashboard shows "· Last used …".

## Notes for reviewers

The `waitUntil` detection is now duplicated between `otel.ts` and `auth.ts`. Extracting a shared `waitUntilCompat` helper is a reasonable follow-up, but left out here to keep `auth.ts` self-contained per the edge-file convention — happy to fold it in if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgFfw2WAhfYfhxoNyCVKUe)_