### PR TITLE
feat(web): link repo/branch scopes to GitHub

### DIFF
--- a/packages/web/src/components/lore/LessonDetailSheet.tsx
+++ b/packages/web/src/components/lore/LessonDetailSheet.tsx
@@ -87,7 +87,7 @@ export function LessonDetailSheet({ lesson, onClose, onMutated }: LessonDetailSh
             <div className="flex items-start justify-between gap-3 border-b border-[var(--color-border)] p-5">
               <div className="flex flex-col gap-1.5">
                 <div className="flex items-center gap-2">
-                  <ScopeBadge scope={lesson.scope} type={lesson.scope_type} showPath />
+                  <ScopeBadge scope={lesson.scope} type={lesson.scope_type} showPath linkRepo />
                   {isArchived && (
                     <span className="rounded-full bg-[var(--color-bg-elevated)] px-2 py-0.5 text-xs text-[var(--color-content-tertiary)]">
                       archived

--- a/packages/web/src/components/lore/ScopeTree.tsx
+++ b/packages/web/src/components/lore/ScopeTree.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, ExternalLink } from 'lucide-react';
 import { scopeIcon } from '@/components/memory/scope-meta';
-import type { ScopePrefix } from '@/lib/scope';
+import { scopeRepoUrl, type ScopePrefix } from '@/lib/scope';
 
 export interface ScopeNode {
   scope: string;
@@ -25,40 +25,65 @@ function ScopeTreeItem({ node, depth, selected, onSelect }: ScopeTreeItemProps) 
   const Icon = scopeIcon(node.type);
   const hasChildren = (node.children?.length ?? 0) > 0;
   const isSelected = selected === node.scope;
+  const repoUrl = scopeRepoUrl(node.scope);
 
   return (
     <li>
-      <button
-        type="button"
-        onClick={() => {
-          onSelect(node.scope);
-          if (hasChildren) setExpanded((v) => !v);
-        }}
-        className={[
-          'group flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-sm transition-all duration-150',
-          isSelected
-            ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
-            : 'text-[var(--color-content-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-content-primary)]',
-        ].join(' ')}
-        style={{ paddingLeft: `${(depth + 1) * 12}px` }}
-        aria-expanded={hasChildren ? expanded : undefined}
-        aria-selected={isSelected}
-      >
-        {hasChildren ? (
-          <ChevronRight
+      {/* Row: the select button fills the width; the GitHub link is a sibling
+          (not nested) so we never put an <a> inside a <button>. */}
+      <div className="group/row relative flex items-center">
+        <button
+          type="button"
+          onClick={() => {
+            onSelect(node.scope);
+            if (hasChildren) setExpanded((v) => !v);
+          }}
+          className={[
+            'group flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-sm transition-all duration-150',
+            isSelected
+              ? 'bg-[var(--color-accent-subtle)] text-[var(--color-accent)]'
+              : 'text-[var(--color-content-secondary)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-content-primary)]',
+          ].join(' ')}
+          style={{ paddingLeft: `${(depth + 1) * 12}px` }}
+          aria-expanded={hasChildren ? expanded : undefined}
+          aria-selected={isSelected}
+        >
+          {hasChildren ? (
+            <ChevronRight
+              className={[
+                'size-3 shrink-0 transition-transform duration-150',
+                expanded ? 'rotate-90' : '',
+              ].join(' ')}
+              aria-hidden
+            />
+          ) : (
+            <span className="size-3 shrink-0" aria-hidden />
+          )}
+          <Icon className="size-3.5 shrink-0 opacity-70" aria-hidden />
+          <span className="min-w-0 flex-1 truncate font-mono text-xs">{node.label}</span>
+          <span
             className={[
-              'size-3 shrink-0 transition-transform duration-150',
-              expanded ? 'rotate-90' : '',
+              'ml-auto shrink-0 text-xs tabular-nums opacity-50',
+              repoUrl ? 'mr-6' : '',
             ].join(' ')}
-            aria-hidden
-          />
-        ) : (
-          <span className="size-3 shrink-0" aria-hidden />
+          >
+            {node.count}
+          </span>
+        </button>
+        {repoUrl && (
+          <a
+            href={repoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`Open ${node.label} on GitHub`}
+            title="Open on GitHub"
+            className="absolute right-2 flex size-5 items-center justify-center rounded text-[var(--color-content-tertiary)] opacity-0 transition-all duration-150 hover:text-[var(--color-content-primary)] focus-visible:opacity-100 group-hover/row:opacity-100"
+          >
+            <ExternalLink className="size-3" aria-hidden />
+          </a>
         )}
-        <Icon className="size-3.5 shrink-0 opacity-70" aria-hidden />
-        <span className="min-w-0 flex-1 truncate font-mono text-xs">{node.label}</span>
-        <span className="ml-auto shrink-0 text-xs tabular-nums opacity-50">{node.count}</span>
-      </button>
+      </div>
 
       {hasChildren && expanded && (
         <ul className="mt-0.5" role="group">

--- a/packages/web/src/components/memory/ScopeBadge.tsx
+++ b/packages/web/src/components/memory/ScopeBadge.tsx
@@ -11,7 +11,9 @@
  * works in both server and client components.
  */
 
+import { ExternalLink } from 'lucide-react';
 import { Badge } from '@/components/ui/Badge';
+import { scopeRepoUrl } from '@/lib/scope';
 import { scopeIcon, scopeLabel, scopeType, type ScopePrefix } from './scope-meta';
 
 export interface ScopeBadgeProps {
@@ -33,6 +35,12 @@ export interface ScopeBadgeProps {
   label?: boolean;
   /** Append the full canonical scope string after the pill. @default false */
   showPath?: boolean;
+  /**
+   * For `repo` / `branch` scopes, render a trailing GitHub link icon that opens
+   * the repository (or branch tree) in a new tab. No-op for `global` / `project`
+   * scopes, which have no repository to point at. @default false
+   */
+  linkRepo?: boolean;
   /** Class applied to the wrapper. */
   className?: string;
   /** Class applied to the canonical-path `<code>` (e.g. margins, colour). */
@@ -47,12 +55,14 @@ export function ScopeBadge({
   showType = true,
   label = false,
   showPath = false,
+  linkRepo = false,
   className = '',
   pathClassName = '',
 }: ScopeBadgeProps) {
   const resolvedType = type ?? scopeType(scope);
   const Icon = scopeIcon(resolvedType);
   const pillText = label ? scopeLabel(scope) : showType ? resolvedType : null;
+  const repoUrl = linkRepo ? scopeRepoUrl(scope) : null;
 
   return (
     <span className={['inline-flex min-w-0 items-center gap-1.5', className].join(' ')}>
@@ -73,6 +83,19 @@ export function ScopeBadge({
         >
           {scope}
         </code>
+      )}
+      {repoUrl && (
+        <a
+          href={repoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`Open ${scopeLabel(scope)} on GitHub`}
+          title="Open on GitHub"
+          className="inline-flex shrink-0 items-center text-[var(--color-content-tertiary)] transition-colors duration-150 hover:text-[var(--color-content-primary)]"
+        >
+          <ExternalLink className="size-3" aria-hidden />
+        </a>
       )}
     </span>
   );

--- a/packages/web/src/lib/scope.spec.ts
+++ b/packages/web/src/lib/scope.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { scopeType } from './scope';
+import { scopeType, scopeRepoUrl } from './scope';
 
 describe('scopeType', () => {
   it('returns "global" for the literal string "global"', () => {
@@ -24,5 +24,36 @@ describe('scopeType', () => {
     // The function does a simple split — upper-case is not normalised here;
     // that responsibility lives in mcp-core. Test documents current behaviour.
     expect(scopeType('project::MyProject')).toBe('project');
+  });
+});
+
+describe('scopeRepoUrl', () => {
+  it('builds a GitHub repo URL for repo scopes', () => {
+    expect(scopeRepoUrl('repo::mthines/lorekit')).toBe(
+      'https://github.com/mthines/lorekit',
+    );
+    expect(scopeRepoUrl('repo::mthines/gw-tools')).toBe(
+      'https://github.com/mthines/gw-tools',
+    );
+  });
+
+  it('builds a GitHub branch (tree) URL for branch scopes', () => {
+    expect(scopeRepoUrl('branch::mthines/gw-tools::feat/x')).toBe(
+      'https://github.com/mthines/gw-tools/tree/feat/x',
+    );
+    expect(scopeRepoUrl('branch::mthines/lorekit::main')).toBe(
+      'https://github.com/mthines/lorekit/tree/main',
+    );
+  });
+
+  it('returns null for scopes with no repository to point at', () => {
+    expect(scopeRepoUrl('global')).toBeNull();
+    expect(scopeRepoUrl('project::lorekit')).toBeNull();
+  });
+
+  it('returns null for malformed repo/branch scopes', () => {
+    expect(scopeRepoUrl('repo::not-a-repo')).toBeNull(); // missing owner/name split
+    expect(scopeRepoUrl('branch::owner/repo')).toBeNull(); // missing branch segment
+    expect(scopeRepoUrl('branch::not-a-repo::main')).toBeNull(); // bad owner/name
   });
 });

--- a/packages/web/src/lib/scope.ts
+++ b/packages/web/src/lib/scope.ts
@@ -15,3 +15,38 @@ export function scopeType(scope: string): ScopePrefix {
   const prefix = scope.split('::')[0] as ScopePrefix;
   return prefix;
 }
+
+/**
+ * Derive the GitHub URL for a scope that names a repository.
+ *
+ * The repo is already encoded in the scope string, so no link needs to be
+ * stored — it's a pure function of the scope:
+ *   `repo::owner/repo`            → https://github.com/owner/repo
+ *   `branch::owner/repo::branch`  → https://github.com/owner/repo/tree/branch
+ *
+ * Returns `null` for `global` / `project` scopes (no repository to point at)
+ * and for malformed scopes.
+ *
+ * Note on case: canonical scopes are lowercased upstream. GitHub matches
+ * owner/repo case-insensitively (and redirects), so repo links are always
+ * safe. Branch names are case-sensitive in git, so a `/tree/<branch>` link
+ * for a branch that was authored with upper-case characters may 404 — an
+ * accepted trade-off for pointing directly at the branch.
+ */
+export function scopeRepoUrl(scope: string): string | null {
+  const type = scopeType(scope);
+
+  if (type === 'repo') {
+    const ownerRepo = scope.slice('repo::'.length);
+    if (!/^[\w.-]+\/[\w.-]+$/.test(ownerRepo)) return null;
+    return `https://github.com/${ownerRepo}`;
+  }
+
+  if (type === 'branch') {
+    const [, ownerRepo, branch] = scope.split('::');
+    if (!ownerRepo || !branch || !/^[\w.-]+\/[\w.-]+$/.test(ownerRepo)) return null;
+    return `https://github.com/${ownerRepo}/tree/${branch}`;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## What & why

When browsing memories for a `repo` or `branch` scope, users can now click through to the repository (or branch) on GitHub. The link is **derived purely from the scope string** — the repo is already encoded in every scope (`repo::owner/repo`, `branch::owner/repo::branch`), so no data needs to be stored.

Deliberately **no** new column on `memories`, no migration, no MCP tool change, no change to how agents write lore. The change is fully contained in `@lorekit/web`.

## Changes

- **`packages/web/src/lib/scope.ts`** — new pure helper `scopeRepoUrl(scope)`:
  - `repo::owner/repo` → `https://github.com/owner/repo`
  - `branch::owner/repo::branch` → `https://github.com/owner/repo/tree/branch`
  - `global` / `project` / malformed scopes → `null`
- **`ScopeBadge.tsx`** — opt-in `linkRepo` prop rendering a trailing external-link icon that opens GitHub in a new tab (`rel="noopener noreferrer"`, `stopPropagation` so it doesn't trigger a surrounding card/row click, `aria-label`).
- **`LessonDetailSheet.tsx`** — enables `linkRepo` in the detail-sheet header.
- **`ScopeTree.tsx`** — adds the GitHub link to repo/branch tree rows, rendered as a **sibling** of the row `<button>` (not nested — an `<a>` inside a `<button>` is invalid markup), revealed on hover/focus.

## Reviewer notes

- The link is left **off** in `ScopeHealthCard` and card list rows on purpose: those badges already sit inside a Next `<Link>`, and nesting an anchor inside an anchor is invalid.
- **Branch links are best-effort `/tree/<branch>`.** Canonical scopes are lowercased upstream; GitHub matches `owner/repo` case-insensitively (always safe), but git branch names are case-sensitive, so a branch originally authored with upper-case could 404. This is an accepted trade-off for pointing directly at the branch — easy to switch branches to repo-root if preferred.
- Host is hardcoded to `github.com`, consistent with the rest of the product (webhook handler, `owner/name` repo CHECK). Single spot to make configurable if other hosts are ever needed.

## Testing

- 4 new unit tests in `scope.spec.ts` covering repo URL, branch tree URL, null for global/project, and null for malformed scopes. Full suite (9 tests) passes.
- `pnpm nx run-many -t typecheck,lint,test -p web` — typecheck and tests clean; lint reports only pre-existing warnings in untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WXFuxToG5n3h7GY7M633J2)_