### PR TITLE
feat(cli): add uninstall command with atomic, fail-safe config writes

### DIFF
--- a/packages/cli/bin/lorekit.mjs
+++ b/packages/cli/bin/lorekit.mjs
@@ -4,6 +4,7 @@ import process from 'node:process';
 import { readFileSync } from 'node:fs';
 import { parseArgs, log, err, c } from '../src/util.mjs';
 import { install } from '../src/install.mjs';
+import { uninstall } from '../src/uninstall.mjs';
 import { doctor } from '../src/doctor.mjs';
 import { hook } from '../src/hook.mjs';
 import { migrate } from '../src/migrate.mjs';
@@ -27,6 +28,10 @@ ${c.bold('Commands')}
               project (.claude) or globally for every project (~/.claude);
               --project / --global choose non-interactively, --no-hooks skips
               the hooks (skill stays model-invoked only).
+  uninstall   Reverse install: remove the lorekit-memory skill, the MCP server
+              entry, and the lifecycle hooks for the chosen scope. Surgical —
+              other servers, hooks, and settings are left untouched. Prompts
+              project vs global; --project / --global choose non-interactively.
   doctor      Verify the skill install, MCP connectivity, token, and scope.
   migrate     Relocate a LoreKit-format local store into the current layout.
               Dry-run by default; pass --yes to apply. Idempotent.
@@ -71,6 +76,7 @@ ${c.bold('Environment')}
 ${c.bold('Examples')}
   npx @lorekit/cli install --endpoint https://ref.supabase.co/functions/v1/mcp --token lk_rw_xxx
   npx @lorekit/cli install --global    # set up memory for every project (~/.claude)
+  npx @lorekit/cli uninstall --global  # tear that global setup back down
   npx @lorekit/cli doctor --deep
   npx @lorekit/cli migrate --from .lore                 # preview a rename
   npx @lorekit/cli migrate --from .lore --to project --yes
@@ -111,6 +117,8 @@ async function main() {
   switch (command) {
     case 'install':
       return install(args);
+    case 'uninstall':
+      return uninstall(args);
     case 'doctor':
       return doctor(args);
     case 'migrate':

--- a/packages/cli/src/config.mjs
+++ b/packages/cli/src/config.mjs
@@ -13,6 +13,35 @@ export function resolveProjectRoot(dir) {
   return path.resolve(dir || process.cwd());
 }
 
+// Atomic config write: serialize to a sibling temp file, then rename over the
+// target. rename(2) is atomic within a filesystem, so a crash / Ctrl-C / ENOSPC
+// mid-write can never leave a half-written (corrupt) file — the original stays
+// intact until the complete new content is swapped in. This matters most for
+// ~/.claude.json, which can be large and holds all of Claude Code's per-project
+// state and OAuth tokens. The temp file inherits the target's permissions when
+// it exists (so we don't widen a locked-down 0600 config to 0644 on replace).
+export function writeFileAtomic(file, data) {
+  const dir = path.dirname(file);
+  fs.mkdirSync(dir, { recursive: true });
+  const tmp = path.join(dir, `.${path.basename(file)}.${process.pid}.tmp`);
+  try {
+    fs.writeFileSync(tmp, data);
+    try {
+      fs.chmodSync(tmp, fs.statSync(file).mode);
+    } catch {
+      /* target didn't exist — leave the temp file's default perms */
+    }
+    fs.renameSync(tmp, file);
+  } catch (e) {
+    try {
+      fs.rmSync(tmp, { force: true });
+    } catch {
+      /* best-effort cleanup of the temp file */
+    }
+    throw e;
+  }
+}
+
 // The user's home directory. Honors $HOME / %USERPROFILE% (so it can be
 // redirected in tests) and falls back to the OS lookup.
 export function homeDir() {
@@ -50,6 +79,12 @@ export function settingsPath(root, scope = 'project') {
 // tool failure, nudge a retrospective at end of turn. Mirrors the plugin's
 // hooks.json so `install` delivers the same deterministic layer.
 export const CLAUDE_HOOK_EVENTS = ['SessionStart', 'PostToolUseFailure', 'Stop'];
+
+// Matches a hook command that fires the lorekit engine, whether wired as a
+// global `lorekit hook …` or `npx -y @lorekit/cli hook …`. Shared by the
+// upsert (find-or-update) and remove (uninstall) paths so they agree on what
+// counts as "ours".
+export const LOREKIT_HOOK_RE = /(?:@lorekit\/cli|lorekit) hook\b/;
 
 // npx stages the package's own bin into an ephemeral cache dir
 // (…/_npx/<hash>/node_modules/.bin) and prepends it to PATH for the lifetime of
@@ -122,7 +157,7 @@ export function upsertClaudeHooks(root, scope, runner) {
     for (const group of groups) {
       const inner = group && Array.isArray(group.hooks) ? group.hooks : [];
       existing = inner.find(
-        (h) => h && typeof h.command === 'string' && /(?:@lorekit\/cli|lorekit) hook\b/.test(h.command),
+        (h) => h && typeof h.command === 'string' && LOREKIT_HOOK_RE.test(h.command),
       );
       if (existing) break;
     }
@@ -139,8 +174,7 @@ export function upsertClaudeHooks(root, scope, runner) {
     }
   }
 
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify(config, null, 2) + '\n');
+  writeFileAtomic(file, JSON.stringify(config, null, 2) + '\n');
   return { file, added, updated, unchanged };
 }
 
@@ -181,7 +215,7 @@ export function upsertMcpServer(root, remoteUrl, scope = 'project') {
     command: 'npx',
     args: ['-y', 'mcp-remote', remoteUrl],
   };
-  fs.writeFileSync(file, JSON.stringify(config, null, 2) + '\n');
+  writeFileAtomic(file, JSON.stringify(config, null, 2) + '\n');
   return { file, existed };
 }
 
@@ -190,6 +224,71 @@ export function upsertMcpServer(root, remoteUrl, scope = 'project') {
 // no lorekit server. Callers that need to distinguish those use readMcpConfig.
 export function readLorekitServer(root) {
   return readServerFromFile(mcpJsonPath(root));
+}
+
+// --- uninstall: surgical removal of the three things `install` writes. -------
+// Each helper touches only lorekit's own entries and leaves every other
+// server / hook / setting intact, so uninstalling never damages a shared
+// ~/.claude.json or settings.json.
+
+// Delete the scaffolded skill directory. We own the whole
+// .claude/skills/lorekit-memory tree, so a recursive remove is safe.
+export function removeSkill(root, scope = 'project') {
+  const dest = skillInstallDir(root, scope);
+  const removed = fs.existsSync(dest);
+  if (removed) fs.rmSync(dest, { recursive: true, force: true });
+  return { dest, removed };
+}
+
+// Drop the `lorekit` MCP server entry, preserving any other servers (and, for
+// the global ~/.claude.json, all other user settings). Prunes an emptied
+// mcpServers object. No-op (no write) when there's nothing to remove.
+export function removeMcpServer(root, scope = 'project') {
+  const file = mcpConfigPath(root, scope);
+  const config = readJsonIfExists(file);
+  const hasEntry =
+    config &&
+    config.mcpServers &&
+    typeof config.mcpServers === 'object' &&
+    Object.prototype.hasOwnProperty.call(config.mcpServers, 'lorekit');
+  if (!hasEntry) return { file, removed: false };
+
+  delete config.mcpServers.lorekit;
+  if (Object.keys(config.mcpServers).length === 0) delete config.mcpServers;
+  writeFileAtomic(file, JSON.stringify(config, null, 2) + '\n');
+  return { file, removed: true };
+}
+
+// Strip lorekit hook entries from every event, preserving non-lorekit hooks in
+// the same groups. Prunes groups left with no hooks and events left with no
+// groups. Returns the count removed; only writes when something changed.
+export function removeClaudeHooks(root, scope = 'project') {
+  const file = settingsPath(root, scope);
+  const config = readJsonIfExists(file);
+  if (!config || !config.hooks || typeof config.hooks !== 'object') {
+    return { file, removed: 0 };
+  }
+
+  let removed = 0;
+  for (const event of Object.keys(config.hooks)) {
+    const groups = config.hooks[event];
+    if (!Array.isArray(groups)) continue;
+    for (const group of groups) {
+      if (!group || !Array.isArray(group.hooks)) continue;
+      const before = group.hooks.length;
+      group.hooks = group.hooks.filter(
+        (h) => !(h && typeof h.command === 'string' && LOREKIT_HOOK_RE.test(h.command)),
+      );
+      removed += before - group.hooks.length;
+    }
+    // Drop groups we emptied, then the event key if it has no groups left.
+    config.hooks[event] = groups.filter((g) => g && Array.isArray(g.hooks) && g.hooks.length > 0);
+    if (config.hooks[event].length === 0) delete config.hooks[event];
+  }
+  if (Object.keys(config.hooks).length === 0) delete config.hooks;
+
+  if (removed > 0) writeFileAtomic(file, JSON.stringify(config, null, 2) + '\n');
+  return { file, removed };
 }
 
 // Recursively copy the skill source into the target, skipping files that

--- a/packages/cli/src/uninstall.mjs
+++ b/packages/cli/src/uninstall.mjs
@@ -1,0 +1,114 @@
+// `lorekit uninstall` — reverse `install`: remove the skill, the MCP server
+// entry, and the lifecycle hooks for the chosen scope. Surgical — every other
+// server, hook, and setting is left untouched.
+import path from 'node:path';
+import readline from 'node:readline';
+import process from 'node:process';
+import {
+  SKILL_NAME,
+  resolveProjectRoot,
+  removeSkill,
+  removeMcpServer,
+  removeClaudeHooks,
+  homeDir,
+} from './config.mjs';
+import { log, heading, status, c } from './util.mjs';
+
+function ask(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => rl.question(question, (a) => { rl.close(); resolve(a.trim()); }));
+}
+
+export async function uninstall(args) {
+  const root = resolveProjectRoot(args.dir);
+  const nonInteractive = Boolean(args.yes) || !process.stdin.isTTY;
+
+  heading('LoreKit uninstall');
+  log(`  project: ${c.dim(root)}`);
+
+  // Mirror install's scope selection: --project / --global force it, else
+  // prompt when interactive, else default to project.
+  let scope = args.global ? 'global' : args.project ? 'project' : null;
+  if (!scope) {
+    if (nonInteractive) {
+      scope = 'project';
+    } else {
+      const ans = (
+        await ask('  Remove from this project or the global install? [project/global] (project): ')
+      ).toLowerCase();
+      scope = ans.startsWith('g') ? 'global' : 'project';
+    }
+  }
+  log(
+    `  scope: ${c.dim(
+      scope === 'global' ? 'global — ~/.claude, applies to every project' : 'project — this repo only',
+    )}`,
+  );
+
+  // Each removal is independent and best-effort: a corrupt or unwritable config
+  // for one target must not crash the run or block the others. `removeMcpServer`
+  // / `removeClaudeHooks` throw on an unparseable file (the same fail-safe as
+  // install — never clobber what we can't understand), so we catch and report it
+  // cleanly, leaving that file byte-for-byte untouched. Atomic writes
+  // (writeFileAtomic) guarantee a config can't be half-written even on a crash.
+  const skill = attempt(() => removeSkill(root, scope));
+  const mcp = attempt(() => removeMcpServer(root, scope));
+  const hooks = attempt(() => removeClaudeHooks(root, scope));
+
+  // Global paths shown relative to ~; project paths repo-relative.
+  const display = (p) =>
+    scope === 'global' ? p.replace(homeDir(), '~') : path.relative(root, p) || p;
+  const mcpLabel = scope === 'global' ? '~/.claude.json' : '.mcp.json';
+
+  heading('Done');
+  report(skill, `skill ${SKILL_NAME}`, {
+    done: (r) => `removed → ${display(r.dest)}`,
+    noop: 'not installed — nothing to remove',
+  });
+  report(mcp, mcpLabel, {
+    done: (r) => `lorekit server removed → ${display(r.file)}`,
+    noop: 'no lorekit server entry — nothing to remove',
+  });
+  report(hooks, 'hooks', {
+    done: (r) => `${r.removed} removed → ${display(r.file)}`,
+    noop: 'no lorekit hooks — nothing to remove',
+  });
+
+  const failed = [skill, mcp, hooks].some((s) => !s.ok);
+  const any = (skill.result?.removed || mcp.result?.removed || hooks.result?.removed) && true;
+
+  if (failed) {
+    log(`\n  ${c.dim('Some items could not be removed and were left untouched — see above.')}`);
+    return 1;
+  }
+  if (!any) {
+    const other = scope === 'global' ? '--project' : '--global';
+    log(`\n  ${c.dim(`Nothing found for the ${scope} scope — try ${other}?`)}`);
+  } else {
+    log(`\n  ${c.dim('Removed. Your other MCP servers, hooks, and settings were left untouched.')}`);
+    log(`  ${c.dim('Note: your token may remain in shell history or env — rotate it if it leaked.')}`);
+  }
+  return 0;
+}
+
+// Run a removal step, converting a throw into a reportable outcome so one bad
+// config can't crash the whole uninstall or leave a stack trace on screen.
+function attempt(fn) {
+  try {
+    return { ok: true, result: fn() };
+  } catch (e) {
+    return { ok: false, error: e };
+  }
+}
+
+// Render one status line for a step: a clean error (file left untouched), a
+// "removed" line, or a "nothing to remove" line.
+function report(step, label, { done, noop }) {
+  if (!step.ok) {
+    status('fail', label, `left untouched — ${step.error.message}`);
+    return;
+  }
+  const r = step.result;
+  const removed = r.removed;
+  status(removed ? 'pass' : 'info', label, removed ? done(r) : noop);
+}

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -12,6 +12,7 @@ import {
   mcpJsonPath,
   onPath,
   resolveHookRunner,
+  writeFileAtomic,
 } from '../src/config.mjs';
 
 function tmpRoot() {
@@ -78,6 +79,30 @@ test('readJsonIfExists still throws on malformed JSON (install clobber-guard)', 
   const root = tmpRoot();
   fs.writeFileSync(mcpJsonPath(root), '{ broken');
   assert.throws(() => readJsonIfExists(mcpJsonPath(root)), /Failed to parse/);
+});
+
+test('writeFileAtomic replaces content, preserves perms, and leaves no temp file', () => {
+  const root = tmpRoot();
+  const file = path.join(root, '.claude.json');
+  fs.writeFileSync(file, 'old');
+  fs.chmodSync(file, 0o600); // a locked-down config holding secrets
+
+  writeFileAtomic(file, 'new-content');
+
+  assert.equal(fs.readFileSync(file, 'utf8'), 'new-content', 'content replaced');
+  assert.equal(fs.statSync(file).mode & 0o777, 0o600, 'original 0600 perms preserved on replace');
+  assert.deepEqual(
+    fs.readdirSync(root).filter((f) => f.includes('.tmp')),
+    [],
+    'no leftover temp file',
+  );
+});
+
+test('writeFileAtomic creates a new file (and its parent dir) when absent', () => {
+  const root = tmpRoot();
+  const file = path.join(root, 'nested', 'dir', '.mcp.json');
+  writeFileAtomic(file, 'fresh');
+  assert.equal(fs.readFileSync(file, 'utf8'), 'fresh');
 });
 
 test('copyDir reports how many files it actually wrote', () => {

--- a/packages/cli/test/uninstall.test.mjs
+++ b/packages/cli/test/uninstall.test.mjs
@@ -1,0 +1,158 @@
+// `lorekit uninstall` — reverses install for project / global scope, touching
+// only lorekit's own skill, MCP entry, and hooks.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { install } from '../src/install.mjs';
+import { uninstall } from '../src/uninstall.mjs';
+
+function tmp(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+const ENDPOINT = 'https://ref.supabase.co/functions/v1/mcp';
+const TOKEN = 'lk_rw_test';
+
+function withHome(home, fn) {
+  const prevHome = process.env.HOME;
+  const prevProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevProfile;
+    });
+}
+
+test('uninstall --project removes skill, MCP entry, and hooks', async () => {
+  const root = tmp('lk-uninst-proj-');
+  await install({ dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, project: true });
+
+  // Sanity: install put everything in place.
+  assert.ok(fs.existsSync(path.join(root, '.claude', 'skills', 'lorekit-memory', 'SKILL.md')));
+  assert.ok(fs.existsSync(path.join(root, '.mcp.json')));
+  assert.ok(fs.existsSync(path.join(root, '.claude', 'settings.json')));
+
+  const code = await uninstall({ dir: root, yes: true, project: true });
+  assert.equal(code, 0);
+
+  assert.ok(!fs.existsSync(path.join(root, '.claude', 'skills', 'lorekit-memory')), 'skill dir gone');
+
+  const mcp = JSON.parse(fs.readFileSync(path.join(root, '.mcp.json'), 'utf8'));
+  assert.ok(!mcp.mcpServers?.lorekit, 'lorekit server removed');
+
+  const settings = JSON.parse(fs.readFileSync(path.join(root, '.claude', 'settings.json'), 'utf8'));
+  const cmds = Object.values(settings.hooks ?? {})
+    .flat()
+    .flatMap((g) => g.hooks.map((h) => h.command));
+  assert.ok(!cmds.some((cmd) => /lorekit(\/cli)? hook/.test(cmd)), 'no lorekit hooks left');
+});
+
+test('uninstall preserves other MCP servers and non-lorekit hooks + settings', async () => {
+  const root = tmp('lk-uninst-preserve-');
+  // Seed unrelated project config first.
+  fs.writeFileSync(
+    path.join(root, '.mcp.json'),
+    JSON.stringify({ mcpServers: { other: { command: 'x' } } }),
+  );
+  fs.mkdirSync(path.join(root, '.claude'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, '.claude', 'settings.json'),
+    JSON.stringify({
+      model: 'opus',
+      hooks: { SessionStart: [{ hooks: [{ type: 'command', command: 'echo hi' }] }] },
+    }),
+  );
+
+  await install({ dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, project: true });
+  await uninstall({ dir: root, yes: true, project: true });
+
+  const mcp = JSON.parse(fs.readFileSync(path.join(root, '.mcp.json'), 'utf8'));
+  assert.ok(!mcp.mcpServers.lorekit, 'lorekit removed');
+  assert.ok(mcp.mcpServers.other, 'other server preserved');
+
+  const settings = JSON.parse(fs.readFileSync(path.join(root, '.claude', 'settings.json'), 'utf8'));
+  assert.equal(settings.model, 'opus', 'unrelated settings preserved');
+  const startCmds = settings.hooks.SessionStart.flatMap((g) => g.hooks.map((h) => h.command));
+  assert.ok(startCmds.includes('echo hi'), 'pre-existing hook preserved');
+  assert.ok(!startCmds.some((cmd) => /lorekit(\/cli)? hook/.test(cmd)), 'lorekit hook stripped');
+});
+
+test('uninstall --global removes from ~/.claude, leaving user config intact', async () => {
+  const home = tmp('lk-uninst-home-');
+  const root = tmp('lk-uninst-cwd-');
+  fs.writeFileSync(
+    path.join(home, '.claude.json'),
+    JSON.stringify({ theme: 'dark', mcpServers: { other: { command: 'x' } } }),
+  );
+
+  await withHome(home, async () => {
+    await install({ dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, global: true });
+    const code = await uninstall({ dir: root, yes: true, global: true });
+    assert.equal(code, 0);
+
+    assert.ok(!fs.existsSync(path.join(home, '.claude', 'skills', 'lorekit-memory')), 'global skill gone');
+
+    const cfg = JSON.parse(fs.readFileSync(path.join(home, '.claude.json'), 'utf8'));
+    assert.equal(cfg.theme, 'dark', 'unrelated user settings preserved');
+    assert.ok(cfg.mcpServers.other, 'other server preserved');
+    assert.ok(!cfg.mcpServers.lorekit, 'lorekit server removed');
+
+    const settings = JSON.parse(fs.readFileSync(path.join(home, '.claude', 'settings.json'), 'utf8'));
+    const cmds = Object.values(settings.hooks ?? {})
+      .flat()
+      .flatMap((g) => g.hooks.map((h) => h.command));
+    assert.ok(!cmds.some((cmd) => /lorekit(\/cli)? hook/.test(cmd)), 'global hooks removed');
+  });
+});
+
+test('uninstall leaves a corrupt config untouched, still removes what it can, and exits non-zero', async () => {
+  const root = tmp('lk-uninst-corrupt-');
+  await install({ dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, project: true });
+
+  // Corrupt the .mcp.json after a clean install.
+  const mcpFile = path.join(root, '.mcp.json');
+  const corrupt = '{ not json';
+  fs.writeFileSync(mcpFile, corrupt);
+
+  const code = await uninstall({ dir: root, yes: true, project: true });
+  assert.equal(code, 1, 'non-zero exit when a target could not be removed');
+
+  // The unparseable file is byte-for-byte untouched, never clobbered.
+  assert.equal(fs.readFileSync(mcpFile, 'utf8'), corrupt, 'corrupt .mcp.json left as-is');
+
+  // The other targets were still removed — one bad file does not block the rest.
+  assert.ok(!fs.existsSync(path.join(root, '.claude', 'skills', 'lorekit-memory')), 'skill still removed');
+  const settings = JSON.parse(fs.readFileSync(path.join(root, '.claude', 'settings.json'), 'utf8'));
+  const cmds = Object.values(settings.hooks ?? {})
+    .flat()
+    .flatMap((g) => g.hooks.map((h) => h.command));
+  assert.ok(!cmds.some((cmd) => /lorekit(\/cli)? hook/.test(cmd)), 'hooks still removed');
+});
+
+test('uninstall leaves no leftover temp files', async () => {
+  const root = tmp('lk-uninst-tmp-');
+  await install({ dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, project: true });
+  await uninstall({ dir: root, yes: true, project: true });
+  const leftovers = fs.readdirSync(path.join(root, '.claude')).filter((f) => f.includes('.tmp'));
+  assert.deepEqual(leftovers, [], 'no .tmp remnants from atomic writes');
+});
+
+test('uninstall is idempotent and a no-op when nothing is installed', async () => {
+  const root = tmp('lk-uninst-noop-');
+  const code = await uninstall({ dir: root, yes: true, project: true });
+  assert.equal(code, 0, 'exits clean with nothing to remove');
+  assert.ok(!fs.existsSync(path.join(root, '.mcp.json')), 'no file created by a no-op uninstall');
+
+  // Running after a real install twice is safe.
+  await install({ dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, project: true });
+  await uninstall({ dir: root, yes: true, project: true });
+  const second = await uninstall({ dir: root, yes: true, project: true });
+  assert.equal(second, 0, 'second uninstall is a clean no-op');
+});


### PR DESCRIPTION
## Why

`lorekit install` had no inverse — removing it meant hand-editing `~/.claude.json`, `~/.claude/settings.json`, and deleting the skill dir by hand, which is error-prone on a large shared config that also holds OAuth tokens.

## What changed

- Add `lorekit uninstall` (project/global, mirrors install's scope selection) that surgically removes only lorekit's skill, MCP server entry, and lifecycle hooks — every other server, hook, and setting is preserved
- `writeFileAtomic` (temp-file + `rename`) for all config writes, so a crash/Ctrl-C/ENOSPC mid-write can't truncate a config; original file permissions are preserved on replace
- Each removal runs best-effort — a corrupt/unwritable config is reported cleanly and left byte-for-byte untouched, other targets still removed, non-zero exit when anything failed

## How to verify

- `cd packages/cli && node --test` (covers project/global/preserve-others/corrupt-config/idempotent/no-temp-leak paths)