### PR TITLE
feat(cli): interactive arrow-key picker for install scope

### DIFF
--- a/packages/cli/src/install.mjs
+++ b/packages/cli/src/install.mjs
@@ -19,7 +19,7 @@ import {
 } from './config.mjs';
 import { buildRemoteUrl } from './mcp.mjs';
 import { deriveScope } from './scope.mjs';
-import { log, err, heading, status, c } from './util.mjs';
+import { log, err, heading, status, select, c } from './util.mjs';
 
 function ask(question) {
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
@@ -42,10 +42,10 @@ export async function install(args) {
     if (nonInteractive) {
       scope = 'project';
     } else {
-      const ans = (
-        await ask('  Install for this project or globally for all projects? [project/global] (project): ')
-      ).toLowerCase();
-      scope = ans.startsWith('g') ? 'global' : 'project';
+      scope = await select('Install LoreKit for…', [
+        { label: 'This project', value: 'project', hint: 'this repo only (.claude, .mcp.json)' },
+        { label: 'All projects (global)', value: 'global', hint: 'every project (~/.claude)' },
+      ]);
     }
   }
   log(

--- a/packages/cli/src/util.mjs
+++ b/packages/cli/src/util.mjs
@@ -40,6 +40,83 @@ export function status(kind, label, detail) {
   log(`  ${mark} ${label}${tail}`);
 }
 
+// Map a raw keypress to a select-list action. Pure so it can be unit-tested
+// without a pseudo-TTY. Supports arrow keys (both the `ESC [` and application
+// `ESC O` cursor modes) and vim-style j/k.
+export function selectAction(key) {
+  if (key === '') return 'cancel'; // Ctrl-C
+  if (key === '\r' || key === '\n') return 'submit';
+  if (key === 'k' || (key.startsWith('') && key.endsWith('A'))) return 'up';
+  if (key === 'j' || (key.startsWith('') && key.endsWith('B'))) return 'down';
+  return null;
+}
+
+// Interactive single-choice list. `options` is [{ label, value, hint? }].
+// Arrow keys / j / k move, Enter selects, Ctrl-C aborts. Falls back to the
+// default option when stdin isn't a TTY (CI / piped input), matching the
+// non-interactive install path. Zero-dependency; renders with raw ANSI.
+export function select(question, options, { defaultIndex = 0 } = {}) {
+  const { stdin, stdout } = process;
+  let index = Math.max(0, Math.min(defaultIndex, options.length - 1));
+
+  if (!stdin.isTTY) return Promise.resolve(options[index].value);
+
+  return new Promise((resolve) => {
+    const render = (first) => {
+      if (!first) stdout.write(`[${options.length}A`); // cursor up N lines
+      for (let i = 0; i < options.length; i++) {
+        const active = i === index;
+        const pointer = active ? c.cyan('❯') : ' ';
+        const label = active ? c.cyan(options[i].label) : options[i].label;
+        const hint = options[i].hint ? ` ${c.dim('— ' + options[i].hint)}` : '';
+        stdout.write(`[2K  ${pointer} ${label}${hint}\n`); // clear line, write
+      }
+    };
+
+    log(`  ${question}`);
+    stdout.write('[?25l'); // hide cursor
+    render(true);
+
+    const prevRaw = Boolean(stdin.isRaw);
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('utf8');
+
+    const cleanup = () => {
+      stdin.setRawMode(prevRaw);
+      stdin.pause();
+      stdin.removeListener('data', onData);
+      stdout.write('[?25h'); // show cursor
+    };
+
+    const onData = (key) => {
+      switch (selectAction(key)) {
+        case 'cancel':
+          cleanup();
+          stdout.write('\n');
+          process.exit(130);
+          break;
+        case 'up':
+          index = (index - 1 + options.length) % options.length;
+          render(false);
+          break;
+        case 'down':
+          index = (index + 1) % options.length;
+          render(false);
+          break;
+        case 'submit':
+          cleanup();
+          resolve(options[index].value);
+          break;
+        default:
+          break;
+      }
+    };
+
+    stdin.on('data', onData);
+  });
+}
+
 // Minimal flag parser: --key value, --key=value, -k value, and bare --flags.
 // `aliases` maps short → long; `booleans` lists flags that take no value.
 export function parseArgs(argv, { aliases = {}, booleans = [] } = {}) {

--- a/packages/cli/test/unit.test.mjs
+++ b/packages/cli/test/unit.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import { ownerRepoFromRemote } from '../src/scope.mjs';
 import { splitEndpoint, buildRemoteUrl } from '../src/mcp.mjs';
 import { tokenKind } from '../src/config.mjs';
-import { parseArgs } from '../src/util.mjs';
+import { parseArgs, selectAction, select } from '../src/util.mjs';
 
 test('ownerRepoFromRemote normalizes remote URL variants', () => {
   assert.equal(ownerRepoFromRemote('git@github.com:mthines/LoreKit.git'), 'mthines/lorekit');
@@ -48,4 +48,31 @@ test('parseArgs handles flags, values, =, and aliases', () => {
   assert.equal(args.endpoint, 'https://x');
   assert.equal(args.token, 'lk_rw_1');
   assert.equal(args.yes, true);
+});
+
+test('selectAction maps keys to list actions', () => {
+  assert.equal(selectAction(''), 'cancel'); // Ctrl-C
+  assert.equal(selectAction('\r'), 'submit');
+  assert.equal(selectAction('\n'), 'submit');
+  assert.equal(selectAction('[A'), 'up'); // arrow-up (ESC [ cursor mode)
+  assert.equal(selectAction('OA'), 'up'); // arrow-up (ESC O application mode)
+  assert.equal(selectAction('[B'), 'down');
+  assert.equal(selectAction('OB'), 'down');
+  assert.equal(selectAction('k'), 'up');
+  assert.equal(selectAction('j'), 'down');
+  assert.equal(selectAction('x'), null);
+});
+
+test('select resolves the default option when stdin is not a TTY', async () => {
+  const wasTTY = process.stdin.isTTY;
+  process.stdin.isTTY = false; // simulate piped / CI stdin
+  try {
+    const value = await select('pick', [
+      { label: 'A', value: 'a' },
+      { label: 'B', value: 'b' },
+    ], { defaultIndex: 1 });
+    assert.equal(value, 'b');
+  } finally {
+    process.stdin.isTTY = wasTTY;
+  }
 });


### PR DESCRIPTION
## Why

The install scope prompt was free-text (`project/global (project):`) — easy to mistype and giving no affordance for the two choices.

## What changed

- Replace the scope prompt with a zero-dependency arrow-key select list (↑/↓ or j/k, Enter, Ctrl-C to abort)
- Non-TTY / CI runs fall back to the default option — the non-interactive install path is unchanged
- Factor the key→action mapping into a pure `selectAction` (handles `ESC [` and application `ESC O` cursor modes), unit-tested alongside the non-TTY fallback

## How to verify

- `node --test packages/cli/test/unit.test.mjs` — covers `selectAction` + non-TTY fallback; run `node packages/cli/bin/lorekit.mjs install` in a TTY to see the picker