### PR TITLE
ci: auto-merge the release PR so releases need no human step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,13 @@
 #   1. release-please reads the conventional commits since the last release and
 #      maintains a single "release PR" that bumps packages/cli/package.json and
 #      writes packages/cli/CHANGELOG.md. Feature merges just keep that PR up to
-#      date — nothing is published.
-#   2. When you merge that release PR, the resulting push carries the release
-#      commit; release-please then creates the git tag + GitHub Release and sets
-#      `release_created=true`, which gates the publish job below. The job checks
-#      out the (now version-bumped) main and publishes to npm.
+#      date — nothing is published. This job then turns on GitHub auto-merge for
+#      that PR, so it lands itself the moment required CI passes — no human merge.
+#   2. Auto-merge lands the release PR once CI is green; the resulting push
+#      carries the release commit; release-please then creates the git tag +
+#      GitHub Release and sets `release_created=true`, which gates the publish
+#      job below. The job checks out the (now version-bumped) main and publishes
+#      to npm.
 #
 # Auth:
 #   • release-please runs as a GitHub App (create-github-app-token) rather than
@@ -75,6 +77,25 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Merge the release PR with zero human intervention. We enable GitHub's
+      # native auto-merge rather than merging outright: GitHub queues the merge
+      # and completes it only once the branch's required status checks (ci.yml's
+      # `check` + `integration`) go green — the App token above is exactly what
+      # let the release PR trigger those checks. The next push to main then cuts
+      # the tag + release and gates publish-cli. `pr` is set only when a release
+      # PR was opened/updated this run (empty on the push that merges it), so the
+      # guard keeps this a clean no-op otherwise. Requires the repo's "Allow
+      # auto-merge" setting to be on (see docs/releasing.md).
+      - name: Auto-merge the release PR
+        if: ${{ steps.rp.outputs.pr != '' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_PR: ${{ steps.rp.outputs.pr }}
+        run: |
+          pr_number=$(jq -r '.number' <<< "$RELEASE_PR")
+          echo "Enabling auto-merge on release PR #$pr_number"
+          gh pr merge "$pr_number" --repo "$GITHUB_REPOSITORY" --auto --squash
 
   # ── 2. Publish to npm — only when a release was actually cut ─────────────────
   publish-cli:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -23,10 +23,15 @@ the rest.
 2. **release-please keeps a "release PR" open**, continuously updating
    `packages/cli/package.json` and `packages/cli/CHANGELOG.md` with the next
    version and the accumulated notes. Nothing is published yet.
-3. **You merge the release PR** when you want to cut a release. That push makes
-   release-please create the tag `cli-vX.Y.Z` + a GitHub Release, which gates
-   the `publish-cli` job — it checks out the freshly-bumped `main` and runs
-   `npm publish` via Trusted Publishing.
+3. **The release PR merges itself** — `release.yml` turns on GitHub auto-merge
+   for it, so it lands the moment the required CI checks (`check` + `integration`)
+   pass. No human merge step. That push makes release-please create the tag
+   `cli-vX.Y.Z` + a GitHub Release, which gates the `publish-cli` job — it checks
+   out the freshly-bumped `main` and runs `npm publish` via Trusted Publishing.
+
+> Because the release PR auto-merges, **every CLI-affecting commit on `main`
+> flows to npm on its own**. To batch or hold releases, see "Hold a release"
+> below.
 
 The version is decided by the commits since the last release:
 
@@ -39,7 +44,7 @@ The version is decided by the commits since the last release:
 
 ## One-time setup
 
-Two things must exist for the pipeline to run end-to-end. Both are already
+Three things must exist for the pipeline to run end-to-end. All are already
 referenced by `.github/workflows/release.yml`.
 
 ### 1. A GitHub App for release-please
@@ -78,10 +83,23 @@ The package must already exist on npm before a trusted publisher can be added,
 so the very first publish is done by hand (`cd packages/cli && npm publish
 --access public`); every release after that is automated and token-free.
 
+### 3. Repo auto-merge enabled + required checks
+
+The release PR merges itself via GitHub's native auto-merge, so:
+
+- Under **Settings → General → Pull Requests**, tick **Allow auto-merge**.
+  Without it, `gh pr merge --auto` in `release.yml` errors and the PR sits
+  unmerged.
+- Keep `check` + `integration` as **required status checks** on `main` (branch
+  protection or a ruleset). Auto-merge holds the merge until they pass, so an
+  unverified release can never land. The workflow squash-merges the PR.
+
 ## Adjusting a release
 
 - **Change what's in the release** — edit the release PR's title/body or amend
   commits; release-please recomputes on the next push to `main`.
-- **Hold a release** — just don't merge the release PR. Feature merges keep
-  accumulating into it.
+- **Hold a release** — auto-merge lands the release PR as soon as CI is green,
+  so to hold, turn off auto-merge on that specific PR (or dismiss it) before it
+  goes green; feature merges keep accumulating into the next one. To pause
+  releases entirely, temporarily untick **Allow auto-merge** for the repo.
 - **Force a version** — add a `Release-As: X.Y.Z` footer to a commit on `main`.


### PR DESCRIPTION
## Why

Cutting a CLI release still needed a human to merge the release-please PR. This removes that last manual step, so a `feat:`/`fix:` commit flows to npm on its own.

## What changed

- `release.yml` enables GitHub auto-merge on the release PR right after release-please opens/updates it
- Auto-merge holds the merge until the required checks (`check` + `integration`) pass, so an unverified release can't land
- Documented the new "Allow auto-merge" repo prerequisite in `docs/releasing.md`

## How to verify

- Merge a `feat:`/`fix:` commit to `main` → the release PR appears with auto-merge enabled and lands itself once CI is green

## Notes for reviewers

Requires the repo's **Settings → Allow auto-merge** to be on; without it the `gh pr merge --auto` step errors and the PR just sits.

---
_Generated by [Claude Code](https://claude.ai/code/session_013C9uQk29HRg2BVEck7KXd6)_