### PR TITLE
feat(orgs): send invite emails via Resend

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -27,6 +27,13 @@
 | `NEXT_PUBLIC_DASH0_AUTH_TOKEN` | Ingesting-only Dash0 token (public — visible in bundle) |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | Dash0 OTLP endpoint (server-side) |
 | `OTEL_EXPORTER_OTLP_HEADERS` | `Authorization=Bearer <token>` |
+| `RESEND_API_KEY` | Optional. Resend API key for org invite emails. Unset → invites are in-app only |
+| `RESEND_FROM` | Optional. Verified sending address, e.g. `LoreKit <invites@yourdomain.com>` |
+
+> Org invite emails are optional. With no `RESEND_API_KEY`, an invite just
+> appears in the invitee's dashboard on next sign-in (no email). To send
+> emails, verify a sending domain in Resend, then set `RESEND_API_KEY` +
+> `RESEND_FROM` here.
 
 ### Supabase Edge Function secrets
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -204,6 +204,11 @@ NEXT_PUBLIC_DASH0_AUTH_TOKEN      <ingesting-only-dash0-token>
 
 OTEL_EXPORTER_OTLP_ENDPOINT       https://ingress.europe-west4.gcp.dash0-dev.com
 OTEL_EXPORTER_OTLP_HEADERS        Authorization=Bearer <DASH0_AUTH_TOKEN>
+
+# Optional — org invite emails via Resend. Unset → invites are in-app only.
+# Verify a sending domain in Resend before setting these.
+RESEND_API_KEY                    re_<your-resend-api-key>
+RESEND_FROM                       LoreKit <invites@yourdomain.com>
 ```
 
 Also add your Vercel URL to Supabase → Auth → URL Configuration:

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -6,6 +6,14 @@ NEXT_PUBLIC_SUPABASE_PROJECT_REF=pqokxlhvnosogizsjztg
 # ── App ────────────────────────────────────────────────────────────────────────
 NEXT_PUBLIC_APP_URL=http://localhost:3001
 
+# ── Org invite emails (Resend) ────────────────────────────────────────────────
+# Optional. When RESEND_API_KEY is unset, org invites are in-app only (no email
+# sent) — everything still works. To send invite emails, set an API key and a
+# verified sending address (verify the domain in Resend first). Locally these
+# are usually left unset so no email ships in dev.
+# RESEND_API_KEY=re_...
+# RESEND_FROM=LoreKit <invites@yourdomain.com>
+
 # ── Deployment environment ────────────────────────────────────────────────────
 # Vercel injects VERCEL_ENV automatically ('production' | 'preview' | 'development').
 # For local dev this is absent — instrumentation maps it to 'local'.

--- a/packages/web/src/lib/invite-email.spec.ts
+++ b/packages/web/src/lib/invite-email.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { sendInviteEmail } from './invite-email';
+
+// sendInviteEmail reads RESEND_API_KEY / RESEND_FROM / NEXT_PUBLIC_APP_URL at
+// call time and calls the global fetch. Snapshot + restore the env and the
+// fetch stub around every case so nothing leaks between tests (the
+// mcp-url.spec.ts pattern), and so the suite never touches the network.
+const ENV_KEYS = ['RESEND_API_KEY', 'RESEND_FROM', 'NEXT_PUBLIC_APP_URL'] as const;
+const originalEnv: Record<string, string | undefined> = {};
+for (const k of ENV_KEYS) originalEnv[k] = process.env[k];
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (originalEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = originalEnv[k];
+  }
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('sendInviteEmail', () => {
+  it('POSTs a correctly-shaped invite to Resend for an email invite', async () => {
+    process.env['RESEND_API_KEY'] = 'test-key';
+    process.env['RESEND_FROM'] = 'LoreKit <invites@test.dev>';
+    process.env['NEXT_PUBLIC_APP_URL'] = 'https://app.test';
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await sendInviteEmail({
+      to: 'invitee@example.com',
+      orgName: 'Acme Team',
+      role: 'member',
+      invitedByLabel: 'octocat',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.resend.com/emails');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer test-key');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('application/json');
+
+    const body = JSON.parse(init.body as string);
+    expect(body.from).toBe('LoreKit <invites@test.dev>');
+    expect(body.to).toEqual(['invitee@example.com']);
+    expect(body.subject).toBe("You've been invited to Acme Team on LoreKit");
+    // Both text and html carry org name, role, inviter, and the dashboard link.
+    for (const part of [body.text, body.html]) {
+      expect(part).toContain('Acme Team');
+      expect(part).toContain('member');
+      expect(part).toContain('octocat');
+      expect(part).toContain('https://app.test/dashboard');
+    }
+  });
+
+  it('no-ops (no fetch) when RESEND_API_KEY is unset', async () => {
+    delete process.env['RESEND_API_KEY'];
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      sendInviteEmail({ to: 'invitee@example.com', orgName: 'Acme Team', role: 'member' }),
+    ).resolves.toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('no-ops for a handle-only / null recipient (no address to send to)', async () => {
+    process.env['RESEND_API_KEY'] = 'test-key';
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await sendInviteEmail({ to: 'ghhandle', orgName: 'Acme Team', role: 'member' });
+    await sendInviteEmail({ to: null, orgName: 'Acme Team', role: 'member' });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('never propagates a failed fetch (non-throwing contract)', async () => {
+    process.env['RESEND_API_KEY'] = 'test-key';
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network down'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      sendInviteEmail({ to: 'invitee@example.com', orgName: 'Acme Team', role: 'member' }),
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/lib/invite-email.ts
+++ b/packages/web/src/lib/invite-email.ts
@@ -1,0 +1,93 @@
+/**
+ * sendInviteEmail — fire a transactional org-invite email via Resend.
+ *
+ * A plain (NOT `'use server'`) impure-shell module: it reads env + calls
+ * `fetch` and nothing else (no `next/cache`, no supabase), so it's importable
+ * by a node-env vitest spec — the `mcp-url.ts` pattern.
+ *
+ * NON-THROWING by contract, mirroring `recordAuditEvent` (audit-log.ts): the
+ * whole body is guarded, so an email failure (bad key, unverified domain,
+ * network error) can never break the invite that already succeeded in the DB.
+ * Callers do not need their own try/catch.
+ *
+ * No-ops (no network call) when there's no real recipient, or when
+ * `RESEND_API_KEY` is unset — so local/dev and any environment without the key
+ * work unchanged and invites still succeed; only handle-only invites and
+ * key-less environments simply send nothing.
+ */
+
+export interface InviteEmailInput {
+  /** invitee_email — the helper no-ops if this is falsy or lacks an '@'. */
+  to: string | null;
+  /** Resolved org name (caller falls back to slug / a generic label). */
+  orgName: string;
+  /** 'admin' | 'member' | 'viewer'. */
+  role: string;
+  /** GitHub handle or email of the inviter, when resolvable. */
+  invitedByLabel?: string | null;
+}
+
+const RESEND_ENDPOINT = 'https://api.resend.com/emails';
+const DEFAULT_FROM = 'LoreKit <invites@lorekit.io>';
+const DEFAULT_APP_URL = 'https://lorekit-io.vercel.app';
+
+export async function sendInviteEmail(input: InviteEmailInput): Promise<void> {
+  try {
+    const { to, orgName, role, invitedByLabel } = input;
+
+    // No address to send to (handle-only invite, or empty) — nothing to do.
+    if (!to || !to.includes('@')) return;
+
+    const apiKey = process.env['RESEND_API_KEY'];
+    if (!apiKey) {
+      console.debug('[sendInviteEmail] RESEND_API_KEY unset — skipping invite email');
+      return;
+    }
+
+    const from = process.env['RESEND_FROM'] ?? DEFAULT_FROM;
+    const base = process.env['NEXT_PUBLIC_APP_URL'] ?? DEFAULT_APP_URL;
+    const link = `${base}/dashboard`;
+
+    const invitedBy = invitedByLabel ? `${invitedByLabel} invited you` : 'You have been invited';
+    const subject = `You've been invited to ${orgName} on LoreKit`;
+
+    const text = [
+      `${invitedBy} to join ${orgName} on LoreKit as a ${role}.`,
+      '',
+      `Sign in with GitHub to accept: ${link}`,
+      '',
+      'LoreKit — shared, persistent memory for your agents.',
+    ].join('\n');
+
+    const html = [
+      `<p>${escapeHtml(invitedBy)} to join <strong>${escapeHtml(orgName)}</strong> on LoreKit as a <strong>${escapeHtml(role)}</strong>.</p>`,
+      `<p><a href="${escapeHtml(link)}">Sign in with GitHub to accept</a></p>`,
+      `<p style="color:#888;font-size:12px">LoreKit — shared, persistent memory for your agents.</p>`,
+    ].join('');
+
+    const res = await fetch(RESEND_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ from, to: [to], subject, text, html }),
+    });
+
+    if (!res.ok) {
+      // Non-fatal: log and move on. The invite already exists in the DB.
+      console.error(`[sendInviteEmail] Resend responded ${res.status}`);
+    }
+  } catch (err) {
+    console.error('[sendInviteEmail] failed:', (err as Error).message);
+  }
+}
+
+/** Minimal HTML-entity escaping for interpolated values in the email body. */
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/packages/web/src/lib/org-invites.ts
+++ b/packages/web/src/lib/org-invites.ts
@@ -16,6 +16,7 @@
 import { createServerClient } from '@/lib/supabase/server';
 import { revalidatePath } from 'next/cache';
 import { recordAuditEvent } from '@/lib/audit-log';
+import { sendInviteEmail } from '@/lib/invite-email';
 import type { OrgRole } from '@/lib/orgs';
 
 export type OrgInviteStatus = 'pending' | 'accepted' | 'declined' | 'revoked';
@@ -92,6 +93,24 @@ export async function inviteMember(
     target: orgId,
     metadata: { invitee: trimmed, role },
   });
+
+  // Fire the notification email for email invites only (a handle-only invite
+  // has no address). Non-blocking and non-throwing — sendInviteEmail swallows
+  // every failure, so a bad key / unverified domain never breaks the invite
+  // that already succeeded above. Resolve the org name (RLS-scoped; the caller
+  // is a member) for the subject line, falling back to slug then a generic.
+  if (isEmail) {
+    const { data: org } = await supabase
+      .from('orgs')
+      .select('name, slug')
+      .eq('id', orgId)
+      .maybeSingle();
+    const orgName = org?.name ?? org?.slug ?? 'your organization';
+    const invitedByLabel =
+      (user.user_metadata?.user_name as string | undefined) ?? user.email ?? null;
+    await sendInviteEmail({ to: trimmed, orgName, role, invitedByLabel });
+  }
+
   revalidatePath('/settings', 'layout');
   return { inviteId: inviteId as string };
 }


### PR DESCRIPTION
## Why

Org invites (Phases 1–4) are **in-app only** — an invitee only discovers an invite via the `PendingInvitesBanner` after they sign in. Someone who hasn't logged in, or was invited by an email they haven't signed in with, never learns they were invited. This sends a notification email for email invites.

## What (2 new files + 1 wire-up + docs)

- **`packages/web/src/lib/invite-email.ts`** — `sendInviteEmail`: a plain `fetch` POST to `https://api.resend.com/emails` (no SDK, no new dependency). **Non-throwing by contract**, mirroring `recordAuditEvent`: the whole body is guarded, so a bad key / unverified domain / network error can never break the invite that already succeeded in the DB. **No-ops** (no network call) when there's no email recipient, or when `RESEND_API_KEY` is unset — so dev and any key-less environment work unchanged and invites still succeed.
- **`inviteMember`** (`org-invites.ts`) fires it after the invite row is created and after `recordAuditEvent`, for **email invites only** (a handle-only invite has no address, so it stays in-app). It resolves the org name (RLS-scoped) for the subject line, and deep-links to `/dashboard` where the existing banner surfaces the invite after GitHub OAuth — **no magic-link token**; copy says "Sign in with GitHub to accept".
- **Unit test** (`invite-email.spec.ts`, mocked `fetch`): correct payload for an email invite; no-op without `RESEND_API_KEY`; no-op for a handle-only / null recipient; a rejected `fetch` never propagates.
- Documented `RESEND_API_KEY` + `RESEND_FROM` in `packages/web/.env.example`, `SETUP.md`, and `docs/deployment.md`.

## Operational step

To actually send in production: **verify a sending domain in Resend**, then set `RESEND_API_KEY` and `RESEND_FROM` (e.g. `LoreKit <invites@yourdomain.com>`) in Vercel. Until then, invites keep working exactly as today (in-app only) — the send simply no-ops.

## Scope

No migration, no dependency, no retries/queues/bounce-handling, no non-invite emails. Handle-only invites are intentionally not emailed (no address).

## Verification

`pnpm nx run-many -t typecheck,test,lint --all` → green; the 4-assertion `invite-email` spec passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdsZzQfrSRL9ngAi8rCGWL)_