### PR TITLE
chore(web): trace invite-email sends with OpenTelemetry

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@dash0/sdk-web": "^0.10.1",
+    "@opentelemetry/api": "^1.9.0",
     "@supabase/ssr": "^0.6.0",
     "@supabase/supabase-js": "^2.0.0",
     "@tanstack/react-query": "^5.0.0",

--- a/packages/web/src/lib/invite-email.ts
+++ b/packages/web/src/lib/invite-email.ts
@@ -16,6 +16,8 @@
  * key-less environments simply send nothing.
  */
 
+import { trace, SpanStatusCode } from '@opentelemetry/api';
+
 export interface InviteEmailInput {
   /** invitee_email — the helper no-ops if this is falsy or lacks an '@'. */
   to: string | null;
@@ -31,56 +33,91 @@ const RESEND_ENDPOINT = 'https://api.resend.com/emails';
 const DEFAULT_FROM = 'LoreKit <invites@lorekit.io>';
 const DEFAULT_APP_URL = 'https://lorekit-io.vercel.app';
 
+// The SDK is initialised by @vercel/otel in instrumentation.ts; this only calls
+// the API (no-op tracer if no SDK is registered, e.g. under vitest). The
+// outbound fetch is already auto-instrumented as an HTTP client span — this
+// explicit parent span exists because sendInviteEmail SWALLOWS every failure by
+// contract, so its `lorekit.invite.email.outcome` attribute + recorded
+// exception are the only way to observe a skipped/failed send in production.
+const tracer = trace.getTracer('lorekit.web');
+
+type InviteEmailOutcome = 'sent' | 'skipped_no_recipient' | 'skipped_no_api_key' | 'error';
+
 export async function sendInviteEmail(input: InviteEmailInput): Promise<void> {
-  try {
-    const { to, orgName, role, invitedByLabel } = input;
+  return tracer.startActiveSpan('lorekit.invite.email.send', async (span) => {
+    // Attribute the role but NOT the recipient / org name — those are PII we
+    // deliberately keep off spans.
+    span.setAttribute('lorekit.invite.role', input.role);
 
-    // No address to send to (handle-only invite, or empty) — nothing to do.
-    if (!to || !to.includes('@')) return;
+    const finish = (outcome: InviteEmailOutcome) => {
+      span.setAttribute('lorekit.invite.email.outcome', outcome);
+    };
 
-    const apiKey = process.env['RESEND_API_KEY'];
-    if (!apiKey) {
-      console.debug('[sendInviteEmail] RESEND_API_KEY unset — skipping invite email');
-      return;
+    try {
+      const { to, orgName, role, invitedByLabel } = input;
+
+      // No address to send to (handle-only invite, or empty) — nothing to do.
+      if (!to || !to.includes('@')) {
+        finish('skipped_no_recipient');
+        return;
+      }
+
+      const apiKey = process.env['RESEND_API_KEY'];
+      if (!apiKey) {
+        finish('skipped_no_api_key');
+        console.debug('[sendInviteEmail] RESEND_API_KEY unset — skipping invite email');
+        return;
+      }
+
+      const from = process.env['RESEND_FROM'] ?? DEFAULT_FROM;
+      const base = process.env['NEXT_PUBLIC_APP_URL'] ?? DEFAULT_APP_URL;
+      const link = `${base}/dashboard`;
+
+      const invitedBy = invitedByLabel ? `${invitedByLabel} invited you` : 'You have been invited';
+      const subject = `You've been invited to ${orgName} on LoreKit`;
+
+      const text = [
+        `${invitedBy} to join ${orgName} on LoreKit as a ${role}.`,
+        '',
+        `Sign in with GitHub to accept: ${link}`,
+        '',
+        'LoreKit — shared, persistent memory for your agents.',
+      ].join('\n');
+
+      const html = [
+        `<p>${escapeHtml(invitedBy)} to join <strong>${escapeHtml(orgName)}</strong> on LoreKit as a <strong>${escapeHtml(role)}</strong>.</p>`,
+        `<p><a href="${escapeHtml(link)}">Sign in with GitHub to accept</a></p>`,
+        `<p style="color:#888;font-size:12px">LoreKit — shared, persistent memory for your agents.</p>`,
+      ].join('');
+
+      const res = await fetch(RESEND_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ from, to: [to], subject, text, html }),
+      });
+
+      if (!res.ok) {
+        // Non-fatal: record and move on. The invite already exists in the DB.
+        finish('error');
+        span.setAttribute('lorekit.invite.email.status_code', res.status);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: `resend responded ${res.status}` });
+        console.error(`[sendInviteEmail] Resend responded ${res.status}`);
+        return;
+      }
+
+      finish('sent');
+    } catch (err) {
+      finish('error');
+      span.recordException(err as Error);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message });
+      console.error('[sendInviteEmail] failed:', (err as Error).message);
+    } finally {
+      span.end();
     }
-
-    const from = process.env['RESEND_FROM'] ?? DEFAULT_FROM;
-    const base = process.env['NEXT_PUBLIC_APP_URL'] ?? DEFAULT_APP_URL;
-    const link = `${base}/dashboard`;
-
-    const invitedBy = invitedByLabel ? `${invitedByLabel} invited you` : 'You have been invited';
-    const subject = `You've been invited to ${orgName} on LoreKit`;
-
-    const text = [
-      `${invitedBy} to join ${orgName} on LoreKit as a ${role}.`,
-      '',
-      `Sign in with GitHub to accept: ${link}`,
-      '',
-      'LoreKit — shared, persistent memory for your agents.',
-    ].join('\n');
-
-    const html = [
-      `<p>${escapeHtml(invitedBy)} to join <strong>${escapeHtml(orgName)}</strong> on LoreKit as a <strong>${escapeHtml(role)}</strong>.</p>`,
-      `<p><a href="${escapeHtml(link)}">Sign in with GitHub to accept</a></p>`,
-      `<p style="color:#888;font-size:12px">LoreKit — shared, persistent memory for your agents.</p>`,
-    ].join('');
-
-    const res = await fetch(RESEND_ENDPOINT, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ from, to: [to], subject, text, html }),
-    });
-
-    if (!res.ok) {
-      // Non-fatal: log and move on. The invite already exists in the DB.
-      console.error(`[sendInviteEmail] Resend responded ${res.status}`);
-    }
-  } catch (err) {
-    console.error('[sendInviteEmail] failed:', (err as Error).message);
-  }
+  });
 }
 
 /** Minimal HTML-entity escaping for interpolated values in the email body. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       '@dash0/sdk-web':
         specifier: ^0.10.1
         version: 0.10.1(rollup@4.62.2)
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
       '@supabase/ssr':
         specifier: ^0.6.0
         version: 0.6.1(@supabase/supabase-js@2.110.8)


### PR DESCRIPTION
## Why

Follow-up to #104. `sendInviteEmail` is **non-throwing by contract** — it swallows every failure (bad key, unverified domain, network error) so an email problem can never break the invite that already succeeded. The flip side: a failed or skipped send is **invisible** without telemetry. This wires OpenTelemetry so those outcomes are observable in production.

## What

- Wraps the send in an explicit **`lorekit.invite.email.send`** span with a bounded **`lorekit.invite.email.outcome`** attribute (`sent` | `skipped_no_recipient` | `skipped_no_api_key` | `error`), plus `lorekit.invite.role`. On failure it records the exception and sets `SpanStatusCode.ERROR` (and `status_code` for a non-2xx Resend response).
- **Privacy:** the recipient email and org name are deliberately kept *off* the span (PII) — only the role and outcome are attributed, consistent with the codebase's `lorekit.*` custom-attribute conventions.
- Adds **`@opentelemetry/api`** as a direct `@lorekit/web` dependency (it was a phantom transitive; pinned `^1.9.0` to match `mcp-core`/`mcp-server`). The SDK itself is already initialised by `@vercel/otel` in `instrumentation.ts`; this module only calls the API (no-op tracer when no SDK is registered, e.g. under vitest).

## Note

The outbound `fetch` to Resend was *already* auto-instrumented by `@vercel/otel` as an HTTP client span — this adds the **named parent span + outcome semantics** so the deliberately-silent side effect is legible in traces, not just an anonymous HTTP call.

## Verification

`pnpm nx run-many -t typecheck,test,lint --all` → green; frozen-lockfile install verified; the existing 4-assertion `invite-email` spec still passes (the no-op tracer under vitest leaves the fetch-called / non-throwing assertions unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdsZzQfrSRL9ngAi8rCGWL)_