### PR TITLE
fix(orgs): address review feedback from #103 and #104

### DIFF
--- a/packages/web/src/components/dashboard/OrganizationManager.tsx
+++ b/packages/web/src/components/dashboard/OrganizationManager.tsx
@@ -200,7 +200,7 @@ function CreateOrgForm({
 
 // ── Invite form ───────────────────────────────────────────────────────────────
 
-function InviteForm({ orgId, onInvited }: { orgId: string; onInvited: (invite: OrgInvite) => void }) {
+function InviteForm({ orgId, orgName, onInvited }: { orgId: string; orgName: string; onInvited: (invite: OrgInvite) => void }) {
   const { showToast } = useToast();
   const [input, setInput] = useState('');
   const [role, setRole] = useState<Exclude<OrgRole, 'owner'>>('member');
@@ -217,7 +217,7 @@ function InviteForm({ orgId, onInvited }: { orgId: string; onInvited: (invite: O
     }
 
     startTransition(async () => {
-      const result = await inviteMember(orgId, classified.value, role);
+      const result = await inviteMember(orgId, classified.value, role, orgName);
       if ('error' in result) {
         setError(result.error);
         return;
@@ -408,10 +408,20 @@ export function OrganizationManager({ initialOrgs, currentUserId }: Organization
       const anchor = document.createElement('a');
       anchor.href = url;
       anchor.download = `lorekit-${org.slug}-lore.json`;
+      // Append to the DOM (Firefox requires the anchor be in the document to
+      // dispatch the click), and defer cleanup: revoking the object URL
+      // synchronously after click() aborts the download in Safari before the
+      // browser has queued it.
+      document.body.appendChild(anchor);
       anchor.click();
-      URL.revokeObjectURL(url);
+      setTimeout(() => {
+        anchor.remove();
+        URL.revokeObjectURL(url);
+      }, 100);
       showToast(
-        `Exported ${result.rows.length} ${result.rows.length === 1 ? 'memory' : 'memories'}.`,
+        result.truncated
+          ? `Exported the first ${result.rows.length} memories (export is capped).`
+          : `Exported ${result.rows.length} ${result.rows.length === 1 ? 'memory' : 'memories'}.`,
         'success',
       );
     });
@@ -628,7 +638,7 @@ export function OrganizationManager({ initialOrgs, currentUserId }: Organization
           </div>
 
           {/* Invite form — invite/admin+owner only */}
-          {caps?.canInvite && <InviteForm orgId={selectedOrg.id} onInvited={handleInvited} />}
+          {caps?.canInvite && <InviteForm orgId={selectedOrg.id} orgName={selectedOrg.name} onInvited={handleInvited} />}
 
           {/* Pending invites */}
           {pendingInvites.length > 0 && (

--- a/packages/web/src/lib/invite-email.spec.ts
+++ b/packages/web/src/lib/invite-email.spec.ts
@@ -53,6 +53,26 @@ describe('sendInviteEmail', () => {
     }
   });
 
+  it('HTML-escapes the org name in the html body (no raw markup injection)', async () => {
+    process.env['RESEND_API_KEY'] = 'test-key';
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await sendInviteEmail({
+      to: 'invitee@example.com',
+      orgName: 'Acme & <b>Partners</b>',
+      role: 'member',
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    // The html body must carry the escaped form, never the raw tags/ampersand.
+    expect(body.html).toContain('Acme &amp; &lt;b&gt;Partners&lt;/b&gt;');
+    expect(body.html).not.toContain('<b>Partners</b>');
+    // The plain-text body carries the org name verbatim (not HTML).
+    expect(body.text).toContain('Acme & <b>Partners</b>');
+  });
+
   it('no-ops (no fetch) when RESEND_API_KEY is unset', async () => {
     delete process.env['RESEND_API_KEY'];
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });

--- a/packages/web/src/lib/invite-email.ts
+++ b/packages/web/src/lib/invite-email.ts
@@ -70,6 +70,13 @@ export async function sendInviteEmail(input: InviteEmailInput): Promise<void> {
       }
 
       const from = process.env['RESEND_FROM'] ?? DEFAULT_FROM;
+      // NEXT_PUBLIC_APP_URL is the app's single canonical base URL. It's a
+      // NEXT_PUBLIC_* var (also readable in the browser bundle), but it holds
+      // the same public origin the email link needs, and it's already set to the
+      // real deployment URL in prod. Reusing it avoids a second server-only
+      // APP_URL that would have to be kept in sync; there's no secret here (the
+      // dashboard origin is public), so the client/server distinction doesn't
+      // matter for this value.
       const base = process.env['NEXT_PUBLIC_APP_URL'] ?? DEFAULT_APP_URL;
       const link = `${base}/dashboard`;
 

--- a/packages/web/src/lib/org-invites.ts
+++ b/packages/web/src/lib/org-invites.ts
@@ -69,6 +69,13 @@ export async function inviteMember(
   orgId: string,
   handleOrEmail: string,
   role: Exclude<OrgRole, 'owner'>,
+  /**
+   * The org's display name, for the invite email subject. The dashboard call
+   * site already has it in state, so passing it here skips a DB round-trip. When
+   * omitted (or blank), it's resolved from the DB, then falls back to slug /
+   * generic — the email is never blocked on the name.
+   */
+  orgName?: string,
 ): Promise<{ inviteId: string } | { error: string }> {
   const supabase = await createServerClient();
   const { data: { user } } = await supabase.auth.getUser();
@@ -97,18 +104,21 @@ export async function inviteMember(
   // Fire the notification email for email invites only (a handle-only invite
   // has no address). Non-blocking and non-throwing — sendInviteEmail swallows
   // every failure, so a bad key / unverified domain never breaks the invite
-  // that already succeeded above. Resolve the org name (RLS-scoped; the caller
-  // is a member) for the subject line, falling back to slug then a generic.
+  // that already succeeded above. Prefer the caller-supplied org name; only
+  // hit the DB when it wasn't passed.
   if (isEmail) {
-    const { data: org } = await supabase
-      .from('orgs')
-      .select('name, slug')
-      .eq('id', orgId)
-      .maybeSingle();
-    const orgName = org?.name ?? org?.slug ?? 'your organization';
+    let resolvedName = orgName?.trim() ?? '';
+    if (!resolvedName) {
+      const { data: org } = await supabase
+        .from('orgs')
+        .select('name, slug')
+        .eq('id', orgId)
+        .maybeSingle();
+      resolvedName = org?.name ?? org?.slug ?? 'your organization';
+    }
     const invitedByLabel =
       (user.user_metadata?.user_name as string | undefined) ?? user.email ?? null;
-    await sendInviteEmail({ to: trimmed, orgName, role, invitedByLabel });
+    await sendInviteEmail({ to: trimmed, orgName: resolvedName, role, invitedByLabel });
   }
 
   revalidatePath('/settings', 'layout');

--- a/packages/web/src/lib/orgs.ts
+++ b/packages/web/src/lib/orgs.ts
@@ -181,24 +181,41 @@ export async function deleteOrg(orgId: string): Promise<{ error?: string }> {
 }
 
 /**
+ * Hard cap on rows returned by a single {@link exportOrgLore} call. Bounds the
+ * payload so a very large org can't produce a multi-MB response that times out
+ * the action or exhausts client memory. An org at the cap is an edge case
+ * (memory caps are far lower by default); if it's ever hit, `truncated` tells
+ * the caller the export is partial.
+ */
+export const ORG_EXPORT_ROW_LIMIT = 5000;
+
+/**
  * Export an org's shared lore as rows for a client-side JSON download, offered
  * before deletion so an owner can keep a copy. RLS-scoped: only a member of the
  * org gets rows back (both the active and archived read policies match org rows
- * for members, so this returns the full set). Read-only — never mutates.
+ * for members, so this returns the full set). Bounded to {@link
+ * ORG_EXPORT_ROW_LIMIT} rows — `truncated` is true if more exist. Read-only.
  */
-export async function exportOrgLore(orgId: string): Promise<{ rows: MemoryExportRow[] } | { error: string }> {
+export async function exportOrgLore(
+  orgId: string,
+): Promise<{ rows: MemoryExportRow[]; truncated: boolean } | { error: string }> {
   const supabase = await createServerClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return { error: 'Not authenticated' };
 
+  // Fetch one past the cap so we can tell the caller the export was truncated
+  // without a separate count query.
   const { data, error } = await supabase
     .from('memories')
     .select('scope, key, value, tags, created_at, updated_at, archived_at, source_agent, trigger')
     .eq('org_id', orgId)
-    .order('created_at', { ascending: true });
+    .order('created_at', { ascending: true })
+    .limit(ORG_EXPORT_ROW_LIMIT + 1);
 
   if (error) return { error: error.message };
-  return { rows: (data ?? []) as MemoryExportRow[] };
+  const all = (data ?? []) as MemoryExportRow[];
+  const truncated = all.length > ORG_EXPORT_ROW_LIMIT;
+  return { rows: truncated ? all.slice(0, ORG_EXPORT_ROW_LIMIT) : all, truncated };
 }
 
 /**

--- a/supabase/tests/migrations.test.sql
+++ b/supabase/tests/migrations.test.sql
@@ -1304,6 +1304,28 @@ begin
 end;
 $$;
 
+-- ── 33b. Purge works directly on a LIVE org (skipping soft-delete) ──────────
+-- The owner may permanently delete without first soft-deleting; purge is not
+-- gated on deleted_at.
+do $$
+declare v_orgs int;
+begin
+  insert into orgs (id, slug, name, created_by) values
+    ('00000000-0000-0000-0000-0000000000fa', 'sod-live', 'Live Purge Org', '00000000-0000-0000-0000-0000000000a1');
+  insert into org_members (org_id, user_id, role) values
+    ('00000000-0000-0000-0000-0000000000fa', '00000000-0000-0000-0000-0000000000a1', 'owner');
+
+  set local role authenticated;
+  perform set_config('request.jwt.claims',
+    '{"sub":"00000000-0000-0000-0000-0000000000a1","role":"authenticated"}', true);
+  perform lorekit_org_purge('00000000-0000-0000-0000-0000000000fa');
+  reset role;
+
+  select count(*) into v_orgs from orgs where id = '00000000-0000-0000-0000-0000000000fa';
+  assert v_orgs = 0, 'safe-delete: purge must remove a live (never soft-deleted) org too';
+end;
+$$;
+
 rollback;
 
 \echo 'migrations.test.sql: all assertions passed'


### PR DESCRIPTION
Follow-up implementing the review suggestions on #103 (safe org deletion) and #104 (invite emails), both already merged.

## From #103

- **Blob download (was flagged blocking)** — `handleExportLore` now appends the anchor to `document.body` (Firefox requires it) and defers `URL.revokeObjectURL` + `anchor.remove()` behind a `setTimeout(…, 100)`. Revoking the object URL synchronously after `click()` aborts the download in Safari before the browser queues it.
- **`exportOrgLore` bounded** — caps at `ORG_EXPORT_ROW_LIMIT` (5000), fetching one past the cap to set a `truncated` flag (surfaced in the export toast). A very large org can no longer return a multi-MB payload that times out the action or exhausts client memory.
- **New `migrations.test.sql` §33b** — asserts `lorekit_org_purge` works directly on a **live** (never soft-deleted) org, not only on a soft-deleted one.

## From #104

- **Dropped the per-invite org-name round-trip** — `inviteMember` takes an optional `orgName`; the dashboard call site (`InviteForm`) passes `selectedOrg.name`, which it already has in state. Falls back to the DB lookup (then slug, then generic) when not supplied, so the email is never blocked on the name.
- **HTML-escaping test** — a new case with `orgName: 'Acme & <b>Partners</b>'` asserts the html body carries the escaped form (`Acme &amp; &lt;b&gt;…`) and never raw markup, while the text body stays verbatim.
- **Decision comment** on reusing `NEXT_PUBLIC_APP_URL` for the server-side email link (it's the app's single canonical public origin; a server-only `APP_URL` would just duplicate it, and there's no secret in a public dashboard URL).

The "non-ok Resend response isn't traced" note from #104 is already handled by **#105** (the `lorekit.invite.email.send` span records the status code + ERROR status).

## Verification

25 migrations + `migrations.test.sql` (incl. §33b) pass on native Postgres; `pnpm nx run-many -t typecheck,test,lint --all` green; the `invite-email` spec is now 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdsZzQfrSRL9ngAi8rCGWL)_