### PR TITLE
fix(web): move ORG_DELETE_RETENTION_DAYS out of 'use server' file

### DIFF
--- a/packages/web/src/components/dashboard/OrganizationManager.tsx
+++ b/packages/web/src/components/dashboard/OrganizationManager.tsx
@@ -25,7 +25,6 @@ import {
   leaveOrg,
   deleteOrg,
   exportOrgLore,
-  ORG_DELETE_RETENTION_DAYS,
   type OrgMembership,
   type OrgMember,
   type OrgRole,
@@ -33,7 +32,7 @@ import {
 import { inviteMember, listInvites, revokeInvite, type OrgInvite } from '@/lib/org-invites';
 import { listMemberIdentities, type OrgMemberIdentity } from '@/lib/org-members';
 import { normalizeSlug } from '@/lib/org-slug';
-import { roleCapabilities, canActOnOrgMember, classifyInviteInput } from '@/lib/org-ui';
+import { roleCapabilities, canActOnOrgMember, classifyInviteInput, ORG_DELETE_RETENTION_DAYS } from '@/lib/org-ui';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { useToast } from '@/components/providers/ToastProvider';

--- a/packages/web/src/lib/org-ui.ts
+++ b/packages/web/src/lib/org-ui.ts
@@ -8,6 +8,20 @@
 import type { OrgRole } from './orgs';
 import type { OrgInvite } from './org-invites';
 
+// ── Org deletion policy ──────────────────────────────────────────────────────
+
+/**
+ * How long a soft-deleted org (and its shared lore) is retained before it's
+ * eligible for permanent purge. There is no automated purge job yet — this is
+ * the documented intended window, surfaced in the delete confirmation copy so
+ * an owner knows the delete is recoverable. `lorekit_org_purge` is the explicit
+ * permanent-delete path (SQL-only for now, see 00025).
+ *
+ * Lives here (not in the `'use server'` `orgs.ts`) because a "use server" file
+ * may only export async functions — a plain value export is a compile error.
+ */
+export const ORG_DELETE_RETENTION_DAYS = 30;
+
 // ── Role → UI-affordance capability matrix ───────────────────────────────────
 
 export interface OrgRoleCapabilities {

--- a/packages/web/src/lib/orgs.ts
+++ b/packages/web/src/lib/orgs.ts
@@ -51,13 +51,10 @@ export interface OrgMember {
 }
 
 /**
- * How long a soft-deleted org (and its shared lore) is retained before it's
- * eligible for permanent purge. There is no automated purge job yet — this is
- * the documented intended window, surfaced in the delete confirmation copy so
- * an owner knows the delete is recoverable. `lorekit_org_purge` is the explicit
- * permanent-delete path (SQL-only for now, see 00025).
+ * The org-deletion retention window (`ORG_DELETE_RETENTION_DAYS`) lives in the
+ * pure `org-ui.ts` module, not here: a `'use server'` file may only export
+ * async functions, so a plain value export is a compile error.
  */
-export const ORG_DELETE_RETENTION_DAYS = 30;
 
 /** A single org-owned memory row, shaped for the pre-delete JSON export. */
 export interface MemoryExportRow {


### PR DESCRIPTION
A "use server" file may only export async functions. The plain value
export `ORG_DELETE_RETENTION_DAYS` in orgs.ts broke the Vercel
production build ("Only async functions are allowed to be exported in a
'use server' file").

Move the constant to the pure org-ui.ts module (already the home for
the dashboard's UI-facing values) and update OrganizationManager.tsx's
import. The retention window is only ever consumed as UI copy, so
org-ui.ts is its natural home.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P6jykETjKnqbSKjdmBaAPP