### PR TITLE
docs: document organizations, shared lore, deletion & invite emails

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 | [architecture.md](./architecture.md) | All | System diagram, package map, auth tiers, data model |
 | [mcp-tools.md](./mcp-tools.md) | Agents + developers | All 9 MCP tools with request/response examples |
 | [scope-format.md](./scope-format.md) | Agents + developers | Canonical scope string spec and resolution strategy |
+| [org-sharing.md](./org-sharing.md) | Users + operators | Organizations & shared lore: roles, invites, ownership, deletion + recovery, invite emails |
 | [api-tokens.md](./api-tokens.md) | Developers | Token types, permissions, generation, CI usage |
 | [limits.md](./limits.md) | Agents + developers | Memory cap, rate limiting, per-user overrides, 429 semantics |
 | [otel.md](./otel.md) | Developers | Dash0 setup, custom spans, environment variables |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -81,7 +81,7 @@ Authorization: Bearer <token>
             → user-scoped DB client (RLS enforced automatically)
 ```
 
-**Key security invariant:** API key auth uses the service-role client (bypasses RLS), but **every query** includes `.eq('user_id', userId)` so users cannot access each other's memories.
+**Key security invariant:** API key auth uses the service-role client (bypasses RLS), so **every read is tenant-scoped in app code** — to the caller's own `user_id` **or** an org they belong to — through the single `applyTenantScope` predicate ([Organizations](#organizations)). A user can never read another user's personal memories, or an org's memories unless they're a member.
 
 ---
 
@@ -92,7 +92,9 @@ Authorization: Bearer <token>
 | Column | Type | Notes |
 |--------|------|-------|
 | `id` | uuid | PK |
-| `user_id` | uuid | References `auth.users`. Null for CI/service writes (but not for API token writes). |
+| `user_id` | uuid | References `auth.users`. Null for CI/service writes **and for org-owned rows** (but not for personal API-token writes). |
+| `org_id` | uuid | FK → `orgs(id)`, nullable. Set for org-owned (shared) lore, null for personal. See [Organizations](#organizations). |
+| `created_by` / `updated_by` | uuid | Author attribution for org-owned rows (which keep `user_id` null) — powers "last updated by @handle". |
 | `scope` | text | Canonical scope string — see [scope-format.md](./scope-format.md) |
 | `key` | text | Lesson identifier |
 | `value` | text | Lesson body (markdown, max 64 KB) |
@@ -103,7 +105,10 @@ Authorization: Bearer <token>
 | `created_at` | timestamptz | |
 | `updated_at` | timestamptz | Auto-updated by trigger |
 
-Unique constraint: `(user_id, scope, key)`.
+Uniqueness is partitioned across three mutually-exclusive partial indexes so the
+three ownership kinds never collide: org-owned (`org_id, scope, key`), personal
+(`user_id, scope, key` where `org_id is null`), and service/CI (`scope, key`
+where both are null).
 
 ### `api_tokens` table
 
@@ -157,6 +162,39 @@ piece. Migration `00012_audit_log_search.sql` adds the supporting indexes: a
 doesn't degrade to a sequential scan) and a `(user_id, created_at desc, id)`
 index covering the keyset seek (00010's `(user_id, created_at desc)` index
 lacks the `id` tiebreaker the keyset predicate needs).
+
+### Organizations
+
+Organizations let a team share one authoritative set of memories (see the
+user/operator guide, [org-sharing.md](./org-sharing.md)). Two tables back it:
+`orgs` (name, slug, and a nullable `deleted_at` soft-delete marker) and
+`org_members` (a `(org, user)` row with a `role` of `owner`/`admin`/`member`/`viewer`).
+
+**One tenant-visibility predicate.** Which orgs a user can see lives in exactly
+one place: the `SECURITY DEFINER` function `lorekit_member_org_ids(user)`. Both
+the `memories` read RLS policies and the edge API-key read path
+(`applyTenantScope`, mirrored between `packages/mcp-core` and the edge function)
+consume it, so widening visibility to org membership was a single change and
+can't drift. This is why the earlier "every query filters `user_id`" invariant
+is now "reads are scoped to `user_id` **OR** an org the caller belongs to" — the
+`org_id in (lorekit_member_org_ids(auth.uid()))` branch is that predicate.
+
+**Membership writes go through RPCs, not RLS.** `orgs`/`org_members`/`org_invites`
+carry no insert/update/delete RLS policy; every state transition (create, invite,
+accept/decline, role change, remove, leave, delete) is a `SECURITY DEFINER` RPC
+that resolves the actor as `auth.uid()` and gates on `lorekit_org_can`. This
+avoids the owner-bootstrap footgun (a self-insert-as-owner policy would let
+anyone seize any org) and keeps invite-accept atomic.
+
+**Deletion is a soft-delete.** `lorekit_org_delete` stamps `orgs.deleted_at`
+rather than removing the row; `lorekit_member_org_ids` excludes soft-deleted
+orgs, so the org's lore vanishes from every read at once while staying
+recoverable. A separate owner-only `lorekit_org_purge` does the real cascading
+delete. See [org-sharing.md](./org-sharing.md#deleting-an-organization-and-getting-it-back).
+
+Org writes are authorization-derived: `memory_write` accepts an org slug but
+requires `lorekit_org_can(writer, org, 'write')` inside the RPC — the org is
+never trusted from the caller.
 
 ---
 

--- a/docs/org-sharing.md
+++ b/docs/org-sharing.md
@@ -1,0 +1,136 @@
+# Organizations & shared lore
+
+By default every memory is **personal** — visible only to the user (or token)
+that wrote it. **Organizations** let a team share one authoritative set of
+lessons: an org owns the rows, and every member reads and writes the same
+shared lore.
+
+This is **org-first**, not copy-on-share. There is a single shared row owned by
+the org — not a personal copy fanned out to each member — so an update is seen
+by everyone immediately and nothing drifts out of sync.
+
+> **Audience:** dashboard users setting up sharing, and operators enabling
+> invite emails. For the agent-facing tool parameters (`org` on `memory.write` /
+> `memory.delete`), see [mcp-tools.md](./mcp-tools.md). For the data model and
+> the tenant-visibility invariant, see [architecture.md](./architecture.md#organizations).
+
+---
+
+## Roles & capabilities
+
+Every membership has one role. Capabilities are cumulative and enforced
+server-side (a single SQL source of truth, `lorekit_org_can`) — the dashboard UI
+only ever mirrors them.
+
+| Role | Read shared lore | Write / archive / restore | Hard-delete lore | Manage members & invites | Rename / delete org |
+|------|:---:|:---:|:---:|:---:|:---:|
+| **viewer** | ✅ | — | — | — | — |
+| **member** | ✅ | ✅ | — | — | — |
+| **admin** | ✅ | ✅ | ✅ | ✅ | — |
+| **owner** | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+Two invariants hold regardless of role:
+
+- An admin may act only on `member`/`viewer` targets — never on an `owner` or
+  another `admin`.
+- The **last remaining owner** can never be removed, demoted, or leave.
+  Ownership is **non-transferable** in v1 (invites can't grant `owner`).
+
+---
+
+## Set up sharing (dashboard)
+
+Everything lives at **Settings → Organization**.
+
+1. **Create an organization.** Give it a name (`Acme Team`) and a URL-safe slug
+   (`acme-team`). You become its **owner**.
+2. **Invite teammates.** Enter a GitHub handle *or* an email address and pick a
+   role. Owner/admin only.
+   - An **email** invite also sends a notification email (if email is
+     configured — see [below](#invite-emails)).
+   - A **handle** invite is in-app only (there's no address to email).
+3. **They accept.** The invitee sees a **pending-invite banner** on their
+   Overview the next time they sign in, plus a badge on the Organization nav
+   item. Accepting adds them to the org; declining clears it.
+4. **Manage.** From the same page an owner/admin can change a member's role,
+   remove a member, revoke a pending invite, or (owner) rename/delete the org.
+   Any member can **leave**.
+
+### A note on how invites are secured
+
+An invite is a *notification*, not access. When someone accepts, the new
+membership row is bound to **their own verified identity** (`auth.uid()`), and
+the invited email/handle is only ever used as a *match target*. So a forwarded
+invite email can only be redeemed by the identity it was actually addressed to —
+never by whoever happens to open the link.
+
+---
+
+## Seeing what's shared
+
+- **Ownership badges.** In the Explorer, an org-owned lesson shows an
+  **ownership badge** next to its scope badge; personal lessons show none.
+- **Ownership filter.** The Explorer has an **All · Personal · {org}** filter so
+  you can narrow the list to your personal lore or a specific org's.
+- **Author & audience.** A lesson's detail panel shows its owning org, who last
+  updated it (`@handle`), and how many members can see it.
+
+## Writing org-owned lore
+
+Agents write org-owned memories by passing the org slug on `memory.write` (the
+`org` parameter — see [mcp-tools.md](./mcp-tools.md#memorywrite)). Ownership is
+**authorization-derived on the server**: the write is accepted only if the
+writer is a write-capable member of that org; it is never trusted from the
+caller. The same applies to `memory.delete`.
+
+> **Planned:** *scope→org binding* — bind a scope (e.g. a repo) to an org so
+> writes under it are routed to the org automatically, without each write naming
+> the org. Not shipped yet; today the `org` slug is explicit per write.
+
+---
+
+## Deleting an organization (and getting it back)
+
+Deletion is **recoverable by design**. Deleting an org does **not** immediately
+destroy anything:
+
+1. **Delete = soft-delete.** The org and its shared lore disappear from every
+   member's view immediately, but the data is retained and **recoverable for 30
+   days** (`ORG_DELETE_RETENTION_DAYS`). The dashboard requires you to **type the
+   org's name** to confirm, and offers an **"Export lore"** JSON download first.
+2. **Purge = permanent.** A separate owner-only operation
+   (`lorekit_org_purge`) performs the real, irreversible delete, cascading the
+   org's memberships, invites, and shared memories away. This is the explicit
+   permanent-delete path; there is no automated purge job yet, so the 30-day
+   window is the intended retention period.
+
+Under the hood, a soft-deleted org vanishes from all reads through a single
+change to the tenant-visibility predicate — see
+[architecture.md](./architecture.md#organizations).
+
+---
+
+## Invite emails
+
+When you invite someone **by email**, LoreKit sends a transactional notification
+email (via [Resend](https://resend.com)) that deep-links to the dashboard, where
+they sign in with GitHub and accept. There's no magic-link token — the email is
+just a nudge to the in-app flow.
+
+Email is **optional and off until configured**. With no API key set, invites
+still work exactly as before (in-app only), and the send simply no-ops — it can
+never break the invite itself.
+
+**To enable it** (operators), set two env vars in the web app (Vercel):
+
+| Variable | Purpose |
+|----------|---------|
+| `RESEND_API_KEY` | Your Resend API key. Unset → no emails, invites stay in-app. |
+| `RESEND_FROM` | Verified sending address, e.g. `LoreKit <invites@yourdomain.com>`. |
+
+You must **verify a sending domain in Resend** first. See
+[deployment.md](./deployment.md) for the full env-var list. The send is
+instrumented — a `lorekit.invite.email.send` span with an
+`outcome` attribute (`sent` / `skipped_no_recipient` / `skipped_no_api_key` /
+`error`) makes a failed or skipped send observable
+([otel.md](./otel.md#invite-email-span)).

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -84,6 +84,31 @@ never read/query/manage). Leave `DEFAULT_TOKEN` empty to keep default export off
 
 ---
 
+## Invite-email span
+
+The org-invite email send (`packages/web/src/lib/invite-email.ts`) is a
+deliberately **non-throwing** side effect — it swallows every failure so a bad
+key or unverified domain can't break the invite. That makes telemetry the *only*
+way to see a failed or skipped send, so it carries an explicit span even though
+`@vercel/otel` already auto-instruments the outbound Resend `fetch`.
+
+```
+lorekit.invite.email.send   (INTERNAL — one per email-invite send attempt)
+```
+
+| Attribute | Example | Notes |
+|-----------|---------|-------|
+| `lorekit.invite.role` | `member` | Role the invitee was offered |
+| `lorekit.invite.email.outcome` | `sent` | Bounded: `sent` \| `skipped_no_recipient` \| `skipped_no_api_key` \| `error` |
+| `lorekit.invite.email.status_code` | `422` | Only on a non-2xx Resend response |
+
+On failure the span also records the exception and sets `ERROR` status. The
+recipient email and org name are deliberately **not** attributed (PII). Group by
+`lorekit.invite.email.outcome` in Dash0 to watch send health; a rising `error`
+rate means the Resend key/domain needs attention.
+
+---
+
 ## Resource attributes
 
 All signals carry these resource attributes:


### PR DESCRIPTION
The org/scope-sharing arc (Phases 1–4, safe deletion #103, invite emails #104, OTel #105) shipped with **no narrative documentation** — `docs/` had zero coverage. This fills the gap.

## New: `docs/org-sharing.md`

The user/operator guide (Diátaxis: explanation + how-to). Covers:
- **Org-first model** (one authoritative shared row, not copy-on-share).
- **Roles & capabilities** table (viewer/member/admin/owner) + the last-owner and admin-can't-touch-admin invariants.
- **Set up sharing** — create org → invite (email or handle) → accept, and how invite security works (membership binds to the accepter's verified identity, invited string is only a match target).
- **Ownership display** — badges + the All·Personal·{org} Explorer filter.
- **Writing org-owned lore** — the `org` slug is authorization-derived server-side; notes scope→org binding as *planned, not shipped* (no aspirational claims).
- **Deletion + recovery** — soft-delete, 30-day retention, type-to-confirm + export-before-delete, and the owner-only purge.
- **Invite emails** — behavior + the `RESEND_API_KEY` / `RESEND_FROM` operator setup.

## Updated

- **`docs/architecture.md`** — added `org_id` / `created_by` / `updated_by` to the `memories` table, corrected the stale uniqueness note (three partitioned indexes) and the auth invariant (reads are widened to org membership via `applyTenantScope`, not `user_id`-only), and added an **Organizations** section (data model, the single `lorekit_member_org_ids` tenant predicate, RPC-only membership writes, soft-delete).
- **`docs/otel.md`** — documented the `lorekit.invite.email.send` span + its bounded `outcome` attribute (from #105).
- **`docs/README.md`** — indexed the new guide.

No content is duplicated from `CLAUDE.md` (which stays the prescriptive agent hot-path); `docs/` owns the narrative. All cross-doc links and anchors verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdsZzQfrSRL9ngAi8rCGWL)_