### PR TITLE
chore(web): bump version to trigger a Vercel deployment

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lorekit/web",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
     "build": "next build",


### PR DESCRIPTION
A minimal `@lorekit/web` version bump (`0.0.1 → 0.0.2`) to force a fresh Vercel build/deploy — e.g. so newly-set environment variables (`RESEND_API_KEY` / `RESEND_FROM`, for invite emails) are picked up, since env changes only take effect on the next deploy.

- Opening this PR triggers a **Vercel preview** deployment immediately.
- **Merging** it triggers the **production** promotion pipeline (`deploy.yml`) so prod redeploys with the current env.

`release-please` only manages `@lorekit/cli`, so this version bump doesn't affect any release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdsZzQfrSRL9ngAi8rCGWL)_