### PR TITLE
fix(web): drop export on ORG_EXPORT_ROW_LIMIT in 'use server' file

### DIFF
--- a/packages/web/src/lib/orgs.ts
+++ b/packages/web/src/lib/orgs.ts
@@ -183,8 +183,12 @@ export async function deleteOrg(orgId: string): Promise<{ error?: string }> {
  * the action or exhausts client memory. An org at the cap is an edge case
  * (memory caps are far lower by default); if it's ever hit, `truncated` tells
  * the caller the export is partial.
+ *
+ * Not exported: it's used only by {@link exportOrgLore} below, and a
+ * `'use server'` file may export async functions only — a value export is a
+ * compile error.
  */
-export const ORG_EXPORT_ROW_LIMIT = 5000;
+const ORG_EXPORT_ROW_LIMIT = 5000;
 
 /**
  * Export an org's shared lore as rows for a client-side JSON download, offered


### PR DESCRIPTION
## Problem

The Vercel production build for `@lorekit/web` is failing on `main`:

```
./src/lib/orgs.ts
Error:   x Only async functions are allowed to be exported in a "use server" file.
187 | export const ORG_EXPORT_ROW_LIMIT = 5000;
```

A file with the top-level `'use server'` directive may only export **async functions**. `orgs.ts` exported the plain value `ORG_EXPORT_ROW_LIMIT`, which SWC rejects.

This is the same class of bug as #107 (`ORG_DELETE_RETENTION_DAYS`), which was reintroduced by a later change adding a second value export.

## Fix

`ORG_EXPORT_ROW_LIMIT` is used **only inside `orgs.ts`** (as `exportOrgLore`'s query cap) and is not imported anywhere else. The `'use server'` restriction applies to *exports* only, so the minimal, correct fix is to make it a module-local `const` — no relocation to another module needed.

## Verification

Built the web package locally with the exact command Vercel runs:

```
pnpm nx build web --configuration=production   # ✓ Successfully ran target build for project web
pnpm nx typecheck web                          # ✓ passes
```

The build now compiles all 14 routes successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P6jykETjKnqbSKjdmBaAPP)_