### PR TITLE
docs: optimize root and CLI READMEs for above-the-fold clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
+<div align="center">
+
+<img width="120" height="120" alt="LoreKit logo" src="https://github.com/user-attachments/assets/d65ac2d4-0a52-483b-9efe-427dfa45c026" />
+
 # LoreKit
 
-> Shared, persistent memory for your AI coding agents.
+**Shared, persistent memory for your AI coding agents.**
+
+Your agent solves something once — a migration gotcha, a flaky-test fix, why the
+build breaks only on CI — and **remembers it in every session after, on every
+machine, across every tool.** One `npx` command to connect; works with Claude
+Code, Cursor, Codex, or any MCP client.
 
 [![Deploy](https://github.com/mthines/lorekit/actions/workflows/deploy.yml/badge.svg?branch=main)](https://github.com/mthines/lorekit/actions/workflows/deploy.yml)
 [![npm](https://img.shields.io/npm/v/@lorekit/cli.svg)](https://www.npmjs.com/package/@lorekit/cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 
-Your coding agent figures something out — the migration pattern you keep
-forgetting to mention, the fix for that flaky test, the reason a build breaks on
-CI but not locally. Then the session ends, and it forgets. Tomorrow you explain
-it again.
+</div>
 
-LoreKit gives your agents a memory that outlives the session. Lessons are
-written once and recalled everywhere: your machine, your teammates' machines,
-CI, and whichever tool you happen to be using that day.
+```bash
+npx @lorekit/cli install     # connect your agent — full setup below
+```
 
 ```
                    ┌─ your agent, any tool, any machine ─┐
@@ -23,9 +29,10 @@ CI, and whichever tool you happen to be using that day.
   time it needs it └─────────────────────────────────────┘
 ```
 
-## The problem you have right now
+## The problem: your agents forget everything
 
-If you use AI coding agents daily, you're paying a quiet tax:
+Every coding agent starts each session with total amnesia. If you use them
+daily, that costs you:
 
 - **Every session starts from zero.** The agent that just untangled a tricky bug
   has no memory of it an hour later. You re-explain the same context, over and
@@ -199,6 +206,4 @@ package, see [DEVELOPMENT.md](./DEVELOPMENT.md).
 ## License
 
 [MIT](./LICENSE) © LoreKit contributors.
-
-<img width="128" height="128" alt="lorekit-logo-2" src="https://github.com/user-attachments/assets/d65ac2d4-0a52-483b-9efe-427dfa45c026" />
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,26 +1,33 @@
 # @lorekit/cli
 
-Install the **LoreKit shared-memory skill** into a project and run health
-checks against your LoreKit MCP server — a small, zero-dependency Node CLI.
+> The fastest way to give your AI coding agent a memory that survives the session.
 
-LoreKit gives coding agents a shared, persistent memory: lessons one agent
-learns are stored centrally and read by every other agent, in every session,
-CI included. This CLI wires an agent up to it in two commands.
+[![npm](https://img.shields.io/npm/v/@lorekit/cli.svg)](https://www.npmjs.com/package/@lorekit/cli)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](../../LICENSE)
 
-## Install
+[LoreKit](https://github.com/mthines/lorekit) gives coding agents a **shared,
+persistent memory**: a lesson one agent learns — a migration gotcha, a
+flaky-test fix, a costly wrong assumption — is stored once and recalled by every
+other agent, in every session, on every machine, CI included.
 
-Install it globally — recommended. You get one pinned version, the `lorekit`
-command stays on your `PATH`, and the plugin hooks (which call `lorekit hook`
-on every lifecycle event) fire instantly instead of paying an `npx` resolution
-cost each time:
+This is the CLI that connects your agent to it. One command scaffolds
+everything — the memory skill, the MCP connection, and the lifecycle hooks — and
+it's a zero-dependency Node binary that also runs fully offline against local
+markdown files if you never want to sign up for anything.
 
 ```bash
 npm install -g @lorekit/cli
-lorekit install
-lorekit doctor
+lorekit install     # wires up the skill, MCP server, and hooks
+lorekit doctor      # verify it's all green
 ```
 
-Upgrade later with `npm install -g @lorekit/cli@latest`.
+## Install
+
+The quickstart above uses the **global install — recommended.** You get one
+pinned version, the `lorekit` command stays on your `PATH`, and the plugin hooks
+(which call `lorekit hook` on every lifecycle event) fire instantly instead of
+paying an `npx` resolution cost each time. Upgrade later with
+`npm install -g @lorekit/cli@latest`.
 
 Prefer not to install anything? Run it on demand with `npx` — same commands,
 always the latest version, fetched and cached per use:


### PR DESCRIPTION
Lead with what LoreKit does and why in the first viewport, per the
standard-readme above-the-fold rule:

- Root: hero logo + one-sentence what/why + a copy-pasteable install
  line moved above the fold (logo was buried at EOF, first install was
  ~80 lines down); de-duplicate the problem statement into one section.
- CLI: add a tagline and npm/license trust badges, lead with the value
  prop instead of "run health checks", and add a quickstart block;
  trim the now-duplicate install commands out of the Install section.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DSHRuTRDyN3stjnHAJkxrX