### PR TITLE
fix(mcp): return authz denials as HTTP 200, not 401 (stops client hang)

### DIFF
--- a/packages/mcp-core/src/mcp-authz-status.spec.ts
+++ b/packages/mcp-core/src/mcp-authz-status.spec.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+/**
+ * Drift guard: post-authentication AUTHORIZATION denials in the edge tools/call
+ * path must NOT answer HTTP 401.
+ *
+ * Regression for the org.* hang: a valid api_key caller hitting an authz limit
+ * (org.* requires JWT; read-only / write-only token) used to be rejected with
+ * JSON-RPC code -32001, which jsonrpcError maps to HTTP 401. Over the
+ * streamable-HTTP transport a 401 on a tools/call is read by mcp-remote as a
+ * *session* auth failure — it silently retries/reconnects and the caller's
+ * tool-call promise never resolves, so the client hangs (observed ~30 min).
+ *
+ * An authorization denial is an in-band response to an accepted call and must
+ * travel as HTTP 200 with the error in the body (JSONRPC_FORBIDDEN). Only a
+ * genuinely unauthenticated request (-32001, pre-dispatch, null id) may be 401.
+ *
+ * This scans the edge `mcp-handler.ts` source (not mcp-core) because the Deno
+ * edge function can't be imported under vitest — same approach as
+ * tenant-scope-usage.spec.ts.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const handlerPath = path.resolve(here, '../../../supabase/functions/mcp/mcp-handler.ts');
+const source = readFileSync(handlerPath, 'utf8');
+
+/** Slice the body of the `if (method === 'tools/call')` block by brace-depth. */
+function extractToolsCallBlock(src: string): string {
+  const marker = src.indexOf("method === 'tools/call'");
+  if (marker === -1) throw new Error("tools/call branch not found in mcp-handler.ts");
+  const bodyStart = src.indexOf('{', marker);
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    if (src[i] === '}' && --depth === 0) return src.slice(bodyStart, i + 1);
+  }
+  throw new Error('could not find end of tools/call block');
+}
+
+describe('mcp-handler authz status guard', () => {
+  it('maps only the unauthenticated code (-32001) to HTTP 401', () => {
+    // The 401 branch exists (drives OAuth retry) and is keyed on -32001 alone.
+    expect(source).toMatch(/code === -32001 \? 401/);
+  });
+
+  it('defines a distinct authorization-denied code mapped to HTTP 200', () => {
+    expect(source).toMatch(/const JSONRPC_FORBIDDEN = -32003;/);
+    // The status expression must send JSONRPC_FORBIDDEN to 200, not 400/401.
+    expect(source).toMatch(/code === JSONRPC_FORBIDDEN \? 200/);
+  });
+
+  it('returns JSONRPC_FORBIDDEN (not -32001) for every authz denial in tools/call', () => {
+    const block = extractToolsCallBlock(source);
+
+    // The three post-auth authorization denials: org.* JWT requirement,
+    // write-permission-missing, read-permission-missing.
+    const forbiddenReturns = block.match(/jsonrpcError\(\s*id,\s*JSONRPC_FORBIDDEN/g) ?? [];
+    expect(forbiddenReturns.length).toBe(3);
+
+    // No authorization denial may fall back to the 401 code: no jsonrpcError
+    // call site in the tools/call block may pass -32001. (Comments referencing
+    // -32001 are fine — this targets actual return sites, not documentation.)
+    expect(block).not.toMatch(/jsonrpcError\(\s*id,\s*-32001/);
+  });
+});

--- a/supabase/functions/mcp/mcp-handler.ts
+++ b/supabase/functions/mcp/mcp-handler.ts
@@ -57,10 +57,32 @@ function jsonrpc(id: unknown, result: unknown): Response {
   });
 }
 
+/**
+ * JSON-RPC error code for an *authenticated* caller that lacks permission for a
+ * specific tool — an authorization failure, NOT an authentication failure.
+ *
+ * Deliberately distinct from the pre-dispatch Unauthorized code (-32001). The
+ * HTTP status carries transport-level auth state; the JSON-RPC code carries
+ * application state. Only a genuinely unauthenticated request (-32001, emitted
+ * with a null id before dispatch) may answer HTTP 401 — that status is what
+ * drives an MCP client's OAuth retry. An authorization denial is an in-band
+ * response to an accepted tool call and MUST travel as HTTP 200 with the error
+ * in the body. Answering 401 here makes streamable-HTTP MCP clients (e.g.
+ * mcp-remote) treat the whole session as unauthenticated and silently
+ * retry/reconnect — the caller's tool-call promise never resolves and the
+ * client hangs indefinitely instead of surfacing the error.
+ */
+const JSONRPC_FORBIDDEN = -32003;
+
 export function jsonrpcError(id: unknown, code: number, message: string): Response {
+  // -32001 (Unauthorized, pre-dispatch) → 401 to trigger client reauth.
+  // JSONRPC_FORBIDDEN (authenticated-but-denied) → 200 so the JSON-RPC error is
+  // delivered in-band rather than read as a transport auth failure (which hangs
+  // mcp-remote). Everything else is a bad/failed request → 400.
+  const status = code === -32001 ? 401 : code === JSONRPC_FORBIDDEN ? 200 : 400;
   return new Response(
     JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } }),
-    { status: code === -32001 ? 401 : 400, headers: { 'Content-Type': 'application/json' } },
+    { status, headers: { 'Content-Type': 'application/json' } },
   );
 }
 
@@ -247,25 +269,35 @@ export async function handleMcp(req: Request, auth: AuthContext, span: Span): Pr
     if (isOrgTool) {
       // org.* tools require a Supabase user JWT so auth.uid() resolves inside
       // the SECURITY DEFINER RPCs. Reject api_key and service callers.
+      // This is an AUTHORIZATION denial (the caller authenticated fine) → it
+      // must be JSONRPC_FORBIDDEN (HTTP 200), never -32001 (HTTP 401), or the
+      // MCP client hangs. See jsonrpcError().
       if (!isJwtAuth(auth)) {
-        span.error('PermissionDenied: org.* requires JWT auth');
+        span
+          .error('PermissionDenied: org.* requires JWT auth')
+          .setAttributes({ 'authz.result': 'denied', 'authz.reason': 'jwt_required' });
         return jsonrpcError(
           id,
-          -32001,
+          JSONRPC_FORBIDDEN,
           'org.* tools require Supabase JWT authentication. ' +
             'They are not available via API token — connect via the dashboard or a Supabase user session.',
         );
       }
     } else {
       // memory.* permission check (api_key auth only; JWT auth is RLS-gated).
+      // Authenticated-but-insufficient-scope → JSONRPC_FORBIDDEN (HTTP 200).
       const requiredPermission = toolRequires(toolName as keyof typeof MEMORY_TOOLS);
       if (requiredPermission === 'write' && !canWrite(auth)) {
-        span.error('PermissionDenied: read-only token');
-        return jsonrpcError(id, -32001, 'This token does not have write permission. Use a read+write (lk_rw_) or write-only (lk_wo_) token.');
+        span
+          .error('PermissionDenied: read-only token')
+          .setAttributes({ 'authz.result': 'denied', 'authz.reason': 'write_permission_missing' });
+        return jsonrpcError(id, JSONRPC_FORBIDDEN, 'This token does not have write permission. Use a read+write (lk_rw_) or write-only (lk_wo_) token.');
       }
       if (requiredPermission === 'read' && !canRead(auth)) {
-        span.error('PermissionDenied: write-only token');
-        return jsonrpcError(id, -32001, 'This token does not have read permission. Use a read+write (lk_rw_) or read-only (lk_ro_) token.');
+        span
+          .error('PermissionDenied: write-only token')
+          .setAttributes({ 'authz.result': 'denied', 'authz.reason': 'read_permission_missing' });
+        return jsonrpcError(id, JSONRPC_FORBIDDEN, 'This token does not have read permission. Use a read+write (lk_rw_) or read-only (lk_ro_) token.');
       }
     }
 


### PR DESCRIPTION
## Problem

Calling any `org.*` MCP tool with an `lk_rw_*` **api_key** token makes the MCP client (mcp-remote → Claude Code) **hang indefinitely** (~30 min, needs manual interrupt) instead of returning an error.

## Root cause

`org.*` requires a Supabase JWT (for `auth.uid()` in the SECURITY DEFINER RPCs), so an api_key caller is correctly denied — but the denial returned JSON-RPC code `-32001`, which `jsonrpcError` maps to **HTTP 401**. Over streamable-HTTP, a 401 on a `tools/call` is read by mcp-remote as a *session* authentication failure: it silently retries/reconnects and the caller's tool-call promise never resolves → hang. The same path affected read-only / write-only `memory.*` token denials.

An authorization denial (authenticated, but insufficient scope) is an **in-band response to an accepted call** and must travel as **HTTP 200 with the JSON-RPC error in the body** — not a transport-level 401.

## Fix

- Introduce `JSONRPC_FORBIDDEN` (`-32003`) mapped to **HTTP 200**; `-32001`/401 now means only genuinely unauthenticated (pre-dispatch), which correctly drives client reauth.
- Route the three post-auth authorization denials (org.* JWT, write-perm-missing, read-perm-missing) through it.
- **Telemetry:** add `authz.result` / `authz.reason` span attributes so denials are filterable in Dash0 (previously only in the error-message string).
- **Regression test:** source-scan drift guard (mirrors `tenant-scope-usage.spec.ts`) asserting no authz denial returns `-32001` and that `JSONRPC_FORBIDDEN` maps to 200.

## Evidence

Dash0 trace `019f9f6009617e8a9c8931bea0cce9d2` — `mcp.tool.name=org.list`, `http.response.status_code=401`, `auth.type=api_key`, duration 0.6s (server responded fast; the hang was client-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)