### PR TITLE
fix(cli): normalize object exit code on telemetry fast-path (fixes doctor crash blocking deploy)

### DIFF
--- a/packages/cli/src/telemetry.mjs
+++ b/packages/cli/src/telemetry.mjs
@@ -257,6 +257,19 @@ function errorLabel(e) {
 }
 
 /**
+ * Coerce a command handler's return value to a numeric exit code. Commands may
+ * resolve to a bare number, or to an { exitCode, ...extra } object (which lets
+ * them surface bounded diagnostic fields for telemetry); anything else → 0.
+ * Single source of truth for exit-code normalization on both traceCommand paths.
+ * @param {unknown} result
+ * @returns {number}
+ */
+function normalizeExitCode(result) {
+  if (result !== null && typeof result === 'object') return result.exitCode ?? 0;
+  return result ?? 0;
+}
+
+/**
  * Time a human-facing command, record its outcome, and export one span + one
  * counter point. Returns the command's exit code unchanged. Telemetry failures
  * are swallowed — the command result is never affected.
@@ -274,8 +287,13 @@ export async function traceCommand(command, args, version, run) {
     config = { enabled: false };
   }
 
-  // Fast path: no export configured → run with zero overhead.
-  if (!config.enabled) return run();
+  // Fast path: no export configured → run with zero telemetry overhead. Still
+  // normalize the result to a numeric exit code: commands may resolve to an
+  // { exitCode, ...extra } object (e.g. `doctor`), and only the instrumented
+  // path below unwraps it. Returning `run()` raw would leak that object all the
+  // way to `process.exit(obj)` in the bin entry → ERR_INVALID_ARG_TYPE crash
+  // (exit 1) for every user without an OTLP endpoint configured.
+  if (!config.enabled) return normalizeExitCode(await run());
 
   const startMs = Date.now();
   let exitCode = 0;
@@ -287,16 +305,14 @@ export async function traceCommand(command, args, version, run) {
     // Commands may return either a plain exit code (number) or an object with
     // { exitCode, ...extra } — the latter lets commands surface bounded,
     // non-PII diagnostic fields (e.g. which checks failed in `doctor`).
+    exitCode = normalizeExitCode(result);
     if (result !== null && typeof result === 'object') {
-      exitCode = result.exitCode ?? 0;
       const { exitCode: _ec, ...rest } = result;
       // Flatten any array-valued extras to a comma-joined string so they fit
       // the flat attribute bag shape (OTLP stringValue).
       for (const [k, v] of Object.entries(rest)) {
         extraAttrs[k] = Array.isArray(v) ? v.join(',') : v;
       }
-    } else {
-      exitCode = result ?? 0;
     }
     if (typeof exitCode === 'number' && exitCode !== 0) {
       status = 'error';

--- a/packages/cli/test/telemetry.test.mjs
+++ b/packages/cli/test/telemetry.test.mjs
@@ -269,6 +269,29 @@ test('traceCommand runs with zero overhead and no fetch when disabled', async ()
   }
 });
 
+test('traceCommand unwraps an { exitCode } object to a number when disabled', async () => {
+  // Regression: `doctor` resolves to { exitCode, ...diagnostics }. With telemetry
+  // disabled (the common case — no OTLP endpoint), the fast path must still
+  // unwrap it to a number. Returning the raw object let it flow to
+  // process.exit(obj) in bin/lorekit.mjs → ERR_INVALID_ARG_TYPE crash (exit 1),
+  // which broke `doctor --deep` in CI smoke and for every un-instrumented user.
+  const prev = process.env.LOREKIT_TELEMETRY;
+  process.env.LOREKIT_TELEMETRY = 'off';
+  try {
+    const ok = await traceCommand('doctor', { deep: true }, '1.0.0', async () => ({
+      exitCode: 0,
+      'lorekit.cli.doctor.failed_checks': 'none',
+    }));
+    assert.equal(typeof ok, 'number');
+    assert.equal(ok, 0);
+    const failed = await traceCommand('doctor', {}, '1.0.0', async () => ({ exitCode: 1 }));
+    assert.equal(failed, 1);
+  } finally {
+    if (prev === undefined) delete process.env.LOREKIT_TELEMETRY;
+    else process.env.LOREKIT_TELEMETRY = prev;
+  }
+});
+
 test('traceCommand never lets a telemetry failure break the command', async () => {
   const prevHeaders = process.env.OTEL_EXPORTER_OTLP_HEADERS;
   process.env.OTEL_EXPORTER_OTLP_HEADERS = 'Authorization=Bearer test';


### PR DESCRIPTION
## Problem

The preview **smoke gate** in `deploy.yml` (`doctor --deep` live round-trip) crashes and fails every production deploy:

```
LoreKit doctor … Summary  0 failed, 2 warning(s).
Error: TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be of type number. Received an instance of Object
    at process.exit … at packages/cli/bin/lorekit.mjs:297
##[error]Process completed with exit code 1.
```

`doctor` logically **passes** (`0 failed`) but the process still exits 1.

## Root cause

`traceCommand`'s telemetry-disabled fast path returned the handler value raw:

```js
if (!config.enabled) return run();
```

`doctor` resolves to `{ exitCode, ...diagnostics }` (line `doctor.mjs:96`). Only the *instrumented* path unwrapped `.exitCode`; the fast path returned the object, which flowed to `process.exit(code ?? 0)` → `ERR_INVALID_ARG_TYPE`. Since telemetry is disabled whenever no OTLP endpoint is configured (CI smoke, and most end-user machines), `doctor` crashed for them.

## Fix

- Extract `normalizeExitCode()` and apply it on **both** paths (single source of truth), so the fast path unwraps `{ exitCode }` too.
- Regression test: disabled telemetry + a handler returning `{ exitCode }` → `traceCommand` resolves to a **number**.

## Why now

This is the gate that blocks #125 (the org.* 401-hang fix) — and every other deploy — from reaching production. Independent, pre-existing bug surfaced while verifying #125's deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)