### PR TITLE
fix(mcp): bad/missing token fails fast in-band, never hangs the client

### DIFF
--- a/packages/mcp-core/src/mcp-authz-status.spec.ts
+++ b/packages/mcp-core/src/mcp-authz-status.spec.ts
@@ -4,65 +4,71 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
 /**
- * Drift guard: post-authentication AUTHORIZATION denials in the edge tools/call
- * path must NOT answer HTTP 401.
+ * Drift guard: the edge MCP endpoint must never answer an auth error with HTTP
+ * 401, and must never emit an auth error with a null JSON-RPC id.
  *
- * Regression for the org.* hang: a valid api_key caller hitting an authz limit
- * (org.* requires JWT; read-only / write-only token) used to be rejected with
- * JSON-RPC code -32001, which jsonrpcError maps to HTTP 401. Over the
- * streamable-HTTP transport a 401 on a tools/call is read by mcp-remote as a
- * *session* auth failure — it silently retries/reconnects and the caller's
- * tool-call promise never resolves, so the client hangs (observed ~30 min).
+ * Why: this is a token-based MCP server (no OAuth). A 401 on the MCP endpoint is
+ * read by streamable-HTTP clients (mcp-remote) as a *session* auth failure —
+ * they silently retry/reconnect and the caller's promise never resolves, so the
+ * client hangs (observed ~30 min on org.* with a valid token, and again on a
+ * rotated token). A response with id:null can't be correlated to the pending
+ * call and hangs the same way. Both auth-family errors must therefore travel
+ * IN-BAND: HTTP 200 + a JSON-RPC error carrying the real request id, so the
+ * client surfaces "invalid token" / "requires JWT" fast instead of hanging.
  *
- * An authorization denial is an in-band response to an accepted call and must
- * travel as HTTP 200 with the error in the body (JSONRPC_FORBIDDEN). Only a
- * genuinely unauthenticated request (-32001, pre-dispatch, null id) may be 401.
+ *   -32001            unauthenticated (missing / invalid / rotated token)
+ *   JSONRPC_FORBIDDEN authenticated but not permitted (org.* JWT, token scope)
  *
- * This scans the edge `mcp-handler.ts` source (not mcp-core) because the Deno
- * edge function can't be imported under vitest — same approach as
- * tenant-scope-usage.spec.ts.
+ * These scan the Deno edge sources (which vitest can't import) — same approach
+ * as tenant-scope-usage.spec.ts.
  */
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-const handlerPath = path.resolve(here, '../../../supabase/functions/mcp/mcp-handler.ts');
-const source = readFileSync(handlerPath, 'utf8');
+const edge = (f: string) => readFileSync(path.resolve(here, '../../../supabase/functions/mcp/', f), 'utf8');
+const handler = edge('mcp-handler.ts');
+const index = edge('index.ts');
 
-/** Slice the body of the `if (method === 'tools/call')` block by brace-depth. */
-function extractToolsCallBlock(src: string): string {
-  const marker = src.indexOf("method === 'tools/call'");
-  if (marker === -1) throw new Error("tools/call branch not found in mcp-handler.ts");
-  const bodyStart = src.indexOf('{', marker);
+/** Slice a brace-delimited block starting at the first `{` after `marker`. */
+function blockAfter(src: string, marker: string, label: string): string {
+  const at = src.indexOf(marker);
+  if (at === -1) throw new Error(`${label} not found`);
+  const start = src.indexOf('{', at);
   let depth = 0;
-  for (let i = bodyStart; i < src.length; i++) {
+  for (let i = start; i < src.length; i++) {
     if (src[i] === '{') depth++;
-    if (src[i] === '}' && --depth === 0) return src.slice(bodyStart, i + 1);
+    if (src[i] === '}' && --depth === 0) return src.slice(start, i + 1);
   }
-  throw new Error('could not find end of tools/call block');
+  throw new Error(`could not find end of ${label}`);
 }
 
-describe('mcp-handler authz status guard', () => {
-  it('maps only the unauthenticated code (-32001) to HTTP 401', () => {
-    // The 401 branch exists (drives OAuth retry) and is keyed on -32001 alone.
-    expect(source).toMatch(/code === -32001 \? 401/);
-  });
-
-  it('defines a distinct authorization-denied code mapped to HTTP 200', () => {
-    expect(source).toMatch(/const JSONRPC_FORBIDDEN = -32003;/);
-    // The status expression must send JSONRPC_FORBIDDEN to 200, not 400/401.
-    expect(source).toMatch(/code === JSONRPC_FORBIDDEN \? 200/);
+describe('mcp-handler auth status guard', () => {
+  it('maps both auth-family codes to HTTP 200 and never to 401', () => {
+    expect(handler).toMatch(/const JSONRPC_FORBIDDEN = -32003;/);
+    expect(handler).toMatch(
+      /const status = code === -32001 \|\| code === JSONRPC_FORBIDDEN \? 200 : 400;/,
+    );
+    // No status branch may yield 401 (comments may mention it; code may not).
+    expect(handler).not.toMatch(/[?:]\s*401/);
   });
 
   it('returns JSONRPC_FORBIDDEN (not -32001) for every authz denial in tools/call', () => {
-    const block = extractToolsCallBlock(source);
-
-    // The three post-auth authorization denials: org.* JWT requirement,
-    // write-permission-missing, read-permission-missing.
-    const forbiddenReturns = block.match(/jsonrpcError\(\s*id,\s*JSONRPC_FORBIDDEN/g) ?? [];
-    expect(forbiddenReturns.length).toBe(3);
-
-    // No authorization denial may fall back to the 401 code: no jsonrpcError
-    // call site in the tools/call block may pass -32001. (Comments referencing
-    // -32001 are fine — this targets actual return sites, not documentation.)
+    const block = blockAfter(handler, "method === 'tools/call'", 'tools/call block');
+    const forbidden = block.match(/jsonrpcError\(\s*id,\s*JSONRPC_FORBIDDEN/g) ?? [];
+    expect(forbidden.length).toBe(3); // org.* JWT, write-missing, read-missing
     expect(block).not.toMatch(/jsonrpcError\(\s*id,\s*-32001/);
+  });
+});
+
+describe('index.ts auth-failure guard', () => {
+  it('answers a bad/missing token in-band with a real id and HTTP 200, not 401', () => {
+    const block = blockAfter(index, 'if (!auth)', 'auth-failure block');
+    // Status recorded as 200, never 401.
+    expect(block).toMatch(/'http\.response\.status_code': 200/);
+    expect(block).not.toMatch(/'http\.response\.status_code': 401/);
+    // Echoes the real request id (peeked from the body) — never id:null, which
+    // the client can't correlate and would hang on.
+    expect(block).toMatch(/peekRequestId/);
+    expect(block).toMatch(/jsonrpcError\(\s*reqId,/);
+    expect(block).not.toMatch(/jsonrpcError\(\s*null/);
   });
 });

--- a/supabase/functions/mcp/index.ts
+++ b/supabase/functions/mcp/index.ts
@@ -27,6 +27,23 @@ import { handleMcp, jsonrpcError } from './mcp-handler.ts';
 import { handleWebhook } from './webhook.ts';
 import { checkRateLimit, rateLimitMessage } from './limits.ts';
 
+/**
+ * Best-effort read of the JSON-RPC request id from the body, without disturbing
+ * the caller's stream (uses req.clone()). Used only on the auth-failure path so
+ * the in-band error response can echo the real id — a response with id:null
+ * can't be correlated to the pending tools/call and would hang the client.
+ * Returns null for a missing/invalid id or an unparseable body.
+ */
+async function peekRequestId(req: Request): Promise<string | number | null> {
+  try {
+    const body = await req.clone().json();
+    const id = (body as { id?: unknown })?.id;
+    return typeof id === 'string' || typeof id === 'number' ? id : null;
+  } catch {
+    return null;
+  }
+}
+
 Deno.serve(async (req: Request) => {
   const url = new URL(req.url);
 
@@ -49,8 +66,19 @@ Deno.serve(async (req: Request) => {
     // resolveAuth checks Authorization header first, then ?token= query param as fallback.
     const auth = await resolveAuth(req.headers.get('authorization'), url.searchParams.get('token'));
     if (!auth) {
-      span.setAttributes({ 'auth.result': 'failed', 'http.response.status_code': 401 });
-      return jsonrpcError(null, -32001, 'Unauthorized');
+      // Fail fast on a missing / invalid / rotated token — never hang. Return
+      // the error IN-BAND: HTTP 200 (not 401) with a JSON-RPC error carrying the
+      // REAL request id. A 401 makes streamable-HTTP clients (mcp-remote) treat
+      // it as a session-auth failure and stall; an id:null body can't be matched
+      // to the pending tools/call and also hangs — so we peek the id and echo it.
+      // This is a token-based server with no OAuth flow for a 401 to drive.
+      const reqId = await peekRequestId(req);
+      span.setAttributes({ 'auth.result': 'failed', 'http.response.status_code': 200 });
+      return jsonrpcError(
+        reqId,
+        -32001,
+        'Invalid or unknown API token. Check the token in your LoreKit MCP server URL or config (it may have been rotated).',
+      );
     }
 
     span.setAttributes({

--- a/supabase/functions/mcp/mcp-handler.ts
+++ b/supabase/functions/mcp/mcp-handler.ts
@@ -60,26 +60,22 @@ function jsonrpc(id: unknown, result: unknown): Response {
 /**
  * JSON-RPC error code for an *authenticated* caller that lacks permission for a
  * specific tool — an authorization failure, NOT an authentication failure.
- *
- * Deliberately distinct from the pre-dispatch Unauthorized code (-32001). The
- * HTTP status carries transport-level auth state; the JSON-RPC code carries
- * application state. Only a genuinely unauthenticated request (-32001, emitted
- * with a null id before dispatch) may answer HTTP 401 — that status is what
- * drives an MCP client's OAuth retry. An authorization denial is an in-band
- * response to an accepted tool call and MUST travel as HTTP 200 with the error
- * in the body. Answering 401 here makes streamable-HTTP MCP clients (e.g.
- * mcp-remote) treat the whole session as unauthenticated and silently
- * retry/reconnect — the caller's tool-call promise never resolves and the
- * client hangs indefinitely instead of surfacing the error.
+ * Distinct from the Unauthorized code (-32001) so the two are legible in logs,
+ * but both are auth-family errors delivered in-band (see jsonrpcError).
  */
 const JSONRPC_FORBIDDEN = -32003;
 
 export function jsonrpcError(id: unknown, code: number, message: string): Response {
-  // -32001 (Unauthorized, pre-dispatch) → 401 to trigger client reauth.
-  // JSONRPC_FORBIDDEN (authenticated-but-denied) → 200 so the JSON-RPC error is
-  // delivered in-band rather than read as a transport auth failure (which hangs
-  // mcp-remote). Everything else is a bad/failed request → 400.
-  const status = code === -32001 ? 401 : code === JSONRPC_FORBIDDEN ? 200 : 400;
+  // This is a token-based MCP server (no OAuth), so a 401 buys nothing but a
+  // hang: streamable-HTTP clients (mcp-remote) read a 401 on the MCP endpoint as
+  // a *session* auth failure and silently retry/reconnect, so the caller's
+  // promise never resolves. Deliver every auth-family error IN-BAND at HTTP 200
+  // instead — the client parses the JSON-RPC error and surfaces it immediately:
+  //   -32001          unauthenticated (missing / invalid / rotated token)
+  //   JSONRPC_FORBIDDEN authenticated but not permitted (org.* JWT, token scope)
+  // Malformed / internal errors stay 400 (a bad request, not an auth signal).
+  // Nothing returns 401 — a fast, legible error always beats a hang.
+  const status = code === -32001 || code === JSONRPC_FORBIDDEN ? 200 : 400;
   return new Response(
     JSON.stringify({ jsonrpc: '2.0', id, error: { code, message } }),
     { status, headers: { 'Content-Type': 'application/json' } },

--- a/supabase/functions/mcp/mcp-handler.ts
+++ b/supabase/functions/mcp/mcp-handler.ts
@@ -200,7 +200,8 @@ export async function handleMcp(req: Request, auth: AuthContext, span: Span): Pr
         },
         // ── org.* ──────────────────────────────────────────────────────────
         // Require a Supabase user JWT (auth.uid() resolved inside SECURITY
-        // DEFINER RPCs). api_key callers receive -32001 before dispatch.
+        // DEFINER RPCs). api_key callers are rejected at dispatch with
+        // JSONRPC_FORBIDDEN (-32003, HTTP 200) — see the tools/call branch.
         {
           name: 'org.create',
           description:


### PR DESCRIPTION
## Problem

A missing / invalid / **rotated** token makes the MCP client hang, instead of failing fast with "invalid token". (Surfaced live: a rotated `.mcp.json` token produced an HTTP 401 that stalled `mcp-remote`.)

## Root cause

The pre-dispatch auth rejection returned **two** hang triggers at once:

```ts
return jsonrpcError(null, -32001, 'Unauthorized');   // HTTP 401 + id:null
```

- **HTTP 401** on the MCP endpoint → `mcp-remote` treats it as a *session* auth failure and silently retries/reconnects.
- **`id: null`** → even at HTTP 200, the client can't correlate the error to its pending `tools/call`, so the promise never resolves.

This is a token-based server (no OAuth), so a 401 drives no reauth flow — it only hangs.

## Fix

- `jsonrpcError` maps **both** auth-family codes to **HTTP 200**: `-32001` (unauthenticated) and `JSONRPC_FORBIDDEN` (authz). Nothing returns 401; malformed/internal stay 400.
- The auth-failure path **peeks the real request id** from the body (`req.clone()`) and echoes it, with a clear *"Invalid or unknown API token…"* message and `http.response.status_code=200`.
- Drift guard extended: no status branch yields 401, and the auth-failure path returns a real id (never `id:null`).

Completes #125's hang fix for the auth-layer rejection. Verified #125 in prod first: `org.list` with a valid token → 5/5 HTTP 200 `-32003`, <1.6s, no hang.

## Scope

Edge function only (`supabase/functions/mcp`, the deployed surface). The separate Node variant in `packages/mcp-server` (`auth.ts` `sendUnauthorized`, still 401) is not deployed via this pipeline; can be aligned in a follow-up if it's a live surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)