### PR TITLE
fix(cli): mcp readiness banner + correct tree scope help

### DIFF
--- a/packages/cli/bin/lorekit.mjs
+++ b/packages/cli/bin/lorekit.mjs
@@ -59,7 +59,7 @@ ${c.bold('Commands')}
   diff        Compare the offline and remote stores for the applicable scopes and
               report divergence: local-only, remote-only, and conflicting keys
               (grouped by scope). Needs both stores readable. --json, --scope <s>.
-  tree        Show the injected scopes (branch → repo → global) as a precedence
+  tree        Show the injected scopes (project → branch → repo → global) as a precedence
     (resolve) hierarchy and mark, per key, which scope's lesson WINS and which are
               shadowed — the real hook-resolution order. --json, --scope <s>.
   lint        Flag low-quality lessons (empty/short/untrimmed value, empty key,
@@ -315,8 +315,8 @@ ${c.bold('Examples')}
 ${c.bold('Usage')}
   npx @lorekit/cli tree [options]
 
-Shows the scopes the hooks actually inject for the current directory — branch,
-repo, global, in precedence order (most-specific first) — and marks, for any key
+Shows the scopes the hooks actually inject for the current directory — project,
+branch, repo, global, in precedence order (most-specific first) — and marks, for any key
 present at more than one scope, which scope's lesson WINS and which are shadowed.
 This mirrors the SessionStart hook's resolution exactly (a more-specific scope
 overrides a broader scope's same-key lesson). Project-scope lessons are NOT

--- a/packages/cli/bin/lorekit.mjs
+++ b/packages/cli/bin/lorekit.mjs
@@ -319,9 +319,8 @@ Shows the scopes the hooks actually inject for the current directory — project
 branch, repo, global, in precedence order (most-specific first) — and marks, for any key
 present at more than one scope, which scope's lesson WINS and which are shadowed.
 This mirrors the SessionStart hook's resolution exactly (a more-specific scope
-overrides a broader scope's same-key lesson). Project-scope lessons are NOT
-injected by the hooks, so they are not shown here — browse them with \`lorekit list\`.
-Resolved independently per store, in the same Offline / Remote split.
+overrides a broader scope's same-key lesson). Resolved independently per store,
+in the same Offline / Remote split.
 
 ${c.bold('Options')}
   -d, --dir <path>        Target project root (default: current directory)

--- a/packages/cli/src/mcp-server.mjs
+++ b/packages/cli/src/mcp-server.mjs
@@ -337,12 +337,31 @@ function withOverrides(args, env) {
   return out;
 }
 
+// A one-line human-readable readiness banner for `lorekit mcp`. Pure so it can
+// be unit-tested. Printed to STDERR (never stdout — that channel carries only
+// JSON-RPC frames) and only when stdin is a TTY, so a real MCP client that
+// pipes to us gets a pristine, banner-free stdout AND stderr.
+export function startupBanner(mode) {
+  return (
+    `lorekit mcp — local stdio MCP server ready (mode: ${mode}). ` +
+    'Speaking JSON-RPC 2.0 on stdin/stdout; this is machine-facing, so no ' +
+    'further output is normal. Press Ctrl-C to stop.'
+  );
+}
+
 // Entrypoint for `lorekit mcp`. Resolves the store once, then serves stdio
 // until the client closes stdin. Always resolves to exit code 0.
-export async function mcpServer(args = {}, { env = process.env, input = process.stdin, output = process.stdout } = {}) {
+export async function mcpServer(
+  args = {},
+  { env = process.env, input = process.stdin, output = process.stdout, errorOutput = process.stderr } = {},
+) {
   const root = resolveProjectRoot(args.dir);
   const control = loadControl(root, { env: withOverrides(args, env) });
   const handle = createHandler(control);
+  // A human who runs `lorekit mcp` in a terminal would otherwise see a silent
+  // hang with no sign it is alive. Reassure them on stderr — but only when
+  // stdin is a TTY, so a piped MCP client never sees the banner on either channel.
+  if (input && input.isTTY) errorOutput.write(startupBanner(control.mode) + '\n');
   await runStdio(handle, input, output);
   return 0;
 }

--- a/packages/cli/test/mcp-banner.test.mjs
+++ b/packages/cli/test/mcp-banner.test.mjs
@@ -1,0 +1,52 @@
+// `lorekit mcp` prints a human-readable readiness banner to STDERR when run
+// interactively (stdin is a TTY), so a person doesn't see a silent hang — while
+// a piped MCP client still gets a pristine, banner-free stdout AND stderr.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Readable, Writable } from 'node:stream';
+import { startupBanner, mcpServer } from '../src/mcp-server.mjs';
+
+// An input stream that ends immediately (no JSON-RPC frames), with a settable
+// `isTTY` flag — the only thing the banner gate keys on.
+function fakeInput({ isTTY = false } = {}) {
+  const r = Readable.from([]);
+  r.isTTY = isTTY;
+  return r;
+}
+
+function collector() {
+  const chunks = [];
+  const w = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  w.text = () => chunks.join('');
+  return w;
+}
+
+test('startupBanner names the mode and is self-describing', () => {
+  const b = startupBanner('local');
+  assert.match(b, /local/);
+  assert.match(b, /JSON-RPC/);
+  assert.match(b, /ready/i);
+});
+
+test('interactive (TTY) run writes the banner to stderr, never to stdout', async () => {
+  const output = collector();
+  const errorOutput = collector();
+  const code = await mcpServer({}, { input: fakeInput({ isTTY: true }), output, errorOutput });
+  assert.equal(code, 0);
+  assert.match(errorOutput.text(), /ready/i); // human sees reassurance
+  assert.equal(output.text(), ''); // JSON-RPC channel stays pristine
+});
+
+test('piped run (no TTY) writes no banner — clients get a clean stderr', async () => {
+  const output = collector();
+  const errorOutput = collector();
+  const code = await mcpServer({}, { input: fakeInput({ isTTY: false }), output, errorOutput });
+  assert.equal(code, 0);
+  assert.equal(errorOutput.text(), '');
+  assert.equal(output.text(), '');
+});

--- a/packages/cli/test/tree.test.mjs
+++ b/packages/cli/test/tree.test.mjs
@@ -96,8 +96,8 @@ function entry({ scope, key, value, tags = [] }) {
 }
 
 // A git-backed project (remote `acme/widget`, branch `feat/x`) so `deriveScope`
-// resolves the full branch → repo → global `readOrder`, with the same key
-// `shared` present at all three scopes plus a global-only key.
+// resolves the full project → branch → repo → global `readOrder`, with the same
+// key `shared` present at the branch, repo, and global scopes plus a global-only key.
 function seedGitProject() {
   const root = tmp('lk-tree-proj-');
   const home = tmp('lk-tree-home-');

--- a/packages/cli/test/tree.test.mjs
+++ b/packages/cli/test/tree.test.mjs
@@ -316,3 +316,11 @@ test('tree resolves a configured remote independently, marking its shadowed keys
     server.close();
   }
 });
+
+// Guards the readOrder-doc drift: after the smart-hooks PR, `readOrder` (and so
+// tree) includes project scope, so the help must name it as an injected scope.
+test('tree --help lists project among the injected scopes', () => {
+  const res = spawnSync(process.execPath, [BIN, 'tree', '--help'], { encoding: 'utf8' });
+  const out = (res.stdout || '') + (res.stderr || '');
+  assert.match(out, /inject[\s\S]{0,80}project/i);
+});


### PR DESCRIPTION
## Why

Running `lorekit mcp` in a terminal shows nothing and just hangs — it's a healthy stdio JSON-RPC server waiting for a client, but a human can't tell it from a freeze. And `tree`'s help still described the injected scopes as `branch → repo → global`, which the smart-hooks PR (#145) changed to lead with `project`.

## What changed

- `lorekit mcp` prints a one-line readiness banner to **stderr**, gated on `stdin.isTTY` — a human sees it's alive; a piped MCP client's stdout (and stderr) stay pristine.
- Corrected the stale `tree` help text (command summary + `tree --help` body) to `project → branch → repo → global`, and removed a now-contradictory sentence claiming project scope isn't injected.

## How to verify

- `env -u LOREKIT_TOKEN -u LOREKIT_MCP_URL -u LOREKIT_ENDPOINT node --test 'test/'*.test.mjs` (294 pass)

## Notes for reviewers

The banner is written only to an injectable `errorOutput` (default `process.stderr`) and only under a TTY, so the JSON-RPC channel is provably untouched for real clients — covered by both the TTY and piped-client test branches.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgCWXitvA4vMM12FK36GVZ)_