### PR TITLE
feat(web): add consistent GitHub + Discord footer site-wide

### DIFF
--- a/packages/web/src/app/(auth)/login/page.tsx
+++ b/packages/web/src/app/(auth)/login/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react';
 import type { Metadata } from 'next';
 import { LoginButton } from '@/components/auth/LoginButton';
+import { SiteFooter } from '@/components/layout/SiteFooter';
 import { BookOpen, Brain, GitBranch, Zap } from 'lucide-react';
 
 export const metadata: Metadata = {
@@ -150,19 +151,7 @@ export default function LoginPage() {
         ))}
       </section>
 
-      <footer className="relative z-10 border-t border-[var(--color-border)] py-6 text-center">
-        <p className="text-xs text-[var(--color-content-tertiary)]">
-          Open source · built by{' '}
-          <a
-            href="https://github.com/mthines"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-[var(--color-content-secondary)] underline-offset-2 hover:underline"
-          >
-            mthines
-          </a>
-        </p>
-      </footer>
+      <SiteFooter className="relative z-10" />
     </main>
   );
 }

--- a/packages/web/src/app/(dashboard)/layout.tsx
+++ b/packages/web/src/app/(dashboard)/layout.tsx
@@ -79,8 +79,18 @@ export default async function DashboardLayout({ children }: { children: React.Re
                   vertical space — while still reachable on every page.
                 */}
                 <main className="flex-1 overflow-y-auto p-4 pb-20 md:pb-6 md:p-6">
-                  {children}
-                  <SiteFooter className="-mx-4 mt-8 md:-mx-6" />
+                  {/*
+                    Sticky-footer layout: a min-h-full flex column whose content
+                    area grows (flex-1) to push the footer to the bottom of the
+                    viewport when a page is shorter than the screen, while still
+                    letting it flow below the content on taller pages. main stays
+                    the scroll container; the inner content stays an auto-height
+                    block, so the lore explorer's own h-full layout is unaffected.
+                  */}
+                  <div className="flex min-h-full flex-col">
+                    <div className="min-h-0 flex-1">{children}</div>
+                    <SiteFooter className="-mx-4 mt-8 md:-mx-6" />
+                  </div>
                 </main>
               </div>
             </MemorySidebarProvider>

--- a/packages/web/src/app/(dashboard)/layout.tsx
+++ b/packages/web/src/app/(dashboard)/layout.tsx
@@ -4,6 +4,7 @@ import { headers } from 'next/headers';
 import { createServerClient } from '@/lib/supabase/server';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { TopBar } from '@/components/layout/TopBar';
+import { SiteFooter } from '@/components/layout/SiteFooter';
 import { Dash0Provider } from '@/components/providers/Dash0Provider';
 import { MemorySidebarProvider } from '@/components/providers/MemorySidebarProvider';
 import { ToastProvider } from '@/components/providers/ToastProvider';
@@ -70,7 +71,17 @@ export default async function DashboardLayout({ children }: { children: React.Re
               <NavigationCommands />
               <div className="flex flex-1 flex-col overflow-hidden">
                 <TopBar user={user} />
-                <main className="flex-1 overflow-y-auto p-4 pb-20 md:pb-6 md:p-6">{children}</main>
+                {/*
+                  main stays the bounded scroll container (the lore explorer's
+                  desktop two-panel layout relies on this). The footer renders
+                  inside it, after the page content, so it stays subtle —
+                  appearing at the end of the scroll rather than eating fixed
+                  vertical space — while still reachable on every page.
+                */}
+                <main className="flex-1 overflow-y-auto p-4 pb-20 md:pb-6 md:p-6">
+                  {children}
+                  <SiteFooter className="-mx-4 mt-8 md:-mx-6" />
+                </main>
               </div>
             </MemorySidebarProvider>
           </Suspense>

--- a/packages/web/src/components/layout/SiteFooter.tsx
+++ b/packages/web/src/components/layout/SiteFooter.tsx
@@ -1,5 +1,9 @@
 import type { ComponentPropsWithoutRef } from 'react';
 
+const DISCORD_URL = 'https://discord.gg/B9m6BzMRjg';
+const ICON_LINK_CLASS =
+  'inline-flex items-center gap-1.5 transition-colors duration-200 hover:text-[var(--color-content-primary)] focus-visible:outline-2 focus-visible:outline-[var(--color-accent)]';
+
 /**
  * Shared, deliberately subtle site footer rendered both on the public login
  * page and across every authenticated dashboard page, so the GitHub repo and
@@ -19,7 +23,7 @@ export function SiteFooter({ className = '', ...props }: ComponentPropsWithoutRe
         href="https://github.com/mthines/lorekit"
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1.5 transition-colors duration-200 hover:text-[var(--color-content-primary)] focus-visible:outline-2 focus-visible:outline-[var(--color-accent)]"
+        className={ICON_LINK_CLASS}
       >
         <svg
           aria-hidden
@@ -34,10 +38,10 @@ export function SiteFooter({ className = '', ...props }: ComponentPropsWithoutRe
       </a>
 
       <a
-        href="https://discord.gg/B9m6BzMRjg"
+        href={DISCORD_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-1.5 transition-colors duration-200 hover:text-[var(--color-content-primary)] focus-visible:outline-2 focus-visible:outline-[var(--color-accent)]"
+        className={ICON_LINK_CLASS}
       >
         <svg
           aria-hidden
@@ -54,7 +58,7 @@ export function SiteFooter({ className = '', ...props }: ComponentPropsWithoutRe
       <span className="text-[var(--color-content-tertiary)]">
         Need help? Join our{' '}
         <a
-          href="https://discord.gg/B9m6BzMRjg"
+          href={DISCORD_URL}
           target="_blank"
           rel="noopener noreferrer"
           className="underline-offset-2 transition-colors duration-200 hover:text-[var(--color-content-primary)] hover:underline"

--- a/packages/web/src/components/layout/SiteFooter.tsx
+++ b/packages/web/src/components/layout/SiteFooter.tsx
@@ -1,0 +1,68 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+/**
+ * Shared, deliberately subtle site footer rendered both on the public login
+ * page and across every authenticated dashboard page, so the GitHub repo and
+ * Discord support links are reachable from anywhere.
+ *
+ * It keeps to a single low-key line (tertiary text → primary on hover) so it
+ * never competes with page content. The GitHub link mirrors the repo link in
+ * the login page header; the Discord link invites people to join for support.
+ */
+export function SiteFooter({ className = '', ...props }: ComponentPropsWithoutRef<'footer'>) {
+  return (
+    <footer
+      className={`flex flex-wrap items-center justify-center gap-x-5 gap-y-2 border-t border-[var(--color-border)] px-6 py-4 text-xs text-[var(--color-content-tertiary)] ${className}`}
+      {...props}
+    >
+      <a
+        href="https://github.com/mthines/lorekit"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 transition-colors duration-200 hover:text-[var(--color-content-primary)] focus-visible:outline-2 focus-visible:outline-[var(--color-accent)]"
+      >
+        <svg
+          aria-hidden
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="size-4"
+        >
+          <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+        </svg>
+        GitHub
+      </a>
+
+      <a
+        href="https://discord.gg/B9m6BzMRjg"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center gap-1.5 transition-colors duration-200 hover:text-[var(--color-content-primary)] focus-visible:outline-2 focus-visible:outline-[var(--color-accent)]"
+      >
+        <svg
+          aria-hidden
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          className="size-4"
+        >
+          <path d="M20.317 4.369a19.79 19.79 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.865-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.1 13.1 0 0 1-1.872-.892.077.077 0 0 1-.008-.128c.126-.094.252-.192.372-.291a.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.099.246.197.373.291a.077.077 0 0 1-.006.127 12.3 12.3 0 0 1-1.873.893.077.077 0 0 0-.041.106c.36.699.772 1.363 1.225 1.993a.076.076 0 0 0 .084.028 19.84 19.84 0 0 0 6.002-3.03.077.077 0 0 0 .032-.055c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.028ZM8.02 15.331c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.211 0 2.176 1.096 2.157 2.42 0 1.333-.955 2.418-2.157 2.418Zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418Z" />
+        </svg>
+        Discord
+      </a>
+
+      <span className="text-[var(--color-content-tertiary)]">
+        Need help? Join our{' '}
+        <a
+          href="https://discord.gg/B9m6BzMRjg"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline-offset-2 transition-colors duration-200 hover:text-[var(--color-content-primary)] hover:underline"
+        >
+          Discord
+        </a>{' '}
+        for support.
+      </span>
+    </footer>
+  );
+}

--- a/packages/web/src/components/layout/SiteFooter.tsx
+++ b/packages/web/src/components/layout/SiteFooter.tsx
@@ -2,7 +2,7 @@ import type { ComponentPropsWithoutRef } from 'react';
 
 const DISCORD_URL = 'https://discord.gg/B9m6BzMRjg';
 const ICON_LINK_CLASS =
-  'inline-flex items-center gap-1.5 transition-colors duration-200 hover:text-[var(--color-content-primary)] focus-visible:outline-2 focus-visible:outline-[var(--color-accent)]';
+  'inline-flex items-center gap-1.5 transition-colors duration-200 hover:text-[var(--color-content-primary)]';
 
 /**
  * Shared, deliberately subtle site footer rendered both on the public login
@@ -55,7 +55,7 @@ export function SiteFooter({ className = '', ...props }: ComponentPropsWithoutRe
         Discord
       </a>
 
-      <span className="text-[var(--color-content-tertiary)]">
+      <span>
         Need help? Join our{' '}
         <a
           href={DISCORD_URL}


### PR DESCRIPTION
## Why

The GitHub repo link only lived in the login header, and there was no in-app path to community support. This adds one subtle, consistent footer everywhere so both are always reachable.

## What changed

- New `SiteFooter` component linking the LoreKit GitHub repo and the Discord support server
- Rendered at the end of the scrollable content on every authenticated dashboard page (no fixed vertical space)
- Login page swaps its bespoke one-line footer for the shared component

## How to verify

- Open `/login` and any dashboard page — the footer shows GitHub + Discord links; Discord opens the invite.

## Notes for reviewers

The login footer's "built by mthines" credit is dropped in favor of the shared footer — say if it should be kept.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExrBKde26LXbevN5P7jdHe)_