### PR TITLE
fix(web): unify Explorer filter chrome across scope and time views

### DIFF
--- a/packages/web/src/app/(dashboard)/lore/page.tsx
+++ b/packages/web/src/app/(dashboard)/lore/page.tsx
@@ -8,8 +8,9 @@ export default function LorePage() {
   // useScopeTree: lightweight scope-only fetch — tree renders immediately while
   // the lesson list streams in separately via useMemories inside LoreExplorer.
   const { data: scopes, isLoading: scopesLoading, isError: scopesError } = useScopeTree();
-  // useLoreData: full 500-row fetch used only for heatmapData + feedEvents.
-  // Runs in parallel — the heatmap and feed tab can load after the scope tree.
+  // useLoreData: full 500-row fetch used only for heatmapData (the 26-week
+  // contribution graph). Runs in parallel — the heatmap can load after the
+  // scope tree; the lesson list + feed stream in via useMemories separately.
   const { data: loreData } = useLoreData();
 
   const isLoading = scopesLoading;
@@ -42,7 +43,6 @@ export default function LorePage() {
           <LoreExplorer
             scopes={scopes}
             heatmapData={loreData?.heatmapData ?? []}
-            feedEvents={loreData?.feedEvents ?? []}
           />
         )}
       </div>

--- a/packages/web/src/components/activity/ActivityFeed.tsx
+++ b/packages/web/src/components/activity/ActivityFeed.tsx
@@ -36,21 +36,24 @@ function groupByDate(lessons: LessonEntry[]): [string, LessonEntry[]][] {
   return Array.from(groups.entries());
 }
 
-function DateLabel({ date }: { date: string }) {
-  const d = new Date(date);
+/**
+ * Friendly heading for a UTC day string (`YYYY-MM-DD`): "Today" / "Yesterday"
+ * / weekday. One source of truth so the visible `DateLabel` and the day-group
+ * list's `aria-label` never diverge (a screen reader must hear the same label a
+ * sighted user reads, not the raw ISO date).
+ */
+function dayLabel(date: string): string {
   const today = new Date().toISOString().slice(0, 10);
   const yesterday = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+  if (date === today) return 'Today';
+  if (date === yesterday) return 'Yesterday';
+  return new Date(date).toLocaleDateString(undefined, { weekday: 'long', month: 'short', day: 'numeric' });
+}
 
-  const label =
-    date === today
-      ? 'Today'
-      : date === yesterday
-        ? 'Yesterday'
-        : d.toLocaleDateString(undefined, { weekday: 'long', month: 'short', day: 'numeric' });
-
+function DateLabel({ date }: { date: string }) {
   return (
     <div className="sticky top-0 z-10 flex items-center gap-3 bg-[var(--color-bg)] py-2">
-      <span className="text-xs font-medium text-[var(--color-content-tertiary)]">{label}</span>
+      <span className="text-xs font-medium text-[var(--color-content-tertiary)]">{dayLabel(date)}</span>
       <div className="h-px flex-1 bg-[var(--color-border)]" aria-hidden />
     </div>
   );
@@ -73,7 +76,7 @@ export function ActivityFeed({ lessons, isSelected, onSelect }: ActivityFeedProp
       {grouped.map(([date, dayLessons]) => (
         <div key={date}>
           <DateLabel date={date} />
-          <div className="flex flex-col gap-1.5" role="list" aria-label={date}>
+          <div className="flex flex-col gap-1.5" role="list" aria-label={dayLabel(date)}>
             {dayLessons.map((lesson, i) => {
               const TriggerIcon = lesson.trigger ? (TRIGGER_ICONS[lesson.trigger] ?? Bot) : Bot;
               return (

--- a/packages/web/src/components/activity/ActivityFeed.tsx
+++ b/packages/web/src/components/activity/ActivityFeed.tsx
@@ -73,19 +73,20 @@ export function ActivityFeed({ lessons, isSelected, onSelect }: ActivityFeedProp
       {grouped.map(([date, dayLessons]) => (
         <div key={date}>
           <DateLabel date={date} />
-          <div className="flex flex-col gap-1.5">
+          <div className="flex flex-col gap-1.5" role="list" aria-label={date}>
             {dayLessons.map((lesson, i) => {
               const TriggerIcon = lesson.trigger ? (TRIGGER_ICONS[lesson.trigger] ?? Bot) : Bot;
               return (
-                <MemoryCard
-                  key={`${lesson.scope}::${lesson.key}`}
-                  memory={memoryFromLesson(lesson)}
-                  layout="row"
-                  index={i}
-                  selected={isSelected(lesson)}
-                  onClick={() => onSelect(lesson)}
-                  leadingIcon={<TriggerIcon className="size-3.5 text-[var(--color-content-tertiary)]" aria-hidden />}
-                />
+                <div key={`${lesson.scope}::${lesson.key}`} role="listitem">
+                  <MemoryCard
+                    memory={memoryFromLesson(lesson)}
+                    layout="row"
+                    index={i}
+                    selected={isSelected(lesson)}
+                    onClick={() => onSelect(lesson)}
+                    leadingIcon={<TriggerIcon className="size-3.5 text-[var(--color-content-tertiary)]" aria-hidden />}
+                  />
+                </div>
               );
             })}
           </div>

--- a/packages/web/src/components/activity/ActivityFeed.tsx
+++ b/packages/web/src/components/activity/ActivityFeed.tsx
@@ -1,26 +1,22 @@
 'use client';
 
-import { useMemo } from 'react';
-import { Bot, Zap, Webhook, ArrowRight } from 'lucide-react';
-import Link from 'next/link';
-import { MemoryCard, memoryFromEvent } from '@/components/memory/MemoryCard';
-import { scopeLabel } from '@/components/memory/scope-meta';
-import { useMemorySidebar } from '@/components/providers/MemorySidebarProvider';
-import { useUrlState } from '@/lib/hooks/useUrlState';
-import { DateRangePicker, type DateRange } from '@/components/ui/DateRangePicker';
-import type { ScopePrefix } from '@/lib/scope';
+/**
+ * ActivityFeed — the "Browse by time" rendering of the Lore Explorer.
+ *
+ * Presentational only: it receives an already-filtered, owner-aware list of
+ * lessons from {@link LoreExplorer} and groups them by calendar day. Every
+ * filter (scope / search / date range / owner / archived) is owned by
+ * `LoreExplorer` and applied upstream via the shared `useMemories` query, so
+ * this component no longer holds any filter state, scope pills, or date picker
+ * of its own — the scope tree and the shared filter bar drive both views
+ * identically. The only difference between the two tabs is the layout: the
+ * scope view renders a flat card list, the time view renders these date groups.
+ */
 
-export interface ActivityEvent {
-  id: string;
-  scope: string;
-  scope_type: ScopePrefix;
-  key: string;
-  value_preview: string;
-  source_agent: string | null;
-  trigger: string | null;
-  tags: string[];
-  created_at: string;
-}
+import { useMemo } from 'react';
+import { Bot, Zap, Webhook } from 'lucide-react';
+import { MemoryCard, memoryFromLesson } from '@/components/memory/MemoryCard';
+import type { LessonEntry } from '@/components/lore/LessonCard';
 
 const TRIGGER_ICONS: Record<string, typeof Bot> = {
   'stuck-loop': Zap,
@@ -28,14 +24,16 @@ const TRIGGER_ICONS: Record<string, typeof Bot> = {
   'manual': Bot,
 };
 
-function groupByDate(events: ActivityEvent[]): Map<string, ActivityEvent[]> {
-  const groups = new Map<string, ActivityEvent[]>();
-  for (const e of events) {
-    const day = e.created_at.slice(0, 10);
+/** Group lessons into [day, lessons] pairs, preserving the input order. */
+function groupByDate(lessons: LessonEntry[]): [string, LessonEntry[]][] {
+  const groups = new Map<string, LessonEntry[]>();
+  for (const l of lessons) {
+    // UTC day so groups line up with the heatmap cells a range can be set from.
+    const day = new Date(l.created_at).toISOString().slice(0, 10);
     if (!groups.has(day)) groups.set(day, []);
-    groups.get(day)!.push(e);
+    groups.get(day)!.push(l);
   }
-  return groups;
+  return Array.from(groups.entries());
 }
 
 function DateLabel({ date }: { date: string }) {
@@ -58,151 +56,41 @@ function DateLabel({ date }: { date: string }) {
   );
 }
 
-interface ActivityEventRowProps {
-  event: ActivityEvent;
-  index: number;
-  selected: boolean;
-  onSelect: (ref: { scope: string; key: string }) => void;
-}
-
-function ActivityEventRow({ event, index, selected, onSelect }: ActivityEventRowProps) {
-  const TriggerIcon = event.trigger ? (TRIGGER_ICONS[event.trigger] ?? Bot) : Bot;
-
-  return (
-    <MemoryCard
-      memory={memoryFromEvent(event)}
-      layout="row"
-      index={index}
-      selected={selected}
-      onClick={() => onSelect({ scope: event.scope, key: event.key })}
-      leadingIcon={<TriggerIcon className="size-3.5 text-[var(--color-content-tertiary)]" aria-hidden />}
-    />
-  );
-}
-
 interface ActivityFeedProps {
-  events: ActivityEvent[];
-  /** Selected date range (UTC day strings), or null for all time. */
-  range: DateRange | null;
-  onRangeChange: (range: DateRange | null) => void;
+  /** Already filtered + owner-narrowed lessons, newest first. */
+  lessons: LessonEntry[];
+  /** Selection predicate — mirrors the scope view's selected-card check. */
+  isSelected: (lesson: LessonEntry) => boolean;
+  /** Row click — same handler the scope view's cards use (toggles the sheet). */
+  onSelect: (lesson: LessonEntry) => void;
 }
 
-export function ActivityFeed({ events, range, onRangeChange }: ActivityFeedProps) {
-  // URL-backed so a filtered view is shareable and survives refresh. Scoped to
-  // /activity via cleanOnPathname so the param doesn't linger on other pages.
-  const [filter, setFilter] = useUrlState<string>('filter', 'all', {
-    cleanOnPathname: '/activity',
-  });
-  const { openLessonRef, openLessonById, closeLesson } = useMemorySidebar();
-
-  function handleSelect(ref: { scope: string; key: string }) {
-    if (openLessonRef?.scope === ref.scope && openLessonRef?.key === ref.key) {
-      closeLesson();
-    } else {
-      openLessonById(ref);
-    }
-  }
-
-  // Filter pills are derived from the scopes actually present in the events —
-  // dynamic and relevant to this user's data, rather than a hardcoded list of
-  // agent/trigger names. Ordered by frequency (most active scope first), then
-  // alphabetically for a stable tie-break.
-  const scopeFilters = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const e of events) counts.set(e.scope, (counts.get(e.scope) ?? 0) + 1);
-    return Array.from(counts.entries())
-      .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
-      .map(([scope]) => scope);
-  }, [events]);
-
-  // Apply both the scope pill and the date range. Event day is derived in UTC
-  // (toISOString) so it matches the heatmap cells the range can be set from.
-  const filtered = useMemo(() => {
-    let out = events;
-    if (filter !== 'all') out = out.filter((e) => e.scope === filter);
-    if (range) {
-      out = out.filter((e) => {
-        const day = new Date(e.created_at).toISOString().slice(0, 10);
-        return day >= range.from && day <= range.to;
-      });
-    }
-    return out;
-  }, [events, filter, range]);
-
-  const grouped = groupByDate(filtered);
-  const isFiltered = filter !== 'all' || range !== null;
+export function ActivityFeed({ lessons, isSelected, onSelect }: ActivityFeedProps) {
+  const grouped = useMemo(() => groupByDate(lessons), [lessons]);
 
   return (
-    <div className="flex flex-col gap-3">
-      {/* Filters: scope pills (left) + date-range picker (right). */}
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        {scopeFilters.length > 0 ? (
-          <div className="flex flex-wrap gap-1.5" role="group" aria-label="Filter by scope">
-            {['all', ...scopeFilters].map((f) => (
-              <button
-                key={f}
-                type="button"
-                onClick={() => setFilter(f)}
-                aria-pressed={filter === f}
-                title={f === 'all' ? undefined : f}
-                className={[
-                  'rounded-full px-3 py-1 font-mono text-xs font-medium transition-all duration-150',
-                  filter === f
-                    ? 'bg-[var(--color-accent)] text-[#000]'
-                    : 'border border-[var(--color-border)] bg-[var(--color-bg-raised)] text-[var(--color-content-secondary)] hover:bg-[var(--color-bg-elevated)]',
-                ].join(' ')}
-              >
-                {f === 'all' ? 'all' : scopeLabel(f)}
-              </button>
-            ))}
+    <div className="flex flex-col gap-1">
+      {grouped.map(([date, dayLessons]) => (
+        <div key={date}>
+          <DateLabel date={date} />
+          <div className="flex flex-col gap-1.5">
+            {dayLessons.map((lesson, i) => {
+              const TriggerIcon = lesson.trigger ? (TRIGGER_ICONS[lesson.trigger] ?? Bot) : Bot;
+              return (
+                <MemoryCard
+                  key={`${lesson.scope}::${lesson.key}`}
+                  memory={memoryFromLesson(lesson)}
+                  layout="row"
+                  index={i}
+                  selected={isSelected(lesson)}
+                  onClick={() => onSelect(lesson)}
+                  leadingIcon={<TriggerIcon className="size-3.5 text-[var(--color-content-tertiary)]" aria-hidden />}
+                />
+              );
+            })}
           </div>
-        ) : (
-          <span />
-        )}
-        <DateRangePicker value={range} onChange={onRangeChange} className="ml-auto" />
-      </div>
-
-      {/* Grouped events */}
-      {grouped.size > 0 ? (
-        <div className="flex flex-col gap-1">
-          {Array.from(grouped.entries()).map(([date, dayEvents]) => (
-            <div key={date}>
-              <DateLabel date={date} />
-              <div className="flex flex-col gap-1.5">
-                {dayEvents.map((e, i) => (
-                  <ActivityEventRow
-                    key={e.id}
-                    event={e}
-                    index={i}
-                    selected={openLessonRef?.scope === e.scope && openLessonRef?.key === e.key}
-                    onSelect={handleSelect}
-                  />
-                ))}
-              </div>
-            </div>
-          ))}
         </div>
-      ) : (
-        <div className="flex flex-col items-center justify-center gap-2 py-12 text-center">
-          <p className="text-sm text-[var(--color-content-secondary)]">
-            {isFiltered ? 'No memories match these filters' : 'No memories yet'}
-          </p>
-          <p className="text-xs text-[var(--color-content-tertiary)]">
-            {isFiltered
-              ? 'Try widening the date range or clearing the scope filter.'
-              : 'Agent writes will appear here once your LoreKit config is connected.'}
-          </p>
-          {!isFiltered && (
-            <Link
-              href="/learn/setup"
-              className="mt-1 flex items-center gap-1 text-xs font-medium text-[var(--color-accent)] hover:underline"
-            >
-              View setup guide
-              <ArrowRight className="size-3" aria-hidden />
-            </Link>
-          )}
-        </div>
-      )}
+      ))}
     </div>
   );
 }

--- a/packages/web/src/components/lore/LoreExplorer.tsx
+++ b/packages/web/src/components/lore/LoreExplorer.tsx
@@ -124,6 +124,74 @@ function OwnershipFilterBar({
   );
 }
 
+// ── Filter bar (search + date + archived) ─────────────────────────────────────
+// Shared by both tabs and both breakpoints. `variant` carries the only two
+// differences between the desktop and mobile renders: the desktop bar sits in a
+// bordered header (`border-b`/padding), uses smaller type + the page `bg`, and
+// shows an "Archived" text label + hover affordances; the mobile bar is a bare
+// row with an icon-only archived toggle on the raised `bg`. Everything else —
+// the search input, the date picker, the toggle behaviour — is identical, so it
+// lives here once instead of near-verbatim in each breakpoint branch.
+
+function FilterBar({
+  variant,
+  search,
+  onSearchChange,
+  range,
+  onRangeChange,
+  showArchived,
+  onToggleArchived,
+}: {
+  variant: 'desktop' | 'mobile';
+  search: string;
+  onSearchChange: (value: string) => void;
+  range: DateRange | null;
+  onRangeChange: (range: DateRange | null) => void;
+  showArchived: boolean;
+  onToggleArchived: () => void;
+}) {
+  const desktop = variant === 'desktop';
+
+  return (
+    <div className={desktop ? 'flex items-center gap-2 border-b border-[var(--color-border)] p-3' : 'flex items-center gap-2'}>
+      <div className="relative flex-1">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[var(--color-content-tertiary)]" aria-hidden />
+        <input
+          type="search"
+          placeholder="Search memories…"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          aria-label="Search memories"
+          className={[
+            'w-full rounded-lg border border-[var(--color-border)] py-2 pl-8 pr-3 text-[var(--color-content-primary)] placeholder:text-[var(--color-content-tertiary)] focus:border-[var(--color-accent)] focus:outline-none transition-colors duration-150',
+            desktop ? 'bg-[var(--color-bg)] text-xs' : 'bg-[var(--color-bg-raised)] text-sm',
+          ].join(' ')}
+        />
+      </div>
+      <DateRangePicker value={range} onChange={onRangeChange} className="shrink-0" />
+      <button
+        type="button"
+        onClick={onToggleArchived}
+        aria-pressed={showArchived}
+        aria-label={showArchived ? 'Showing archived memories — click to show active' : 'Show archived memories'}
+        title={desktop ? (showArchived ? 'Showing archived' : 'Show archived') : undefined}
+        className={[
+          'flex min-h-9 shrink-0 items-center rounded-lg border transition-all duration-150',
+          desktop ? 'gap-1.5 px-2.5 py-1.5 text-xs font-medium' : 'justify-center p-2',
+          showArchived
+            ? 'border-amber-400/40 bg-amber-400/10 text-amber-400'
+            : `border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-content-tertiary)]${
+                desktop ? ' hover:border-[var(--color-content-tertiary)] hover:text-[var(--color-content-secondary)]' : ''
+              }`,
+        ].join(' ')}
+      >
+        <Archive className={desktop ? 'size-3.5' : 'size-4'} aria-hidden />
+        {desktop && <span className="hidden sm:inline">Archived</span>}
+      </button>
+    </div>
+  );
+}
+
 interface LoreExplorerProps {
   scopes: ScopeNode[];
   heatmapData: { date: string; count: number }[];
@@ -218,6 +286,12 @@ export function LoreExplorer({ scopes, heatmapData }: LoreExplorerProps) {
 
   const isFiltered =
     search.trim() !== '' || range !== null || showArchived || ownerFilter !== 'all';
+
+  function handleToggleArchived() {
+    setShowArchived(!showArchived);
+    // Close the sidebar — the open lesson may not exist in the other list.
+    closeLesson();
+  }
 
   function handleScopeSelect(scope: string | null) {
     startTransition(() => {
@@ -471,39 +545,15 @@ export function LoreExplorer({ scopes, heatmapData }: LoreExplorerProps) {
         </div>
 
         <div className="flex flex-1 flex-col overflow-hidden">
-          <div className="flex items-center gap-2 border-b border-[var(--color-border)] p-3">
-            <div className="relative flex-1">
-              <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[var(--color-content-tertiary)]" aria-hidden />
-              <input
-                type="search"
-                placeholder="Search memories…"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                aria-label="Search memories"
-                className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] py-2 pl-8 pr-3 text-xs text-[var(--color-content-primary)] placeholder:text-[var(--color-content-tertiary)] focus:border-[var(--color-accent)] focus:outline-none transition-colors duration-150"
-              />
-            </div>
-            <DateRangePicker value={range} onChange={setRange} className="shrink-0" />
-            <button
-              type="button"
-              onClick={() => {
-                setShowArchived(!showArchived);
-                closeLesson();
-              }}
-              aria-pressed={showArchived}
-              aria-label={showArchived ? 'Showing archived memories — click to show active' : 'Show archived memories'}
-              title={showArchived ? 'Showing archived' : 'Show archived'}
-              className={[
-                'flex min-h-9 shrink-0 items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium transition-all duration-150',
-                showArchived
-                  ? 'border-amber-400/40 bg-amber-400/10 text-amber-400'
-                  : 'border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-content-tertiary)] hover:border-[var(--color-content-tertiary)] hover:text-[var(--color-content-secondary)]',
-              ].join(' ')}
-            >
-              <Archive className="size-3.5" aria-hidden />
-              <span className="hidden sm:inline">Archived</span>
-            </button>
-          </div>
+          <FilterBar
+            variant="desktop"
+            search={search}
+            onSearchChange={setSearch}
+            range={range}
+            onRangeChange={setRange}
+            showArchived={showArchived}
+            onToggleArchived={handleToggleArchived}
+          />
 
           <OwnershipFilterBar orgs={orgsInView} value={ownerFilter} onChange={setOwnerFilter} />
 
@@ -543,37 +593,15 @@ export function LoreExplorer({ scopes, heatmapData }: LoreExplorerProps) {
           )}
         </div>
 
-        <div className="flex items-center gap-2">
-          <div className="relative flex-1">
-            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[var(--color-content-tertiary)]" aria-hidden />
-            <input
-              type="search"
-              placeholder="Search memories…"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              aria-label="Search memories"
-              className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-raised)] py-2 pl-8 pr-3 text-sm text-[var(--color-content-primary)] placeholder:text-[var(--color-content-tertiary)] focus:border-[var(--color-accent)] focus:outline-none transition-colors duration-150"
-            />
-          </div>
-          <DateRangePicker value={range} onChange={setRange} className="shrink-0" />
-          <button
-            type="button"
-            onClick={() => {
-              setShowArchived(!showArchived);
-              closeLesson();
-            }}
-            aria-pressed={showArchived}
-            aria-label={showArchived ? 'Showing archived memories — click to show active' : 'Show archived memories'}
-            className={[
-              'flex min-h-9 shrink-0 items-center justify-center rounded-lg border p-2 transition-all duration-150',
-              showArchived
-                ? 'border-amber-400/40 bg-amber-400/10 text-amber-400'
-                : 'border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-content-tertiary)]',
-            ].join(' ')}
-          >
-            <Archive className="size-4" aria-hidden />
-          </button>
-        </div>
+        <FilterBar
+          variant="mobile"
+          search={search}
+          onSearchChange={setSearch}
+          range={range}
+          onRangeChange={setRange}
+          showArchived={showArchived}
+          onToggleArchived={handleToggleArchived}
+        />
 
         <OwnershipFilterBar orgs={orgsInView} value={ownerFilter} onChange={setOwnerFilter} />
 

--- a/packages/web/src/components/lore/LoreExplorer.tsx
+++ b/packages/web/src/components/lore/LoreExplorer.tsx
@@ -44,7 +44,7 @@ import { useMemories } from '@/lib/queries/lore';
 import { useReducedMotion } from 'motion/react';
 import type { LessonEntry } from './LessonCard';
 import { ContributionHeatmap } from '@/components/activity/ContributionHeatmap';
-import { ActivityFeed, type ActivityEvent } from '@/components/activity/ActivityFeed';
+import { ActivityFeed } from '@/components/activity/ActivityFeed';
 import { filterByOwnership, type OwnerFilter } from '@/lib/org-ui';
 
 type ViewMode = 'scope' | 'time';
@@ -127,10 +127,9 @@ function OwnershipFilterBar({
 interface LoreExplorerProps {
   scopes: ScopeNode[];
   heatmapData: { date: string; count: number }[];
-  feedEvents: ActivityEvent[];
 }
 
-export function LoreExplorer({ scopes, heatmapData, feedEvents }: LoreExplorerProps) {
+export function LoreExplorer({ scopes, heatmapData }: LoreExplorerProps) {
   const { openLesson, openLessonById, closeLesson } = useMemorySidebar();
   const [, startTransition] = useTransition();
   const reduceMotion = useReducedMotion();
@@ -259,16 +258,47 @@ export function LoreExplorer({ scopes, heatmapData, feedEvents }: LoreExplorerPr
 
   const totalCount = scopes.reduce((sum, s) => sum + s.count, 0);
 
-  // Shared memory list renderer (scope view only).
+  const isLessonSelected = (lesson: LessonEntry) =>
+    openLesson?.key === lesson.key && openLesson?.scope === lesson.scope;
+
+  // Shared "Load more" / "all loaded" control — identical for both views so the
+  // pagination affordance never differs between the scope list and the feed.
+  const loadMore = (
+    <div className="flex justify-center pt-2 pb-1">
+      {hasNextPage ? (
+        <button
+          type="button"
+          onClick={() => fetchNextPage()}
+          disabled={isFetchingNextPage}
+          className="flex min-h-9 items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-raised)] px-4 py-1.5 text-xs font-medium text-[var(--color-content-secondary)] transition-colors duration-150 hover:bg-[var(--color-bg-elevated)] disabled:opacity-60"
+        >
+          {isFetchingNextPage && (
+            <Loader2
+              className={`size-3.5 ${reduceMotion ? '' : 'animate-spin'}`}
+              aria-hidden
+            />
+          )}
+          {isFetchingNextPage ? 'Loading…' : 'Load more'}
+        </button>
+      ) : (
+        <p className="text-[10px] text-[var(--color-content-tertiary)]">All memories loaded</p>
+      )}
+    </div>
+  );
+
+  // Shared results renderer for BOTH tabs. Loading / error / empty are handled
+  // once here; only the populated body differs — a flat card list ("scope") vs
+  // date-grouped feed rows ("time"). Both consume the SAME `filteredLessons`
+  // (server-filtered by scope/search/range/archived, then owner-narrowed
+  // client-side), so every filter applies identically across tabs.
   //
-  // This is a plain function that is CALLED (`{renderLessonList()}`), not a
-  // nested component rendered as `<LessonList />`. A nested component would get
-  // a fresh type identity on every parent render, so React would unmount and
-  // remount the entire list each time any filter/search/transition state
-  // changed — replaying every card's enter animation even when the same cards
-  // remain. Inlining the returned JSX keeps each keyed <LessonCard> mounted
-  // across renders, so only genuinely-new cards animate in.
-  const renderLessonList = () => {
+  // This is a plain function that is CALLED, not a nested component rendered as
+  // `<Results />`. A nested component would get a fresh type identity on every
+  // parent render, so React would unmount and remount the entire list each time
+  // any filter/search/transition state changed — replaying every card's enter
+  // animation even when the same cards remain. Inlining the returned JSX keeps
+  // each keyed card mounted across renders, so only genuinely-new cards animate.
+  const renderResults = () => {
     if (isLoading) {
       return (
         <div className="flex flex-col gap-2 p-3" aria-label="Loading memories" role="status">
@@ -313,39 +343,33 @@ export function LoreExplorer({ scopes, heatmapData, feedEvents }: LoreExplorerPr
       );
     }
 
+    if (view === 'time') {
+      return (
+        <div className="flex flex-col gap-1">
+          <ActivityFeed
+            lessons={filteredLessons}
+            isSelected={isLessonSelected}
+            onSelect={handleLessonClick}
+          />
+          {loadMore}
+        </div>
+      );
+    }
+
     return (
-      <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-2" role="list" aria-label="Memories">
         {filteredLessons.map((lesson, i) => (
           <div key={`${lesson.scope}::${lesson.key}`} role="listitem">
             <LessonCard
               lesson={lesson}
-              selected={openLesson?.key === lesson.key && openLesson?.scope === lesson.scope}
+              selected={isLessonSelected(lesson)}
               onClick={() => handleLessonClick(lesson)}
               index={i}
             />
           </div>
         ))}
 
-        <div className="flex justify-center pt-2 pb-1">
-          {hasNextPage ? (
-            <button
-              type="button"
-              onClick={() => fetchNextPage()}
-              disabled={isFetchingNextPage}
-              className="flex min-h-9 items-center gap-1.5 rounded-full border border-[var(--color-border)] bg-[var(--color-bg-raised)] px-4 py-1.5 text-xs font-medium text-[var(--color-content-secondary)] transition-colors duration-150 hover:bg-[var(--color-bg-elevated)] disabled:opacity-60"
-            >
-              {isFetchingNextPage && (
-                <Loader2
-                  className={`size-3.5 ${reduceMotion ? '' : 'animate-spin'}`}
-                  aria-hidden
-                />
-              )}
-              {isFetchingNextPage ? 'Loading…' : 'Load more'}
-            </button>
-          ) : (
-            <p className="text-[10px] text-[var(--color-content-tertiary)]">All memories loaded</p>
-          )}
-        </div>
+        {loadMore}
       </div>
     );
   };
@@ -419,147 +443,144 @@ export function LoreExplorer({ scopes, heatmapData, feedEvents }: LoreExplorerPr
         ))}
       </div>
 
-      {/* ── Scope view ──────────────────────────────────────────────────── */}
-      {view === 'scope' && (
-        <>
-          {/* Desktop: side-by-side panels */}
-          <div className="hidden md:flex h-full gap-0 overflow-hidden rounded-xl border border-[var(--color-border)]">
-            <div className="flex w-56 shrink-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-bg-raised)]">
-              <div className="border-b border-[var(--color-border)] px-3 py-2.5">
-                <p className="text-xs font-medium text-[var(--color-content-tertiary)]">Scopes</p>
-              </div>
-              <div className="flex-1 overflow-y-auto">
-                {scopes.length > 0 ? (
-                  <ScopeTree
-                    nodes={scopes}
-                    selected={selectedScope}
-                    onSelect={handleScopeSelect}
-                    totalCount={totalCount}
-                  />
-                ) : (
-                  <EmptyState icon={BookOpen} title="No scopes yet" description="Run an agent to create your first memory." />
-                )}
-              </div>
+      {/* ── Results (shared chrome for both tabs) ───────────────────────────
+          Scope tree + filter bar (search / date / archived) + owner bar are the
+          SAME for "Browse by scope" and "Browse by time"; only the body inside
+          `renderResults()` differs (card list vs date-grouped feed). Lifting
+          the chrome out of the two views is what makes the tabs read as one
+          page and keeps every filter — including Owner — active across both. */}
+
+      {/* Desktop: side-by-side panels */}
+      <div className="hidden md:flex h-full gap-0 overflow-hidden rounded-xl border border-[var(--color-border)]">
+        <div className="flex w-56 shrink-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-bg-raised)]">
+          <div className="border-b border-[var(--color-border)] px-3 py-2.5">
+            <p className="text-xs font-medium text-[var(--color-content-tertiary)]">Scopes</p>
+          </div>
+          <div className="flex-1 overflow-y-auto">
+            {scopes.length > 0 ? (
+              <ScopeTree
+                nodes={scopes}
+                selected={selectedScope}
+                onSelect={handleScopeSelect}
+                totalCount={totalCount}
+              />
+            ) : (
+              <EmptyState icon={BookOpen} title="No scopes yet" description="Run an agent to create your first memory." />
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <div className="flex items-center gap-2 border-b border-[var(--color-border)] p-3">
+            <div className="relative flex-1">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[var(--color-content-tertiary)]" aria-hidden />
+              <input
+                type="search"
+                placeholder="Search memories…"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                aria-label="Search memories"
+                className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] py-2 pl-8 pr-3 text-xs text-[var(--color-content-primary)] placeholder:text-[var(--color-content-tertiary)] focus:border-[var(--color-accent)] focus:outline-none transition-colors duration-150"
+              />
             </div>
-
-            <div className="flex flex-1 flex-col overflow-hidden">
-              <div className="flex items-center gap-2 border-b border-[var(--color-border)] p-3">
-                <div className="relative flex-1">
-                  <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[var(--color-content-tertiary)]" aria-hidden />
-                  <input
-                    type="search"
-                    placeholder="Search memories…"
-                    value={search}
-                    onChange={(e) => setSearch(e.target.value)}
-                    aria-label="Search memories"
-                    className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] py-2 pl-8 pr-3 text-xs text-[var(--color-content-primary)] placeholder:text-[var(--color-content-tertiary)] focus:border-[var(--color-accent)] focus:outline-none transition-colors duration-150"
-                  />
-                </div>
-                <DateRangePicker value={range} onChange={setRange} className="shrink-0" />
-                <button
-                  type="button"
-                  onClick={() => {
-                    setShowArchived(!showArchived);
-                    closeLesson();
-                  }}
-                  aria-pressed={showArchived}
-                  aria-label={showArchived ? 'Showing archived memories — click to show active' : 'Show archived memories'}
-                  title={showArchived ? 'Showing archived' : 'Show archived'}
-                  className={[
-                    'flex min-h-9 shrink-0 items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium transition-all duration-150',
-                    showArchived
-                      ? 'border-amber-400/40 bg-amber-400/10 text-amber-400'
-                      : 'border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-content-tertiary)] hover:border-[var(--color-content-tertiary)] hover:text-[var(--color-content-secondary)]',
-                  ].join(' ')}
-                >
-                  <Archive className="size-3.5" aria-hidden />
-                  <span className="hidden sm:inline">Archived</span>
-                </button>
-              </div>
-
-              <OwnershipFilterBar orgs={orgsInView} value={ownerFilter} onChange={setOwnerFilter} />
-
-              <div className="flex-1 overflow-y-auto p-3" role="list" aria-label="Memories">
-                {renderLessonList()}
-              </div>
-            </div>
+            <DateRangePicker value={range} onChange={setRange} className="shrink-0" />
+            <button
+              type="button"
+              onClick={() => {
+                setShowArchived(!showArchived);
+                closeLesson();
+              }}
+              aria-pressed={showArchived}
+              aria-label={showArchived ? 'Showing archived memories — click to show active' : 'Show archived memories'}
+              title={showArchived ? 'Showing archived' : 'Show archived'}
+              className={[
+                'flex min-h-9 shrink-0 items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium transition-all duration-150',
+                showArchived
+                  ? 'border-amber-400/40 bg-amber-400/10 text-amber-400'
+                  : 'border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-content-tertiary)] hover:border-[var(--color-content-tertiary)] hover:text-[var(--color-content-secondary)]',
+              ].join(' ')}
+            >
+              <Archive className="size-3.5" aria-hidden />
+              <span className="hidden sm:inline">Archived</span>
+            </button>
           </div>
 
-          {/* Mobile: stacked layout — pb-6 so the last card and "Load more" button
-              clear the bottom edge of the scroll container. */}
-          <div className="flex md:hidden flex-col gap-3 pb-6">
-            <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)] overflow-hidden">
-              <button
-                type="button"
-                onClick={() => setScopePanelOpen((v) => !v)}
-                aria-expanded={scopePanelOpen}
-                className="flex w-full min-h-11 items-center justify-between gap-2 px-4 py-2.5 text-sm text-[var(--color-content-primary)]"
-              >
-                <span className="font-medium">
-                  Scope: <span className="text-[var(--color-accent)] font-mono text-xs">{selectedScopeLabel}</span>
-                </span>
-                <ChevronDown
-                  className={['size-4 shrink-0 text-[var(--color-content-tertiary)] transition-transform duration-200', scopePanelOpen ? 'rotate-180' : ''].join(' ')}
-                  aria-hidden
-                />
-              </button>
-              {scopePanelOpen && (
-                <div className="border-t border-[var(--color-border)] max-h-52 overflow-y-auto">
-                  <ScopeTree
-                    nodes={scopes}
-                    selected={selectedScope}
-                    onSelect={handleScopeSelect}
-                    totalCount={totalCount}
-                  />
-                </div>
-              )}
-            </div>
+          <OwnershipFilterBar orgs={orgsInView} value={ownerFilter} onChange={setOwnerFilter} />
 
-            <div className="flex items-center gap-2">
-              <div className="relative flex-1">
-                <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[var(--color-content-tertiary)]" aria-hidden />
-                <input
-                  type="search"
-                  placeholder="Search memories…"
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  aria-label="Search memories"
-                  className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-raised)] py-2 pl-8 pr-3 text-sm text-[var(--color-content-primary)] placeholder:text-[var(--color-content-tertiary)] focus:border-[var(--color-accent)] focus:outline-none transition-colors duration-150"
-                />
-              </div>
-              <DateRangePicker value={range} onChange={setRange} className="shrink-0" />
-              <button
-                type="button"
-                onClick={() => {
-                  setShowArchived(!showArchived);
-                  closeLesson();
-                }}
-                aria-pressed={showArchived}
-                aria-label={showArchived ? 'Showing archived memories — click to show active' : 'Show archived memories'}
-                className={[
-                  'flex min-h-9 shrink-0 items-center justify-center rounded-lg border p-2 transition-all duration-150',
-                  showArchived
-                    ? 'border-amber-400/40 bg-amber-400/10 text-amber-400'
-                    : 'border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-content-tertiary)]',
-                ].join(' ')}
-              >
-                <Archive className="size-4" aria-hidden />
-              </button>
-            </div>
-
-            <OwnershipFilterBar orgs={orgsInView} value={ownerFilter} onChange={setOwnerFilter} />
-
-            <div role="list" aria-label="Memories">
-              {renderLessonList()}
-            </div>
+          <div className="flex-1 overflow-y-auto p-3">
+            {renderResults()}
           </div>
-        </>
-      )}
+        </div>
+      </div>
 
-      {/* ── Time view (former /activity) ────────────────────────────────── */}
-      {view === 'time' && (
-        <ActivityFeed events={feedEvents} range={range} onRangeChange={setRange} />
-      )}
+      {/* Mobile: stacked layout — pb-6 so the last card and "Load more" button
+          clear the bottom edge of the scroll container. */}
+      <div className="flex md:hidden flex-col gap-3 pb-6">
+        <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)] overflow-hidden">
+          <button
+            type="button"
+            onClick={() => setScopePanelOpen((v) => !v)}
+            aria-expanded={scopePanelOpen}
+            className="flex w-full min-h-11 items-center justify-between gap-2 px-4 py-2.5 text-sm text-[var(--color-content-primary)]"
+          >
+            <span className="font-medium">
+              Scope: <span className="text-[var(--color-accent)] font-mono text-xs">{selectedScopeLabel}</span>
+            </span>
+            <ChevronDown
+              className={['size-4 shrink-0 text-[var(--color-content-tertiary)] transition-transform duration-200', scopePanelOpen ? 'rotate-180' : ''].join(' ')}
+              aria-hidden
+            />
+          </button>
+          {scopePanelOpen && (
+            <div className="border-t border-[var(--color-border)] max-h-52 overflow-y-auto">
+              <ScopeTree
+                nodes={scopes}
+                selected={selectedScope}
+                onSelect={handleScopeSelect}
+                totalCount={totalCount}
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1">
+            <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[var(--color-content-tertiary)]" aria-hidden />
+            <input
+              type="search"
+              placeholder="Search memories…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              aria-label="Search memories"
+              className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-raised)] py-2 pl-8 pr-3 text-sm text-[var(--color-content-primary)] placeholder:text-[var(--color-content-tertiary)] focus:border-[var(--color-accent)] focus:outline-none transition-colors duration-150"
+            />
+          </div>
+          <DateRangePicker value={range} onChange={setRange} className="shrink-0" />
+          <button
+            type="button"
+            onClick={() => {
+              setShowArchived(!showArchived);
+              closeLesson();
+            }}
+            aria-pressed={showArchived}
+            aria-label={showArchived ? 'Showing archived memories — click to show active' : 'Show archived memories'}
+            className={[
+              'flex min-h-9 shrink-0 items-center justify-center rounded-lg border p-2 transition-all duration-150',
+              showArchived
+                ? 'border-amber-400/40 bg-amber-400/10 text-amber-400'
+                : 'border-[var(--color-border)] bg-[var(--color-bg-elevated)] text-[var(--color-content-tertiary)]',
+            ].join(' ')}
+          >
+            <Archive className="size-4" aria-hidden />
+          </button>
+        </div>
+
+        <OwnershipFilterBar orgs={orgsInView} value={ownerFilter} onChange={setOwnerFilter} />
+
+        <div>
+          {renderResults()}
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/web/src/components/memory/MemoryCard.tsx
+++ b/packages/web/src/components/memory/MemoryCard.tsx
@@ -10,8 +10,9 @@
  *   - the Activity feed rows        → `layout="row"`     (horizontal, leading icon)
  *   - the "N memories" dropdown     → `density="compact"` (key + one-line preview)
  *
- * Callers pass a normalised {@link MemoryCardModel}. Two adapters are provided
- * for the app's two source shapes; build one inline for anything else.
+ * Callers pass a normalised {@link MemoryCardModel}. The {@link memoryFromLesson}
+ * adapter maps the app's `LessonEntry` shape onto it; build one inline for
+ * anything else.
  */
 
 import type { ReactNode } from 'react';
@@ -74,29 +75,6 @@ export function memoryFromLesson(lesson: {
     archived: Boolean(lesson.archived_at),
     org: lesson.org,
     expiresAt: lesson.expires_at ?? null,
-  };
-}
-
-/** Adapt an Activity event into the card model. */
-export function memoryFromEvent(event: {
-  scope: string;
-  scope_type: ScopePrefix;
-  key: string;
-  value_preview: string;
-  tags?: string[];
-  created_at: string;
-  source_agent?: string | null;
-  trigger?: string | null;
-}): MemoryCardModel {
-  return {
-    scope: event.scope,
-    scopeType: event.scope_type,
-    memoryKey: event.key,
-    preview: event.value_preview,
-    sourceAgent: event.source_agent,
-    trigger: event.trigger,
-    tags: event.tags,
-    timestamp: event.created_at,
   };
 }
 

--- a/packages/web/src/lib/queries/lore.ts
+++ b/packages/web/src/lib/queries/lore.ts
@@ -9,15 +9,12 @@ import type { ScopeNode } from '@/components/lore/ScopeTree';
 import type { LessonEntry } from '@/components/lore/LessonCard';
 import { listMemories, archiveLesson, restoreLesson, type MemoryFilters, type MemoryPage } from '@/lib/lore';
 import type { DateRange } from '@/components/ui/DateRangePicker';
-import type { ActivityEvent } from '@/components/activity/ActivityFeed';
 
 export interface LoreData {
   scopes: ScopeNode[];
   lessons: LessonEntry[];
   /** Heatmap series derived from the same lesson rows — no extra fetch. */
   heatmapData: { date: string; count: number }[];
-  /** Time-ordered feed events derived from the same lesson rows. */
-  feedEvents: ActivityEvent[];
 }
 
 // ---------------------------------------------------------------------------
@@ -86,7 +83,7 @@ async function fetchLoreData(): Promise<LoreData> {
     .order('created_at', { ascending: false })
     .limit(500);
 
-  if (error || !data) return { scopes: [], lessons: [], heatmapData: [], feedEvents: [] };
+  if (error || !data) return { scopes: [], lessons: [], heatmapData: [] };
 
   const lessons: LessonEntry[] = data.map((row: Record<string, unknown>) => {
     const orgId = (row.org_id as string | null) ?? null;
@@ -136,20 +133,7 @@ async function fetchLoreData(): Promise<LoreData> {
     lessons.map((l) => ({ created_at: new Date(l.created_at).toISOString() })),
   );
 
-  // Derive time-ordered feed events (same shape as the old /activity page).
-  const feedEvents: ActivityEvent[] = data.map((row: Record<string, unknown>) => ({
-    id: row.id as string,
-    scope: row.scope as string,
-    scope_type: scopeType(row.scope as string),
-    key: row.key as string,
-    value_preview: ((row.value as string) ?? '').slice(0, 120),
-    source_agent: row.source_agent as string | null,
-    trigger: row.trigger as string | null,
-    tags: (row.tags as string[]) ?? [],
-    created_at: row.created_at as string,
-  }));
-
-  return { scopes, lessons, heatmapData, feedEvents };
+  return { scopes, lessons, heatmapData };
 }
 
 export function useLoreData() {


### PR DESCRIPTION
## Why

The Lore Explorer's two tabs looked and behaved differently: "Browse by scope" showed search + date + archived + an Owner filter, while "Browse by time" had its own scope pills, its own date picker, and **no Owner filter** — so switching tabs silently dropped ownership filtering and swapped the scope selector. The root cause was two different data sources (paginated `useMemories` vs a 500-row `feedEvents` snapshot).

## What changed

- Drive both tabs from the same `useMemories` query and lift the filter chrome (scope tree, search, date range, archived, Owner) above the view body — only the results layout differs (card list vs date-grouped feed)
- `ActivityFeed` is now a presentational date-grouping renderer over already-filtered lessons, with list semantics matching the scope view
- Removed the `feedEvents` snapshot, `ActivityEvent` type, and unused `memoryFromEvent` adapter; `useLoreData` now serves only the heatmap
- Dropped the feed's private `filter` URL param (its stale `cleanOnPathname: '/activity'` never fired now the feed lives at `/lore`)

## How to verify

- `pnpm nx run-many -t typecheck,test,lint -p web` (all green); in the app, set Owner on one tab and confirm it persists when switching tabs

## Notes for reviewers

The time view is now paginated (50/page with "Load more") instead of a one-shot 500-row snapshot — matching the scope view and `AuditLogFeed`. Older dates stay reachable via a heatmap day-click, which sets a server-side range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kbic33scDgdgTbm9Vk8vNE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kbic33scDgdgTbm9Vk8vNE)_