### PR TITLE
ci: add aggregated CI Summary gate job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,3 +242,49 @@ jobs:
       - name: Stop local Supabase
         if: always()
         run: supabase stop --no-backup
+
+  # ── CI Summary — the single required status check ────────────────────────────
+  #    Aggregates the result of every job above into ONE pass/fail check plus a
+  #    human-readable table in the run summary. Make THIS the only required check
+  #    in branch protection: it fails if any job failed or was cancelled, and
+  #    passes when every job either succeeded or was *intentionally skipped* (the
+  #    path-gated `plugin`/`integration` jobs on unrelated PRs). GitHub's native
+  #    "required check" treats a skipped job as pending forever, which would wedge
+  #    docs/web-only PRs — this job collapses that ambiguity into a real verdict.
+  summary:
+    name: CI Summary
+    runs-on: ubuntu-latest
+    # `always()` so the gate still runs (and reports) even when an upstream job
+    # failed, was cancelled, or was skipped — otherwise it would be skipped too.
+    if: always()
+    needs: [changes, check, plugin, integration]
+    permissions: {}
+    steps:
+      - name: Aggregate job results into a pass/fail gate
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: |
+          echo "### CI Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Job | Result |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| --- | ------ |" >> "$GITHUB_STEP_SUMMARY"
+
+          failed=0
+          while read -r job result; do
+            case "$result" in
+              success)   icon="✅ success" ;;
+              skipped)   icon="⏭️ skipped (not applicable)" ;;
+              failure)   icon="❌ failure";   failed=1 ;;
+              cancelled) icon="🚫 cancelled"; failed=1 ;;
+              *)         icon="❓ $result";    failed=1 ;;
+            esac
+            echo "| \`$job\` | $icon |" >> "$GITHUB_STEP_SUMMARY"
+          done < <(printf '%s' "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$failed" -eq 1 ]; then
+            echo "**CI failed** — one or more required jobs did not succeed." >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::CI failed — one or more required jobs did not succeed. See the summary table."
+            exit 1
+          fi
+          echo "**CI passed** — every job succeeded or was intentionally skipped." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

Adds a single `summary` job to `.github/workflows/ci.yml` that aggregates the result of every other CI job (`changes`, `check`, `plugin`, `integration`) into **one pass/fail status check**, plus a human-readable result table rendered into the run's GitHub Step Summary.

## Why

Today the `plugin` and `integration` jobs are path-gated and **skip** on unrelated PRs (docs/web-only changes). GitHub's native branch protection treats a *skipped* required check as perpetually **pending**, which would wedge those PRs forever if you required the individual jobs directly.

This gate collapses that ambiguity into a real verdict so you can require **exactly one** check on `main`:

- `success` / `skipped` → treated as passing
- `failure` / `cancelled` (or any unexpected state) → fails the gate

The result: skippable jobs can still skip cleanly, while any genuine failure turns the single required check red.

## How

- `needs: [changes, check, plugin, integration]` — waits for all jobs.
- `if: always()` — runs even when an upstream job fails/cancels/skips (otherwise the gate itself would skip and never report).
- `permissions: {}` — no token scopes needed; it only reads `toJSON(needs)`.
- Iterates job results via `jq`, writes a table to `$GITHUB_STEP_SUMMARY`, and `exit 1`s (with a `::error::` annotation) if any job did not succeed-or-skip.

## Reviewer / follow-up note

To actually gate PRs on this, branch protection on `main` needs updating (repo settings, not code):

1. Add **`CI Summary`** as a required status check.
2. Remove `check` / `Plugin smoke` / `Integration smoke` from the required list — let `CI Summary` be the sole required check, since it already accounts for them. Leaving the skippable jobs individually required reintroduces the perpetual-pending wedge this job fixes.

No behavior change to the existing jobs; this is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01REi1MB2df3W4ZV1uawkyxm

---
_Generated by [Claude Code](https://claude.ai/code/session_01REi1MB2df3W4ZV1uawkyxm)_