### PR TITLE
feat(web): polish landing terminal demo, footer, and get-started card

### DIFF
--- a/packages/web/src/app/(auth)/login/page.tsx
+++ b/packages/web/src/app/(auth)/login/page.tsx
@@ -4,6 +4,7 @@ import { LoginButton } from '@/components/auth/LoginButton';
 import { SiteFooter } from '@/components/layout/SiteFooter';
 import { BookOpen, Brain, GitBranch, Zap } from 'lucide-react';
 import { TerminalTheater } from '@/components/landing/TerminalTheater';
+import { CopyCommand } from '@/components/landing/CopyCommand';
 
 export const metadata: Metadata = {
   title: 'Sign in',
@@ -159,11 +160,9 @@ export default function LoginPage() {
             </li>
             <li className="flex gap-3">
               <span className="flex size-6 shrink-0 items-center justify-center rounded-full border border-[var(--color-accent)]/40 bg-[var(--color-accent-subtle)] font-mono text-xs font-semibold text-[var(--color-accent)]">2</span>
-              <div>
+              <div className="min-w-0 flex-1">
                 <p className="text-sm font-medium text-[var(--color-content-primary)] mb-1">Run one command</p>
-                <code className="block mt-1 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)] px-3 py-2 font-mono text-xs text-[var(--color-accent)]">
-                  npx @lorekit/cli install
-                </code>
+                <CopyCommand command="npx @lorekit/cli install" />
               </div>
             </li>
             <li className="flex gap-3">
@@ -174,12 +173,6 @@ export default function LoginPage() {
               </div>
             </li>
           </ol>
-          <div className="flex flex-col items-center gap-2">
-            <Suspense fallback={null}>
-              <LoginButton />
-            </Suspense>
-            <p className="text-xs text-[var(--color-content-tertiary)]">Sign in free · 2-minute setup</p>
-          </div>
         </div>
       </div>
 

--- a/packages/web/src/app/(dashboard)/layout.tsx
+++ b/packages/web/src/app/(dashboard)/layout.tsx
@@ -72,25 +72,19 @@ export default async function DashboardLayout({ children }: { children: React.Re
               <div className="flex flex-1 flex-col overflow-hidden">
                 <TopBar user={user} />
                 {/*
-                  main stays the bounded scroll container (the lore explorer's
-                  desktop two-panel layout relies on this). The footer renders
-                  inside it, after the page content, so it stays subtle —
-                  appearing at the end of the scroll rather than eating fixed
-                  vertical space — while still reachable on every page.
+                  Sticky-footer layout: main is the bounded scroll container AND
+                  a flex column. The content wrapper grows (flex-1) to push the
+                  footer to the bottom of the viewport when a page is shorter than
+                  the screen, while still letting it flow below the content on
+                  taller pages. Driving the growth from flex (rather than a
+                  percentage min-h-full, which is unreliable inside a flex scroll
+                  container) is what keeps the footer pinned to the bottom. The
+                  content wrapper stays a flex-1/min-h-0 block, so the lore
+                  explorer's own h-full layout is unaffected.
                 */}
-                <main className="flex-1 overflow-y-auto p-4 pb-20 md:pb-6 md:p-6">
-                  {/*
-                    Sticky-footer layout: a min-h-full flex column whose content
-                    area grows (flex-1) to push the footer to the bottom of the
-                    viewport when a page is shorter than the screen, while still
-                    letting it flow below the content on taller pages. main stays
-                    the scroll container; the inner content stays an auto-height
-                    block, so the lore explorer's own h-full layout is unaffected.
-                  */}
-                  <div className="flex min-h-full flex-col">
-                    <div className="min-h-0 flex-1">{children}</div>
-                    <SiteFooter className="-mx-4 mt-8 md:-mx-6" />
-                  </div>
+                <main className="flex flex-1 flex-col overflow-y-auto p-4 pb-20 md:pb-6 md:p-6">
+                  <div className="min-h-0 flex-1">{children}</div>
+                  <SiteFooter className="-mx-4 mt-8 md:-mx-6" />
                 </main>
               </div>
             </MemorySidebarProvider>

--- a/packages/web/src/components/auth/LoginButton.tsx
+++ b/packages/web/src/components/auth/LoginButton.tsx
@@ -264,10 +264,11 @@ export function LoginButton({ compact = false }: LoginButtonProps) {
         <span className="h-px flex-1 bg-[var(--color-border)]" aria-hidden />
       </div>
 
-      {/* Secondary: email */}
+      {/* Secondary: email — kept clearly visible (elevated surface + primary
+          text) so it reads as a real alternative, not a muted afterthought. */}
       <button
         onClick={() => setEmailStep('entering')}
-        className="flex h-10 min-w-[220px] items-center justify-center gap-2 rounded-xl border border-[var(--color-border)] bg-transparent px-6 text-sm font-medium text-[var(--color-content-secondary)] transition-all duration-200 hover:border-[var(--color-border)] hover:bg-[var(--color-bg-elevated)] hover:text-[var(--color-content-primary)] focus-visible:outline-2 focus-visible:outline-[var(--color-accent)]"
+        className="flex h-11 min-w-[220px] items-center justify-center gap-2 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elevated)] px-6 text-sm font-medium text-[var(--color-content-primary)] transition-all duration-200 hover:border-[var(--color-accent)] hover:bg-[var(--color-accent-subtle)] hover:text-[var(--color-accent)] focus-visible:outline-2 focus-visible:outline-[var(--color-accent)]"
       >
         <MailIcon className="size-4 shrink-0" />
         Continue with email

--- a/packages/web/src/components/landing/CopyCommand.tsx
+++ b/packages/web/src/components/landing/CopyCommand.tsx
@@ -15,6 +15,8 @@ export function CopyCommand({ command }: { command: string }) {
     navigator.clipboard.writeText(command).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+    }).catch(() => {
+      // Clipboard access denied — fail silently; the command text is still visible.
     });
   }
 

--- a/packages/web/src/components/landing/CopyCommand.tsx
+++ b/packages/web/src/components/landing/CopyCommand.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, Copy } from 'lucide-react';
+
+/**
+ * A single-line, copyable terminal command shown on the public landing page's
+ * "Get started" card. Mirrors the copy affordance of the dashboard's
+ * `CopyableCode` (ClientConfigTabs) but sized for one inline command.
+ */
+export function CopyCommand({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    navigator.clipboard.writeText(command).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className="mt-1 flex items-center justify-between gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)] pl-3 pr-1.5 py-1.5">
+      <code className="min-w-0 truncate font-mono text-xs text-[var(--color-accent)]">
+        {command}
+      </code>
+      <button
+        onClick={handleCopy}
+        aria-label={copied ? 'Copied' : 'Copy command to clipboard'}
+        className="flex shrink-0 items-center gap-1 rounded-md px-2 py-1 text-[10px] font-medium text-[var(--color-content-tertiary)] transition-colors duration-150 hover:bg-[var(--color-bg-raised)] hover:text-[var(--color-accent)] focus-visible:outline-2 focus-visible:outline-[var(--color-accent)]"
+      >
+        {copied
+          ? <><Check className="size-3" aria-hidden /> Copied</>
+          : <><Copy className="size-3" aria-hidden /> Copy</>}
+      </button>
+    </div>
+  );
+}

--- a/packages/web/src/components/landing/TerminalTheater.tsx
+++ b/packages/web/src/components/landing/TerminalTheater.tsx
@@ -229,7 +229,7 @@ function TypewriterLine({
     error:         'text-[var(--color-error)]',
     separator:     'text-[var(--color-content-tertiary)]',
     'session-end': 'text-[var(--color-error)]',
-    'session-start':'text-[var(--color-success)]',
+    'session-start': 'text-[var(--color-success)]',
   };
   const colorClass = LINE_COLOR[type] ?? 'text-[var(--color-content-secondary)]';
 

--- a/packages/web/src/components/landing/TerminalTheater.tsx
+++ b/packages/web/src/components/landing/TerminalTheater.tsx
@@ -2,14 +2,20 @@
 
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { motion, AnimatePresence, useReducedMotion } from 'motion/react';
+import { Cloud, HardDrive } from 'lucide-react';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
+
+/** Where a memory lives: the on-disk offline store or the hosted remote store. */
+type MemoryStore = 'local' | 'remote';
 
 type MemoryCard = {
   id: string;
   key: string;
   value: string;
   source?: string;
+  /** which store this memory persists in — surfaced as an icon on the card */
+  store: MemoryStore;
 };
 
 type LiveCard = MemoryCard & {
@@ -24,6 +30,7 @@ type ScriptLine = {
     | 'success'
     | 'info'
     | 'agent'
+    | 'error'
     | 'separator'
     | 'session-end'
     | 'session-start';
@@ -43,27 +50,88 @@ type UseCase = {
 
 const USE_CASES: UseCase[] = [
   {
+    label: 'Self-healing',
+    act1: [
+      { type: 'command', text: 'pnpm build', pauseAfter: 240 },
+      {
+        type: 'error',
+        text: '✗ ReferenceError: window is not defined  (server component)',
+        pauseAfter: 320,
+      },
+      {
+        type: 'agent',
+        text: '> Agent: Guarded window access with a typeof check.\n         Recording the fix so I never trip on this again.',
+        pauseAfter: 260,
+      },
+      {
+        type: 'command',
+        text: 'memory.write { scope: "repo::lorekit", key: "fix/ssr-window", value: "guard window with typeof check in server components" }',
+        pauseAfter: 60,
+        card: {
+          id: 'ssr',
+          key: 'fix/ssr-window',
+          value: 'guard window with typeof check in server components',
+          store: 'remote',
+        },
+      },
+      { type: 'success', text: '✓ Saved', pauseAfter: 500 },
+      {
+        type: 'error',
+        text: '✗ Hydration mismatch: server/client <time> differ',
+        pauseAfter: 320,
+      },
+      {
+        type: 'agent',
+        text: '> Agent: Rendered the date client-side only.\n         Saving so it never recurs.',
+        pauseAfter: 260,
+      },
+      {
+        type: 'command',
+        text: 'memory.write { scope: "repo::lorekit", key: "fix/hydration-date", value: "render dates client-side only to avoid hydration mismatch" }',
+        pauseAfter: 60,
+        card: {
+          id: 'hydration',
+          key: 'fix/hydration-date',
+          value: 'render dates client-side only to avoid hydration mismatch',
+          store: 'local',
+        },
+      },
+      { type: 'success', text: '✓ Saved', pauseAfter: 800 },
+    ],
+    act2: [
+      { type: 'separator', text: '— New session —', pauseAfter: 320 },
+      { type: 'command', text: 'memory.list { scope: "repo::lorekit" }', pauseAfter: 60 },
+      { type: 'info', text: '  ↳ 2 memories loaded', pauseAfter: 400 },
+      {
+        type: 'agent',
+        text: '> Agent: Known pitfalls here: SSR window access + date hydration.\n         Writing it right the first time.',
+        pauseAfter: 300,
+      },
+      { type: 'success', text: '✓ Past mistakes avoided automatically', pauseAfter: 2000 },
+    ],
+  },
+  {
     label: 'Code conventions',
     act1: [
       {
         type: 'command',
         text: 'memory.write { scope: "repo::lorekit", key: "style/indent", value: "2 spaces" }',
         pauseAfter: 60,
-        card: { id: 'indent', key: 'style/indent', value: '2 spaces' },
+        card: { id: 'indent', key: 'style/indent', value: '2 spaces', store: 'local' },
       },
       { type: 'success', text: '✓ Saved', pauseAfter: 320 },
       {
         type: 'command',
         text: 'memory.write { scope: "repo::lorekit", key: "style/exports", value: "no default exports" }',
         pauseAfter: 60,
-        card: { id: 'exports', key: 'style/exports', value: 'no default exports' },
+        card: { id: 'exports', key: 'style/exports', value: 'no default exports', store: 'local' },
       },
       { type: 'success', text: '✓ Saved', pauseAfter: 320 },
       {
         type: 'command',
         text: 'memory.write { scope: "repo::lorekit", key: "db/columns", value: "snake_case" }',
         pauseAfter: 60,
-        card: { id: 'db', key: 'db/columns', value: 'snake_case' },
+        card: { id: 'db', key: 'db/columns', value: 'snake_case', store: 'remote' },
       },
       { type: 'success', text: '✓ Saved', pauseAfter: 800 },
     ],
@@ -74,47 +142,6 @@ const USE_CASES: UseCase[] = [
       {
         type: 'agent',
         text: '> Agent: I see snake_case for DB columns and 2-space indentation.\n         Continuing with those conventions.',
-        pauseAfter: 300,
-      },
-      { type: 'success', text: '✓ No context re-establishment needed', pauseAfter: 2000 },
-    ],
-  },
-  {
-    label: 'Auth setup',
-    act1: [
-      {
-        type: 'command',
-        text: 'memory.write { scope: "repo::lorekit", key: "auth/provider", value: "Supabase" }',
-        pauseAfter: 60,
-        card: { id: 'provider', key: 'auth/provider', value: 'Supabase' },
-      },
-      { type: 'success', text: '✓ Saved', pauseAfter: 320 },
-      {
-        type: 'command',
-        text: 'memory.write { scope: "repo::lorekit", key: "auth/pattern", value: "RLS with row-level policies" }',
-        pauseAfter: 60,
-        card: { id: 'pattern', key: 'auth/pattern', value: 'RLS with row-level policies' },
-      },
-      { type: 'success', text: '✓ Saved', pauseAfter: 320 },
-      {
-        type: 'command',
-        text: 'memory.write { scope: "repo::lorekit", key: "auth/sessions", value: "httpOnly cookies" }',
-        pauseAfter: 60,
-        card: {
-          id: 'sessions',
-          key: 'auth/sessions',
-          value: 'httpOnly cookies, no JWT in localStorage',
-        },
-      },
-      { type: 'success', text: '✓ Saved', pauseAfter: 800 },
-    ],
-    act2: [
-      { type: 'separator', text: '— New session —', pauseAfter: 320 },
-      { type: 'command', text: 'memory.list { scope: "repo::lorekit" }', pauseAfter: 60 },
-      { type: 'info', text: '  ↳ 3 memories loaded', pauseAfter: 400 },
-      {
-        type: 'agent',
-        text: '> Agent: Auth is Supabase with RLS. Using httpOnly cookies.\n         Skipping the usual setup questions.',
         pauseAfter: 300,
       },
       { type: 'success', text: '✓ No context re-establishment needed', pauseAfter: 2000 },
@@ -132,6 +159,7 @@ const USE_CASES: UseCase[] = [
           key: 'review/logging',
           value: 'use custom logger, not console.log',
           source: 'PR #42',
+          store: 'remote',
         },
       },
       { type: 'success', text: '✓ Saved  (source: PR #42 review comment)', pauseAfter: 320 },
@@ -144,6 +172,7 @@ const USE_CASES: UseCase[] = [
           key: 'review/components',
           value: 'prefer server components',
           source: 'PR #38',
+          store: 'remote',
         },
       },
       { type: 'success', text: '✓ Saved  (source: PR #38 review comment)', pauseAfter: 800 },
@@ -197,6 +226,7 @@ function TypewriterLine({
     success:       'text-[var(--color-success)]',
     info:          'text-[var(--color-scope-repo)]',
     agent:         'text-[var(--color-accent)]',
+    error:         'text-[var(--color-error)]',
     separator:     'text-[var(--color-content-tertiary)]',
     'session-end': 'text-[var(--color-error)]',
     'session-start':'text-[var(--color-success)]',
@@ -263,6 +293,18 @@ function MemoryCard({ card }: { card: LiveCard }) {
             · {card.source}
           </span>
         )}
+
+        {/* Store indicator — makes it explicit whether this memory is kept in
+            the on-disk offline store or the hosted remote store. */}
+        <span
+          className="ml-auto inline-flex items-center gap-1 text-[10px] uppercase tracking-wide text-[var(--color-content-tertiary)]"
+          title={card.store === 'remote' ? 'Hosted remote store' : 'On-disk local store'}
+        >
+          {card.store === 'remote'
+            ? <Cloud className="size-3" aria-hidden />
+            : <HardDrive className="size-3" aria-hidden />}
+          {card.store}
+        </span>
       </div>
 
       <div>
@@ -288,6 +330,14 @@ export function TerminalTheater() {
 
   const [activeTab, setActiveTab] = useState(0);
   const [renderedLines, setRenderedLines] = useState<ScriptLine[]>([]);
+
+  /**
+   * The terminal-output pane has a fixed height (so the window never resizes),
+   * which means a tall script — e.g. the Self-healing act — would otherwise
+   * stream its final, payoff lines below the fold. Keep the newest line in view
+   * by pinning the scroll to the bottom whenever a line is added.
+   */
+  const outputRef = useRef<HTMLDivElement>(null);
 
   /**
    * Single card array. Cards are added (loaded: false) during act 1 and
@@ -416,6 +466,12 @@ export function TerminalTheater() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab]);
 
+  // Keep the latest streamed line visible within the fixed-height output pane.
+  useEffect(() => {
+    const el = outputRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [renderedLines]);
+
   const anyLoaded = act === 'b';
 
   return (
@@ -493,9 +549,11 @@ export function TerminalTheater() {
           </div>
         </div>
 
-        {/* Terminal output */}
+        {/* Terminal output — fixed height so the window never resizes as lines
+            stream in and out (keeps the footer below it from jumping). */}
         <div
-          className="px-4 py-4 min-h-[180px] space-y-1.5"
+          ref={outputRef}
+          className="px-4 py-4 h-[200px] overflow-y-auto space-y-1.5"
           aria-live="polite"
           aria-label="Terminal output"
         >
@@ -528,10 +586,23 @@ export function TerminalTheater() {
               : 'bg-[var(--color-bg-raised)]',
           ].join(' ')}
         >
-          <p className="font-mono text-[10px] text-[var(--color-content-tertiary)] mb-3 uppercase tracking-widest">
-            memory store
-          </p>
-          <div className="flex flex-col gap-2">
+          <div className="mb-3 flex items-center justify-between">
+            <p className="font-mono text-[10px] text-[var(--color-content-tertiary)] uppercase tracking-widest">
+              memory store
+            </p>
+            {/* Legend for the per-card store icons */}
+            <div className="flex items-center gap-3 font-mono text-[10px] uppercase tracking-wide text-[var(--color-content-tertiary)]">
+              <span className="inline-flex items-center gap-1">
+                <HardDrive className="size-3" aria-hidden /> local
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <Cloud className="size-3" aria-hidden /> remote
+              </span>
+            </div>
+          </div>
+          {/* Fixed height so the card list never changes the window height as
+              memories are written one by one. */}
+          <div className="flex flex-col gap-2 h-[200px] overflow-y-auto pr-1">
             <AnimatePresence mode="popLayout">
               {cards.map((card) => (
                 <MemoryCard key={`${activeTab}-${card.id}`} card={card} />

--- a/packages/web/src/components/layout/SiteFooter.tsx
+++ b/packages/web/src/components/layout/SiteFooter.tsx
@@ -16,7 +16,7 @@ const ICON_LINK_CLASS =
 export function SiteFooter({ className = '', ...props }: ComponentPropsWithoutRef<'footer'>) {
   return (
     <footer
-      className={`flex flex-wrap items-center justify-center gap-x-5 gap-y-2 border-t border-[var(--color-border)] px-6 py-4 text-xs text-[var(--color-content-tertiary)] ${className}`}
+      className={`flex flex-wrap items-center justify-center gap-x-4 gap-y-2 border-t border-[var(--color-border)] px-6 py-5 text-xs text-[var(--color-content-tertiary)] ${className}`}
       {...props}
     >
       <a
@@ -37,6 +37,8 @@ export function SiteFooter({ className = '', ...props }: ComponentPropsWithoutRe
         GitHub
       </a>
 
+      <span aria-hidden className="text-[var(--color-border)]">·</span>
+
       <a
         href={DISCORD_URL}
         target="_blank"
@@ -54,6 +56,8 @@ export function SiteFooter({ className = '', ...props }: ComponentPropsWithoutRe
         </svg>
         Discord
       </a>
+
+      <span aria-hidden className="text-[var(--color-border)]">·</span>
 
       <span>
         Need help? Join our{' '}


### PR DESCRIPTION
## Why

The landing page's terminal demo led with generic examples, resized as it animated (making the footer hard to click), and the "Get started" card duplicated the sign-in buttons already shown above. A few surrounding rough edges (faint email button, no copy affordance, cramped/floating footer) added up.

## What changed

- Lead the terminal demo with a **Self-healing** use case (agent hits an error, records the fix, a later session avoids it) — the strongest memory-value story
- Label each demo memory card **local**/**remote** with an icon + legend
- Fix the terminal to a stable height with internal scroll (auto-scrolls to the newest line) so it no longer resizes
- Remove the duplicate sign-in block from the "Get started" card; add a copy button to the install command
- Make "Continue with email" a prominent filled button; add dot separators + spacing to the footer
- Pin the dashboard footer to the bottom via flex growth on `main` (the old `min-h-full` percentage was unreliable in a flex scroll container)

## How to verify

- `pnpm nx typecheck web`, then open `/login` — cycle the terminal tabs and confirm the window height stays fixed