### PR TITLE
fix(web): stop dashboard footer overlap; add Overview stat range selectors

### DIFF
--- a/packages/web/src/app/(dashboard)/layout.tsx
+++ b/packages/web/src/app/(dashboard)/layout.tsx
@@ -72,19 +72,21 @@ export default async function DashboardLayout({ children }: { children: React.Re
               <div className="flex flex-1 flex-col overflow-hidden">
                 <TopBar user={user} />
                 {/*
-                  Sticky-footer layout: main is the bounded scroll container AND
-                  a flex column. The content wrapper grows (flex-1) to push the
-                  footer to the bottom of the viewport when a page is shorter than
-                  the screen, while still letting it flow below the content on
-                  taller pages. Driving the growth from flex (rather than a
-                  percentage min-h-full, which is unreliable inside a flex scroll
-                  container) is what keeps the footer pinned to the bottom. The
-                  content wrapper stays a flex-1/min-h-0 block, so the lore
-                  explorer's own h-full layout is unaffected.
+                  Sticky-footer layout: main is the bounded scroll container. An
+                  inner `min-h-full flex-col` sheet is what makes the footer
+                  behave: the content grows (grow) to push the footer to the
+                  bottom of the viewport on short pages, while on taller pages the
+                  sheet grows past 100% so the footer flows *below* the content and
+                  scrolls with it. `min-h-full` (a floor, not a cap) is the key —
+                  the previous `flex-1 min-h-0` content wrapper capped its box at
+                  the viewport height, so tall pages overflowed it and the footer
+                  floated on top of the content instead of scrolling after it.
                 */}
-                <main className="flex flex-1 flex-col overflow-y-auto p-4 pb-20 md:pb-6 md:p-6">
-                  <div className="min-h-0 flex-1">{children}</div>
-                  <SiteFooter className="-mx-4 mt-8 md:-mx-6" />
+                <main className="flex-1 overflow-y-auto p-4 pb-20 md:pb-6 md:p-6">
+                  <div className="flex min-h-full flex-col">
+                    <div className="grow">{children}</div>
+                    <SiteFooter className="-mx-4 mt-8 md:-mx-6" />
+                  </div>
                 </main>
               </div>
             </MemorySidebarProvider>

--- a/packages/web/src/components/dashboard/DashboardStats.tsx
+++ b/packages/web/src/components/dashboard/DashboardStats.tsx
@@ -63,7 +63,7 @@ function StatRangeSelect({
             aria-checked={active}
             onClick={() => onChange(opt.value)}
             className={[
-              'rounded px-2 py-1 text-[11px] font-medium tabular-nums transition-colors duration-150',
+              'rounded px-1.5 py-0.5 text-[10px] font-medium tabular-nums transition-colors duration-150',
               active
                 ? 'bg-[var(--color-bg-raised)] text-[var(--color-content-primary)] shadow-sm'
                 : 'text-[var(--color-content-tertiary)] hover:text-[var(--color-content-secondary)]',
@@ -225,15 +225,18 @@ export function DashboardStats() {
               <div className="flex size-9 items-center justify-center rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)]">
                 <Icon className="size-4 text-[var(--color-accent)]" aria-hidden />
               </div>
+              {/* Trend chip first, range selector to its right — so the selector
+                  right-aligns consistently across all cards (including "Active",
+                  which has no chip). */}
               <div className="flex items-center gap-2">
+                {showTrend && trend.points.length >= 2 && (
+                  <TrendChip changePct={trend.changePct} title={rangeTrendTitle(range)} />
+                )}
                 <StatRangeSelect
                   value={range}
                   label={label}
                   onChange={(next) => setRanges((prev) => ({ ...prev, [id]: next }))}
                 />
-                {showTrend && trend.points.length >= 2 && (
-                  <TrendChip changePct={trend.changePct} title={rangeTrendTitle(range)} />
-                )}
               </div>
             </div>
             <div>

--- a/packages/web/src/components/dashboard/DashboardStats.tsx
+++ b/packages/web/src/components/dashboard/DashboardStats.tsx
@@ -1,10 +1,81 @@
 'use client';
 
+import { useMemo, useState } from 'react';
 import { BookOpen, Info, Layers, Zap, TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import { ScopeHealthGrid } from '@/components/dashboard/ScopeHealthCard';
 import { Sparkbar } from '@/components/dashboard/Sparkbar';
 import { Tooltip } from '@/components/ui/Tooltip';
 import { useDashboardData } from '@/lib/queries/dashboard';
+import { computeRangeTrends, type MetricRange } from '@/lib/aggregations';
+
+type CardId = 'total' | 'scopes' | 'active';
+
+const RANGE_OPTIONS: { value: MetricRange; label: string }[] = [
+  { value: '24h', label: '24h' },
+  { value: '7d', label: '7d' },
+  { value: '30d', label: '30d' },
+];
+
+const RANGE_NOUN: Record<MetricRange, string> = {
+  '24h': '24 hours',
+  '7d': '7 days',
+  '30d': '30 days',
+};
+
+/** Per-card default range — first two stat cards default to 7d, "Active" to 24h. */
+const DEFAULT_RANGES: Record<CardId, MetricRange> = {
+  total: '7d',
+  scopes: '7d',
+  active: '24h',
+};
+
+function rangeTrendTitle(range: MetricRange): string {
+  return `Last ${RANGE_NOUN[range]} vs. previous ${RANGE_NOUN[range]}`;
+}
+
+/**
+ * Small, subtle segmented control for picking a stat card's time range. A
+ * single-select radiogroup (aria-checked), sized to sit quietly in the card
+ * header without competing with the metric.
+ */
+function StatRangeSelect({
+  value,
+  onChange,
+  label,
+}: {
+  value: MetricRange;
+  onChange: (range: MetricRange) => void;
+  label: string;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={`Time range for ${label}`}
+      className="flex items-center gap-0.5 rounded-md border border-[var(--color-border)] bg-[var(--color-bg-elevated)] p-0.5"
+    >
+      {RANGE_OPTIONS.map((opt) => {
+        const active = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(opt.value)}
+            className={[
+              'rounded px-2 py-1 text-[11px] font-medium tabular-nums transition-colors duration-150',
+              active
+                ? 'bg-[var(--color-bg-raised)] text-[var(--color-content-primary)] shadow-sm'
+                : 'text-[var(--color-content-tertiary)] hover:text-[var(--color-content-secondary)]',
+            ].join(' ')}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 /** Skeleton that matches the real layout to prevent CLS while the query loads. */
 function DashboardStatsSkeleton() {
@@ -59,9 +130,23 @@ function TrendChip({ changePct, title }: { changePct: number; title: string }) {
  * Client component — fetches scope health and lesson stats via TanStack Query.
  * Renders inline skeletons while loading so the surrounding RSC content
  * (header, onboarding checklist) appears immediately.
+ *
+ * Each stat card owns a time-range selector (24h / 7d / 30d). The selected range
+ * drives BOTH the sparkbar buckets and the trend chip, so the chart and the
+ * trend always describe the same period. Trends are recomputed client-side from
+ * the raw rows, so switching a range never refetches.
  */
 export function DashboardStats() {
   const { data, isLoading, isError } = useDashboardData();
+  const [ranges, setRanges] = useState<Record<CardId, MetricRange>>(DEFAULT_RANGES);
+
+  const rows = data?.rows ?? [];
+  // Injected once per data change so the three memoised trend computations stay
+  // stable across unrelated re-renders (and remain pure/testable).
+  const nowIso = useMemo(() => new Date().toISOString(), [rows]);
+  const totalTrends = useMemo(() => computeRangeTrends(rows, nowIso, ranges.total), [rows, nowIso, ranges.total]);
+  const scopeTrends = useMemo(() => computeRangeTrends(rows, nowIso, ranges.scopes), [rows, nowIso, ranges.scopes]);
+  const activeTrends = useMemo(() => computeRangeTrends(rows, nowIso, ranges.active), [rows, nowIso, ranges.active]);
 
   if (isLoading) return <DashboardStatsSkeleton />;
 
@@ -73,65 +158,83 @@ export function DashboardStats() {
     );
   }
 
-  const { scopes, totalLessons, trends } = data;
-  // Rolling 24-hour window (not calendar day) — more relevant than "since
-  // midnight", which resets to 0 every night regardless of recent activity.
-  const dayAgo = Date.now() - 86_400_000;
-  const active24h = scopes.filter(
-    (s) => s.lastActivity != null && new Date(s.lastActivity).getTime() >= dayAgo,
-  ).length;
+  const { scopes, totalLessons } = data;
 
-  const stats = [
+  const cards: {
+    id: CardId;
+    icon: typeof BookOpen;
+    label: string;
+    tooltip: string;
+    value: number;
+    description: string;
+    trend: { points: { label: string; value: number }[]; changePct: number };
+    showTrend: boolean;
+    unit: string;
+    range: MetricRange;
+  }[] = [
     {
+      id: 'total',
       icon: BookOpen,
       label: 'Total memories',
-      tooltip: 'Total number of memories stored across all scopes, based on the most recent 1,000 rows fetched. The trend chip shows the change in memories written in the last 7 days vs. the prior 7 days.',
+      tooltip:
+        'Total number of memories stored across all scopes, based on the most recent 1,000 rows fetched. Use the range selector to view memories written over the last 24 hours, 7 days, or 30 days — the sparkbar and the trend chip always cover the same period.',
       value: totalLessons,
       description: 'across all scopes',
-      trend: trends.lessons,
+      trend: totalTrends.lessons,
       showTrend: true,
       unit: 'memories',
-      trendTitle: 'Last 7 days vs. previous 7',
+      range: ranges.total,
     },
     {
+      id: 'scopes',
       icon: Layers,
-      label: 'Scopes · 7d',
-      tooltip: 'Number of distinct memory scopes (namespaces) that had at least one memory written in the last 7 days. The trend chip compares this week\'s unique scope count to the prior week\'s — useful for spotting whether your agents are exploring new areas or narrowing focus.',
-      value: trends.activeScopes7d,
-      description: 'distinct scopes active this week',
-      trend: trends.scopes,
+      label: 'Scopes',
+      tooltip:
+        'Distinct memory scopes (namespaces) with at least one memory written in the selected range. The trend chip compares this window against the preceding one — useful for spotting whether your agents are exploring new areas or narrowing focus.',
+      value: scopeTrends.activeScopes,
+      description: `distinct scopes active in the last ${RANGE_NOUN[ranges.scopes]}`,
+      trend: scopeTrends.scopes,
       showTrend: true,
       unit: 'scopes',
-      trendTitle: 'Last 7 days vs. previous 7',
+      range: ranges.scopes,
     },
     {
+      id: 'active',
       icon: Zap,
-      label: 'Active · 24h',
-      tooltip: 'Number of distinct scopes that had at least one memory written in the last 24 hours (rolling window, not since midnight). The bar chart below shows hourly memory volume across the same 24-hour period.',
-      value: active24h,
-      description: 'scopes written in the last 24h',
-      trend: trends.activity,
+      label: 'Active',
+      tooltip:
+        'Distinct scopes with at least one memory written in the selected range (rolling window). The bar chart shows memory volume across the same period.',
+      value: activeTrends.activeScopes,
+      description: `scopes active in the last ${RANGE_NOUN[ranges.active]}`,
+      trend: activeTrends.lessons,
       showTrend: false,
       unit: 'memories',
-      trendTitle: 'Last 12 hours vs. previous 12',
+      range: ranges.active,
     },
   ];
 
   return (
     <>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        {stats.map(({ icon: Icon, label, tooltip, value, description, trend, showTrend, unit, trendTitle }) => (
+        {cards.map(({ id, icon: Icon, label, tooltip, value, description, trend, showTrend, unit, range }) => (
           <div
-            key={label}
+            key={id}
             className="flex flex-col gap-3 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)] p-5"
           >
             <div className="flex items-start justify-between gap-2">
               <div className="flex size-9 items-center justify-center rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)]">
                 <Icon className="size-4 text-[var(--color-accent)]" aria-hidden />
               </div>
-              {showTrend && trend.points.length >= 2 && (
-                <TrendChip changePct={trend.changePct} title={trendTitle} />
-              )}
+              <div className="flex items-center gap-2">
+                <StatRangeSelect
+                  value={range}
+                  label={label}
+                  onChange={(next) => setRanges((prev) => ({ ...prev, [id]: next }))}
+                />
+                {showTrend && trend.points.length >= 2 && (
+                  <TrendChip changePct={trend.changePct} title={rangeTrendTitle(range)} />
+                )}
+              </div>
             </div>
             <div>
               <p className="text-2xl font-bold tabular-nums text-[var(--color-content-primary)]">
@@ -155,7 +258,7 @@ export function DashboardStats() {
               points={trend.points}
               unit={unit}
               className="mt-auto h-7 w-full"
-              ariaLabel={`${label}: recent trend`}
+              ariaLabel={`${label}: last ${RANGE_NOUN[range]}`}
             />
           </div>
         ))}

--- a/packages/web/src/components/dashboard/DashboardStats.tsx
+++ b/packages/web/src/components/dashboard/DashboardStats.tsx
@@ -6,7 +6,7 @@ import { ScopeHealthGrid } from '@/components/dashboard/ScopeHealthCard';
 import { Sparkbar } from '@/components/dashboard/Sparkbar';
 import { Tooltip } from '@/components/ui/Tooltip';
 import { useDashboardData } from '@/lib/queries/dashboard';
-import { computeRangeTrends, type MetricRange } from '@/lib/aggregations';
+import { computeRangeTrends, type MetricRange, type StatTrend } from '@/lib/aggregations';
 
 type CardId = 'total' | 'scopes' | 'active';
 
@@ -167,7 +167,7 @@ export function DashboardStats() {
     tooltip: string;
     value: number;
     description: string;
-    trend: { points: { label: string; value: number }[]; changePct: number };
+    trend: StatTrend;
     showTrend: boolean;
     unit: string;
     range: MetricRange;

--- a/packages/web/src/components/lore/MemoryExpandButton.tsx
+++ b/packages/web/src/components/lore/MemoryExpandButton.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useMemo, useRef, useEffect, useState, useCallback } from 'react';
-import { BookOpen, ChevronDown } from 'lucide-react';
+import { BookOpen, ChevronDown, ArrowRight } from 'lucide-react';
 import { motion, AnimatePresence } from 'motion/react';
 import { useLoreData } from '@/lib/queries/lore';
 import { useMemorySidebar } from '@/components/providers/MemorySidebarProvider';
@@ -151,16 +151,17 @@ export function MemoryExpandButton({
                 })}
                 {total > previewCount && (
                   <li>
-                    <p className="px-4 py-2 text-xs text-[var(--color-content-tertiary)]">
-                      +{total - previewCount} more · visit{' '}
-                      <a
-                        href="/lore"
-                        className="text-[var(--color-accent)] underline-offset-2 hover:underline"
-                      >
-                        Lore Explorer
-                      </a>{' '}
-                      to see all.
-                    </p>
+                    {/* Full-width tap target — the whole row navigates to the
+                        Lore Explorer, not just an inline text link. min-h-11
+                        keeps it a comfortable touch target on mobile. */}
+                    <a
+                      href="/lore"
+                      onClick={() => setIsDropdownOpen(false)}
+                      className="flex min-h-11 w-full items-center justify-center gap-1.5 px-4 py-2.5 text-xs font-medium text-[var(--color-accent)] transition-colors duration-150 hover:bg-[var(--color-bg-elevated)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--color-accent)]"
+                    >
+                      See all {total} memories
+                      <ArrowRight className="size-3.5 shrink-0" aria-hidden />
+                    </a>
                   </li>
                 )}
               </ul>

--- a/packages/web/src/lib/aggregations.spec.ts
+++ b/packages/web/src/lib/aggregations.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   aggregateByScope,
   aggregateByDay,
-  computeStatTrends,
+  computeRangeTrends,
   pctChange,
   windowChange,
   scopeWindowChange,
@@ -218,43 +218,49 @@ describe('scopeWindowChange', () => {
   });
 });
 
-// ── computeStatTrends ─────────────────────────────────────────────────────────
+// ── computeRangeTrends ────────────────────────────────────────────────────────
 
-describe('computeStatTrends', () => {
+describe('computeRangeTrends', () => {
   const NOW = '2026-07-24T12:00:00Z'; // Friday
+  const sum = (points: { value: number }[]) => points.reduce((a, p) => a + p.value, 0);
 
-  it('returns daily (30) and hourly (24) bucketed series', () => {
-    const t = computeStatTrends([], NOW);
-    expect(t.lessons.points).toHaveLength(30);
-    expect(t.scopes.points).toHaveLength(30);
-    expect(t.activity.points).toHaveLength(24);
-    expect(t.lessons.points.every((p) => p.value === 0)).toBe(true);
-    expect(t.lessons.changePct).toBe(0);
-    expect(t.activeScopes7d).toBe(0);
+  it('charts the recent window per range (7d → 7 daily, 30d → 30 daily, 24h → 24 hourly)', () => {
+    expect(computeRangeTrends([], NOW, '7d').lessons.points).toHaveLength(7);
+    expect(computeRangeTrends([], NOW, '7d').scopes.points).toHaveLength(7);
+    expect(computeRangeTrends([], NOW, '30d').lessons.points).toHaveLength(30);
+    expect(computeRangeTrends([], NOW, '24h').lessons.points).toHaveLength(24);
   });
 
-  it('counts lessons per day and totals to the in-window count', () => {
+  it('is all-zero and flat for empty input', () => {
+    const t = computeRangeTrends([], NOW, '7d');
+    expect(t.lessons.points.every((p) => p.value === 0)).toBe(true);
+    expect(t.lessons.changePct).toBe(0);
+    expect(t.scopes.changePct).toBe(0);
+    expect(t.activeScopes).toBe(0);
+  });
+
+  it('counts lessons per day with the last bucket = today (7d)', () => {
     const rows = [
       { scope: 'global', created_at: '2026-07-24T10:00:00Z' }, // today
       { scope: 'project::a', created_at: '2026-07-24T11:00:00Z' }, // today
       { scope: 'project::a', created_at: '2026-07-23T09:00:00Z' }, // yesterday
     ];
-    const t = computeStatTrends(rows, NOW);
-    // Last bucket = today.
-    expect(t.lessons.points[t.lessons.points.length - 1]!.value).toBe(2);
-    expect(t.lessons.points[t.lessons.points.length - 2]!.value).toBe(1);
-    const total = t.lessons.points.reduce((a, p) => a + p.value, 0);
-    expect(total).toBe(3);
+    const t = computeRangeTrends(rows, NOW, '7d');
+    const n = t.lessons.points.length;
+    expect(t.lessons.points[n - 1]!.value).toBe(2);
+    expect(t.lessons.points[n - 2]!.value).toBe(1);
+    expect(sum(t.lessons.points)).toBe(3);
   });
 
-  it('counts distinct scopes per day', () => {
+  it('counts distinct scopes per day (7d)', () => {
     const rows = [
       { scope: 'global', created_at: '2026-07-24T10:00:00Z' },
       { scope: 'project::a', created_at: '2026-07-24T11:00:00Z' },
       { scope: 'project::a', created_at: '2026-07-24T12:00:00Z' }, // dup scope same day
     ];
-    const t = computeStatTrends(rows, NOW);
-    expect(t.scopes.points[t.scopes.points.length - 1]!.value).toBe(2); // global + project::a
+    const t = computeRangeTrends(rows, NOW, '7d');
+    const n = t.scopes.points.length;
+    expect(t.scopes.points[n - 1]!.value).toBe(2); // global + project::a
   });
 
   it('counts lessons per hour for the last 24h', () => {
@@ -263,22 +269,37 @@ describe('computeStatTrends', () => {
       { scope: 'global', created_at: '2026-07-24T11:30:00Z' }, // 11:00 bucket
       { scope: 'global', created_at: '2026-07-24T10:15:00Z' }, // 10:00 bucket
     ];
-    const t = computeStatTrends(rows, NOW);
-    expect(t.activity.points).toHaveLength(24);
-    const n = t.activity.points.length;
-    expect(t.activity.points[n - 1]!.value).toBe(0); // 12:00
-    expect(t.activity.points[n - 2]!.value).toBe(1); // 11:00
-    expect(t.activity.points[n - 3]!.value).toBe(1); // 10:00
+    const t = computeRangeTrends(rows, NOW, '24h');
+    const n = t.lessons.points.length;
+    expect(n).toBe(24);
+    expect(t.lessons.points[n - 1]!.value).toBe(0); // 12:00
+    expect(t.lessons.points[n - 2]!.value).toBe(1); // 11:00
+    expect(t.lessons.points[n - 3]!.value).toBe(1); // 10:00
   });
 
-  it('excludes rows older than the daily window', () => {
+  it('excludes rows older than the comparison window (7d)', () => {
     const rows = [{ scope: 'global', created_at: '2026-01-01T10:00:00Z' }];
-    const t = computeStatTrends(rows, NOW);
-    expect(t.lessons.points.reduce((a, p) => a + p.value, 0)).toBe(0);
+    const t = computeRangeTrends(rows, NOW, '7d');
+    expect(sum(t.lessons.points)).toBe(0);
+    expect(t.lessons.changePct).toBe(0);
   });
 
-  // ── scopes.changePct regression ───────────────────────────────────────────
-  it('scopes.changePct uses window-distinct union, not sum of daily distinct counts', () => {
+  it('lessons.changePct compares the recent window vs. the preceding one (7d)', () => {
+    // Prior 7 days (Jul 11–17): 1/day = 7. Recent 7 days (Jul 18–24): 2/day = 14 → +100%.
+    const rows = [
+      ...Array.from({ length: 7 }, (_, i) => ({
+        scope: 'global',
+        created_at: `2026-07-${String(11 + i).padStart(2, '0')}T10:00:00Z`,
+      })),
+      ...Array.from({ length: 14 }, (_, i) => ({
+        scope: 'global',
+        created_at: `2026-07-${String(18 + Math.floor(i / 2)).padStart(2, '0')}T${i % 2 === 0 ? '10' : '14'}:00:00Z`,
+      })),
+    ];
+    expect(computeRangeTrends(rows, NOW, '7d').lessons.changePct).toBe(100);
+  });
+
+  it('scopes.changePct uses window-distinct union, not sum of per-bucket counts (7d)', () => {
     // Recent 7 days (Jul 18–24): 3 scopes, each active on exactly 1 day → union = 3
     // Prior 7 days (Jul 11–17):  1 scope active all 7 days               → union = 1
     // Sum-based (buggy): recent=3, prev=7 → −57% (wrong direction)
@@ -295,11 +316,13 @@ describe('computeStatTrends', () => {
       { scope: 'project::b', created_at: '2026-07-19T10:00:00Z' },
       { scope: 'project::c', created_at: '2026-07-20T10:00:00Z' },
     ];
-    const t = computeStatTrends(rows, NOW);
+    const t = computeRangeTrends(rows, NOW, '7d');
     expect(t.scopes.changePct).toBe(200);
+    // activeScopes is the recent-window distinct union used for the card value.
+    expect(t.activeScopes).toBe(3);
   });
 
-  it('scopes.changePct is 0 when the same scope set is active in both windows', () => {
+  it('scopes.changePct is 0 when the same scope set is active in both windows (7d)', () => {
     const scopes = ['global', 'project::a', 'project::b'];
     const rows = [
       ...scopes.map((scope, i) => ({
@@ -311,84 +334,23 @@ describe('computeStatTrends', () => {
         created_at: `2026-07-${String(18 + i).padStart(2, '0')}T10:00:00Z`,
       })),
     ];
-    const t = computeStatTrends(rows, NOW);
-    expect(t.scopes.changePct).toBe(0);
+    expect(computeRangeTrends(rows, NOW, '7d').scopes.changePct).toBe(0);
   });
 
-  it('lessons.changePct sums counts correctly', () => {
-    // Prior 7 days: 1 lesson/day = 7 total. Recent 7 days: 2 lessons/day = 14 total → +100%
+  it('activeScopes counts distinct scopes active in the selected window (7d)', () => {
     const rows = [
-      ...Array.from({ length: 7 }, (_, i) => ({
-        scope: 'global',
-        created_at: `2026-07-${String(11 + i).padStart(2, '0')}T10:00:00Z`,
-      })),
-      ...Array.from({ length: 14 }, (_, i) => ({
-        scope: 'global',
-        created_at: `2026-07-${String(18 + Math.floor(i / 2)).padStart(2, '0')}T${i % 2 === 0 ? '10' : '14'}:00:00Z`,
-      })),
-    ];
-    const t = computeStatTrends(rows, NOW);
-    expect(t.lessons.changePct).toBe(100);
-  });
-
-  it('activity.changePct compares last 12 hours vs prior 12 hours', () => {
-    // NOW = 12:00 UTC. Prior 12h = yesterday 12:00–23:59 (3 lessons). Recent 12h = today 00:00–11:59 (6 lessons) → +100%
-    const rows = [
-      { scope: 'global', created_at: '2026-07-23T14:00:00Z' },
-      { scope: 'global', created_at: '2026-07-23T16:00:00Z' },
-      { scope: 'global', created_at: '2026-07-23T20:00:00Z' },
-      { scope: 'global', created_at: '2026-07-24T01:00:00Z' },
-      { scope: 'global', created_at: '2026-07-24T03:00:00Z' },
-      { scope: 'global', created_at: '2026-07-24T05:00:00Z' },
-      { scope: 'global', created_at: '2026-07-24T07:00:00Z' },
-      { scope: 'global', created_at: '2026-07-24T09:00:00Z' },
-      { scope: 'global', created_at: '2026-07-24T11:00:00Z' },
-    ];
-    const t = computeStatTrends(rows, NOW);
-    expect(t.activity.changePct).toBe(100);
-  });
-
-  // ── activeScopes7d ────────────────────────────────────────────────────────
-  it('activeScopes7d counts distinct scopes active in the last 7 days', () => {
-    // NOW = 2026-07-24. Last 7 days = Jul 18–24.
-    const rows = [
-      // In window: 3 distinct scopes
       { scope: 'global', created_at: '2026-07-18T10:00:00Z' },
       { scope: 'project::a', created_at: '2026-07-20T10:00:00Z' },
       { scope: 'project::a', created_at: '2026-07-22T10:00:00Z' }, // duplicate scope, same window
       { scope: 'project::b', created_at: '2026-07-24T10:00:00Z' },
-      // Outside window: should not count
-      { scope: 'project::old', created_at: '2026-07-17T23:59:00Z' },
+      { scope: 'project::old', created_at: '2026-07-17T23:59:00Z' }, // outside 7d
     ];
-    const t = computeStatTrends(rows, NOW);
-    // global, project::a, project::b — project::old is outside the 7-day window
-    expect(t.activeScopes7d).toBe(3);
+    expect(computeRangeTrends(rows, NOW, '7d').activeScopes).toBe(3);
   });
 
-  it('activeScopes7d is 0 when no activity in the last 7 days', () => {
-    const rows = [{ scope: 'global', created_at: '2026-07-10T10:00:00Z' }];
-    const t = computeStatTrends(rows, NOW);
-    expect(t.activeScopes7d).toBe(0);
-  });
-
-  it('activeScopes7d matches the recent window used for scopes.changePct', () => {
-    // Same rows as the scopes.changePct regression test.
-    // Recent 7-day union = {project::a, project::b, project::c} → 3
-    const rows = [
-      { scope: 'global', created_at: '2026-07-11T10:00:00Z' },
-      { scope: 'global', created_at: '2026-07-12T10:00:00Z' },
-      { scope: 'global', created_at: '2026-07-13T10:00:00Z' },
-      { scope: 'global', created_at: '2026-07-14T10:00:00Z' },
-      { scope: 'global', created_at: '2026-07-15T10:00:00Z' },
-      { scope: 'global', created_at: '2026-07-16T10:00:00Z' },
-      { scope: 'global', created_at: '2026-07-17T10:00:00Z' },
-      { scope: 'project::a', created_at: '2026-07-18T10:00:00Z' },
-      { scope: 'project::b', created_at: '2026-07-19T10:00:00Z' },
-      { scope: 'project::c', created_at: '2026-07-20T10:00:00Z' },
-    ];
-    const t = computeStatTrends(rows, NOW);
-    expect(t.activeScopes7d).toBe(3);
-    // And the trend confirms: 3 recent vs 1 prior → +200%
-    expect(t.scopes.changePct).toBe(200);
+  it('a wider range admits older rows: 10 days back is out for 7d, in for 30d', () => {
+    const rows = [{ scope: 'project::x', created_at: '2026-07-14T10:00:00Z' }]; // 10 days back
+    expect(computeRangeTrends(rows, NOW, '7d').activeScopes).toBe(0);
+    expect(computeRangeTrends(rows, NOW, '30d').activeScopes).toBe(1);
   });
 });

--- a/packages/web/src/lib/aggregations.ts
+++ b/packages/web/src/lib/aggregations.ts
@@ -86,18 +86,29 @@ export interface StatTrend {
   changePct: number;
 }
 
-export interface StatTrends {
-  /** Lessons written per day, last 30 days. */
+/** Selectable time range for a stat card's chart + trend. */
+export type MetricRange = '24h' | '7d' | '30d';
+
+/** Bucket granularity + count charted for each selectable range. */
+export const RANGE_BUCKETS: Record<MetricRange, { unit: 'hour' | 'day'; count: number }> = {
+  '24h': { unit: 'hour', count: 24 },
+  '7d': { unit: 'day', count: 7 },
+  '30d': { unit: 'day', count: 30 },
+};
+
+/**
+ * A metric's trends for one selected range. `points` cover exactly the charted
+ * (recent) window, and each `changePct` compares that window against the
+ * immediately preceding equal-length window — so the sparkbar and the trend chip
+ * always describe the same period (no chart-vs-trend discrepancy).
+ */
+export interface RangeTrends {
+  /** Memories written per bucket across the selected range. */
   lessons: StatTrend;
-  /** Distinct scopes active per day, last 30 days. */
+  /** Distinct scopes active per bucket across the selected range. */
   scopes: StatTrend;
-  /** Lessons written per hour, last 24 hours. */
-  activity: StatTrend;
-  /**
-   * Count of distinct scopes written to in the last 7 days.
-   * Used as the "Scopes" stat card value so it matches the trend comparison window.
-   */
-  activeScopes7d: number;
+  /** Distinct scopes active anywhere within the selected range window. */
+  activeScopes: number;
 }
 
 const DAY_MS = 86_400_000;
@@ -145,76 +156,80 @@ export function scopeWindowChange(buckets: Set<string>[], k: number): number {
   );
 }
 
+/** Start-of-bucket anchor (UTC) for the bucket containing `now`. */
+function bucketAnchor(now: number, unit: 'hour' | 'day'): number {
+  if (unit === 'hour') return Math.floor(now / HOUR_MS) * HOUR_MS;
+  const d = new Date(now);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}
+
+/** Display label for a bucket start (UTC): "HH:00" for hours, "Mon D" for days. */
+function bucketLabel(start: number, unit: 'hour' | 'day'): string {
+  if (unit === 'hour') return `${String(new Date(start).getUTCHours()).padStart(2, '0')}:00`;
+  return new Date(start).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
 /**
- * Build the three dashboard stat-card trend series, each in its own bucket
- * granularity (all UTC-aligned, oldest → newest):
+ * Build a stat card's trends for a selected range, all UTC-aligned oldest→newest.
  *
- * - `lessons`  — lessons written per day, last 30 days.
- * - `scopes`   — distinct scopes active per day, last 30 days.
- * - `activity` — lessons written per hour, last 24 hours.
- *
- * Each carries a `changePct`: day series compare the last 7 days vs. the prior
- * 7; the hourly series compares the last 12 hours vs. the prior 12.
+ * The range picks the bucket granularity and count (see `RANGE_BUCKETS`): 24h →
+ * 24 hourly buckets, 7d → 7 daily, 30d → 30 daily. To compute a period-over-period
+ * `changePct` without a second query, `2 × count` buckets are tallied and only the
+ * recent `count` are charted; the preceding `count` form the comparison window.
+ * This keeps the sparkbar window identical to the trend window — the two can no
+ * longer disagree.
  *
  * `nowIso` is injected rather than read from the clock so the function is pure
  * and deterministic for tests.
  */
-export function computeStatTrends(rows: TrendRow[], nowIso: string): StatTrends {
+export function computeRangeTrends(
+  rows: TrendRow[],
+  nowIso: string,
+  range: MetricRange,
+): RangeTrends {
+  const { unit, count } = RANGE_BUCKETS[range];
+  const unitMs = unit === 'hour' ? HOUR_MS : DAY_MS;
   const now = Date.parse(nowIso);
   const parsed = rows.map((r) => ({ t: Date.parse(r.created_at), scope: r.scope }));
+  const anchor = bucketAnchor(now, unit);
 
-  // ── Daily buckets: last 30 days, UTC-day aligned. ──
-  const DAYS = 30;
-  const nowDate = new Date(now);
-  const todayMidnight = Date.UTC(nowDate.getUTCFullYear(), nowDate.getUTCMonth(), nowDate.getUTCDate());
-  const lessonsPerDay: BucketPoint[] = [];
-  const scopesPerDay: BucketPoint[] = [];
-  // Retain the raw per-day scope sets for window-distinct changePct (see scopeWindowChange).
-  const scopeSetsPerDay: Set<string>[] = [];
-  for (let i = DAYS - 1; i >= 0; i--) {
-    const start = todayMidnight - i * DAY_MS;
-    const end = start + DAY_MS;
-    let count = 0;
+  // 2 × count buckets: chart the recent half, compare against the prior half.
+  const total = count * 2;
+  const lessonsAll: BucketPoint[] = [];
+  const scopesAll: BucketPoint[] = [];
+  const scopeSetsAll: Set<string>[] = [];
+  for (let i = total - 1; i >= 0; i--) {
+    const start = anchor - i * unitMs;
+    const end = start + unitMs;
+    let c = 0;
     const seen = new Set<string>();
     for (const p of parsed) {
       if (p.t >= start && p.t < end) {
-        count++;
+        c++;
         seen.add(p.scope);
       }
     }
-    const label = new Date(start).toLocaleDateString(undefined, {
-      month: 'short',
-      day: 'numeric',
-      timeZone: 'UTC',
-    });
-    lessonsPerDay.push({ label, value: count });
-    scopesPerDay.push({ label, value: seen.size });
-    scopeSetsPerDay.push(seen);
+    const label = bucketLabel(start, unit);
+    lessonsAll.push({ label, value: c });
+    scopesAll.push({ label, value: seen.size });
+    scopeSetsAll.push(seen);
   }
-
-  // ── Hourly buckets: last 24 hours, UTC-hour aligned. ──
-  const HOURS = 24;
-  const thisHour = Math.floor(now / HOUR_MS) * HOUR_MS;
-  const lessonsPerHour: BucketPoint[] = [];
-  for (let i = HOURS - 1; i >= 0; i--) {
-    const start = thisHour - i * HOUR_MS;
-    const end = start + HOUR_MS;
-    let count = 0;
-    for (const p of parsed) if (p.t >= start && p.t < end) count++;
-    const label = `${String(new Date(start).getUTCHours()).padStart(2, '0')}:00`;
-    lessonsPerHour.push({ label, value: count });
-  }
-
-  // Count of distinct scopes written to in the last 7 days — matches the trend
-  // comparison window so the card value and trend chip describe the same thing.
-  const activeScopes7d = unionSets(scopeSetsPerDay.slice(Math.max(0, scopeSetsPerDay.length - 7))).size;
 
   return {
-    lessons: { points: lessonsPerDay, changePct: windowChange(lessonsPerDay.map((p) => p.value), 7) },
-    // Use window-distinct scope counts: summing daily distinct-scope values
-    // double-counts a scope active on multiple days within the same window.
-    scopes: { points: scopesPerDay, changePct: scopeWindowChange(scopeSetsPerDay, 7) },
-    activity: { points: lessonsPerHour, changePct: windowChange(lessonsPerHour.map((p) => p.value), 12) },
-    activeScopes7d,
+    lessons: {
+      points: lessonsAll.slice(count),
+      changePct: windowChange(lessonsAll.map((p) => p.value), count),
+    },
+    // Window-distinct scope counts: summing per-bucket distinct values would
+    // double-count a scope active in multiple buckets within the same window.
+    scopes: {
+      points: scopesAll.slice(count),
+      changePct: scopeWindowChange(scopeSetsAll, count),
+    },
+    activeScopes: unionSets(scopeSetsAll.slice(count)).size,
   };
 }

--- a/packages/web/src/lib/queries/dashboard.ts
+++ b/packages/web/src/lib/queries/dashboard.ts
@@ -1,25 +1,19 @@
 import { useQuery } from '@tanstack/react-query';
 import { createClient } from '@/lib/supabase/client';
 import { scopeType } from '@/lib/scope';
-import { aggregateByScope, computeStatTrends, type StatTrends } from '@/lib/aggregations';
+import { aggregateByScope, type TrendRow } from '@/lib/aggregations';
 import type { ScopeHealth } from '@/components/dashboard/ScopeHealthCard';
-
-export type { StatTrends };
 
 export interface DashboardData {
   scopes: ScopeHealth[];
   totalLessons: number;
-  /** Per-stat-card trend series (daily / hourly buckets). */
-  trends: StatTrends;
+  /**
+   * Raw trend rows (scope + created_at), newest first. The stat cards compute
+   * their per-card range trends from these client-side, so switching a card's
+   * range (24h / 7d / 30d) never triggers a refetch.
+   */
+  rows: TrendRow[];
 }
-
-const EMPTY_TREND = { points: [], changePct: 0 };
-const EMPTY_TRENDS: StatTrends = {
-  lessons: EMPTY_TREND,
-  scopes: EMPTY_TREND,
-  activity: EMPTY_TREND,
-  activeScopes7d: 0,
-};
 
 async function fetchDashboardData(): Promise<DashboardData> {
   const supabase = createClient();
@@ -37,13 +31,12 @@ async function fetchDashboardData(): Promise<DashboardData> {
     .limit(1000);
 
   if (error || !data) {
-    return { scopes: [], totalLessons: 0, trends: EMPTY_TRENDS };
+    return { scopes: [], totalLessons: 0, rows: [] };
   }
 
   // Normalise timestamps to UTC ISO once, reuse everywhere.
-  const rows = data.map((row) => ({
+  const rows: TrendRow[] = data.map((row) => ({
     scope: row.scope as string,
-    key: row.key as string,
     created_at: new Date(row.created_at as string).toISOString(),
   }));
 
@@ -57,10 +50,7 @@ async function fetchDashboardData(): Promise<DashboardData> {
     lastActivity,
   }));
 
-  // Per-stat-card trend series (daily / hourly buckets).
-  const trends = computeStatTrends(rows, new Date().toISOString());
-
-  return { scopes, totalLessons: data.length, trends };
+  return { scopes, totalLessons: data.length, rows };
 }
 
 export function useDashboardData() {

--- a/packages/web/src/lib/queries/dashboard.ts
+++ b/packages/web/src/lib/queries/dashboard.ts
@@ -24,7 +24,7 @@ async function fetchDashboardData(): Promise<DashboardData> {
   // included in the dashboard total while the plan page excluded them.
   const { data, error } = await supabase
     .from('memories')
-    .select('scope,key,created_at')
+    .select('scope,created_at')
     .is('archived_at', null)
     .or('expires_at.is.null,expires_at.gt.now()')
     .order('created_at', { ascending: false })


### PR DESCRIPTION
## Why

On mobile the dashboard footer floated over page content and covered the "Load more" button so it couldn't be tapped. Separately, the Overview stat cards showed a trend % over a different period than the chart beneath it.

## What changed

- Fix the sticky-footer layout — a `min-h-full` inner sheet instead of a `flex-1 min-h-0` cap — so the footer flows after content (and scrolls with it) instead of floating over it
- Add a per-card **24h / 7d / 30d** range selector to the Overview stats; the range drives both the sparkbar and the trend chip so they always describe the same period (defaults: Total 7d, Scopes 7d, Active 24h)
- Make the memory dropdown's "See all" footer a full-width tap target instead of an inline text link

## How to verify

- `pnpm nx typecheck web && pnpm --filter @lorekit/web exec vitest run` — 280 tests green, incl. the new `computeRangeTrends` suite

## Notes for reviewers

- The 30d trend compares against the prior 30 days, but the query still caps at the 1000 newest rows, so the prior window can be under-sampled on busy instances (pre-existing cap, newly exposed by the 30d option).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqUdHg9jrEqkzrwP2QDg8F

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqUdHg9jrEqkzrwP2QDg8F)_