### PR TITLE
feat(web): use LoreKit logo in login header instead of ⚡ emoji

### DIFF
--- a/packages/web/src/app/(auth)/login/page.tsx
+++ b/packages/web/src/app/(auth)/login/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react';
 import type { Metadata } from 'next';
+import Image from 'next/image';
 import { LoginButton } from '@/components/auth/LoginButton';
 import { SiteFooter } from '@/components/layout/SiteFooter';
 import { BookOpen, Brain, GitBranch, Zap } from 'lucide-react';
@@ -62,9 +63,14 @@ export default function LoginPage() {
 
       <header className="relative z-10 flex h-16 items-center justify-between px-6 md:px-10">
         <div className="flex items-center gap-2.5">
-          <div className="flex size-8 items-center justify-center rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elevated)]">
-            <span className="text-base" aria-hidden>⚡</span>
-          </div>
+          <Image
+            src="/icons/icon-192.png"
+            alt="LoreKit"
+            width={32}
+            height={32}
+            className="shrink-0 rounded-xl"
+            priority
+          />
           <span className="text-sm font-semibold text-[var(--color-content-primary)]">LoreKit</span>
         </div>
         <div className="flex items-center gap-1 sm:gap-3">


### PR DESCRIPTION
## Why

The login page's top header used a generic ⚡ emoji as the brand mark, while the rest of the app (the dashboard sidebar) already shows the real LoreKit logo. This makes the sign-in page look like a placeholder.

## What changed

- Swap the ⚡ emoji box for the actual logo via `next/image` (`/icons/icon-192.png`), mirroring the `Sidebar` pattern so the brand mark is consistent app-wide

## How to verify

- Open `/login`: the top-left brand shows the amber ring logo (not ⚡), next to the "LoreKit" wordmark

---
_Generated by [Claude Code](https://claude.ai/code/session_01UfBPygwmNN7qyTToM8zTpR)_