### PR TITLE
ci: add /preview comment-triggered preview deploy workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,296 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Preview deploy — triggered by a `/preview` comment on a PR.
+#
+# Flow:
+#   1. A maintainer (OWNER / MEMBER / COLLABORATOR) comments `/preview` on a PR.
+#   2. Guard job validates commenter, adds 👀 reaction, resolves PR head SHA.
+#   3. deploy-api: deploys Supabase edge functions + migrations to the
+#      `preview` environment from the PR's pinned head SHA.
+#   4. deploy-web: builds Next.js and deploys a Vercel preview (not promoted
+#      to production). Posts the preview URL.
+#   5. smoke: runs the same smoke tests as deploy.yml's smoke-preview job.
+#   6. report: posts a PR comment with results table + endpoint URLs.
+#
+# Required secrets:
+#   preview environment: SUPABASE_PROJECT_REF, SUPABASE_DB_PASSWORD,
+#                        SUPABASE_ACCESS_TOKEN, LOREKIT_SMOKE_TOKEN
+#   repository level:    VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID
+#   optional:            DISCORD_WEBHOOK_URL
+#
+# Security: issue_comment reads from main's workflow file (not the PR branch).
+# PR head is checked out by pinned SHA, not a user-controllable ref.
+# Only OWNER/MEMBER/COLLABORATOR comments are acted on.
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Preview Deploy
+
+on:
+  issue_comment:
+    types: [created]
+
+concurrency:
+  group: preview-deploy-pr-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  guard:
+    name: Check trigger conditions
+    runs-on: ubuntu-latest
+    if: >
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/preview')
+    permissions:
+      pull-requests: write
+    outputs:
+      authorized: ${{ steps.check.outputs.authorized }}
+      pr_number: ${{ github.event.issue.number }}
+      pr_sha: ${{ steps.pr.outputs.sha }}
+      pr_branch: ${{ steps.pr.outputs.branch }}
+    steps:
+      - name: Check commenter authorization
+        id: check
+        env:
+          ASSOCIATION: ${{ github.event.comment.author_association }}
+        run: |
+          case "$ASSOCIATION" in
+            OWNER|MEMBER|COLLABORATOR)
+              echo "authorized=true" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "authorized=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
+
+      - name: Add 👀 reaction
+        if: steps.check.outputs.authorized == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes',
+            });
+
+      - name: Resolve PR head SHA and branch
+        if: steps.check.outputs.authorized == 'true'
+        id: pr
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            });
+            core.setOutput('sha', pr.data.head.sha);
+            core.setOutput('branch', pr.data.head.ref);
+
+  deploy-api:
+    name: Deploy API → preview
+    runs-on: ubuntu-latest
+    needs: guard
+    if: needs.guard.outputs.authorized == 'true'
+    environment: preview
+    permissions:
+      contents: read
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+      PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.guard.outputs.pr_sha }}
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520 # v3.0.0
+        with:
+          version: latest
+
+      - name: Verify required secrets
+        run: |
+          missing=""
+          [ -z "$PROJECT_REF" ] && missing="$missing SUPABASE_PROJECT_REF"
+          [ -z "$SUPABASE_DB_PASSWORD" ] && missing="$missing SUPABASE_DB_PASSWORD"
+          [ -n "$missing" ] && { echo "::error::Missing secrets:$missing"; exit 1; }
+
+      - name: Tag deploy in Dash0
+        run: |
+          supabase secrets set \
+            VCS_REPOSITORY_URL_FULL="https://github.com/${{ github.repository }}" \
+            VCS_REF_HEAD_NAME="${{ needs.guard.outputs.pr_branch }}" \
+            VCS_REF_HEAD_REVISION="${{ needs.guard.outputs.pr_sha }}" \
+            VCS_REPOSITORY_NAME="${{ github.repository }}" \
+            --project-ref "$PROJECT_REF"
+
+      - name: Link Supabase project
+        run: supabase link --project-ref "$PROJECT_REF"
+
+      - name: Apply database migrations
+        run: supabase db push
+
+      - name: Deploy edge functions
+        run: supabase functions deploy --no-verify-jwt --project-ref "$PROJECT_REF"
+
+  deploy-web:
+    name: Deploy web → Vercel preview
+    runs-on: ubuntu-latest
+    needs: guard
+    if: needs.guard.outputs.authorized == 'true'
+    permissions:
+      contents: read
+    outputs:
+      vercel_url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.guard.outputs.pr_sha }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Vercel CLI
+        run: pnpm add -g vercel
+
+      - name: Pull Vercel environment
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: vercel pull --yes --environment=preview
+
+      - name: Build Vercel preview
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: vercel build
+
+      - name: Deploy to Vercel preview
+        id: deploy
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+        run: |
+          URL=$(vercel deploy --prebuilt 2>&1 | tail -1)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+  smoke:
+    name: Smoke test → preview API
+    runs-on: ubuntu-latest
+    needs: [guard, deploy-api]
+    if: needs.guard.outputs.authorized == 'true'
+    environment: preview
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.guard.outputs.pr_sha }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run MCP server smoke tests
+        run: pnpm nx test mcp-server -- smoke.integration
+        env:
+          LOREKIT_SMOKE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co/functions/v1/mcp
+          LOREKIT_SMOKE_TOKEN: ${{ secrets.LOREKIT_SMOKE_TOKEN }}
+
+      - name: Onboarding smoke (doctor --deep)
+        run: |
+          node packages/cli/bin/lorekit.mjs install --project --no-hooks --yes \
+            --endpoint "$URL" --token "$TOKEN"
+          node packages/cli/bin/lorekit.mjs doctor --deep --endpoint "$URL" --token "$TOKEN"
+        env:
+          URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co/functions/v1/mcp
+          TOKEN: ${{ secrets.LOREKIT_SMOKE_TOKEN }}
+
+  report:
+    name: Post result comment
+    runs-on: ubuntu-latest
+    if: always() && needs.guard.outputs.authorized == 'true'
+    needs: [guard, deploy-api, deploy-web, smoke]
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Post deploy results to PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          RESULT_DEPLOY_API: ${{ needs.deploy-api.result }}
+          RESULT_DEPLOY_WEB: ${{ needs.deploy-web.result }}
+          RESULT_SMOKE: ${{ needs.smoke.result }}
+          VERCEL_URL: ${{ needs.deploy-web.outputs.vercel_url }}
+          PR_SHA: ${{ needs.guard.outputs.pr_sha }}
+          PR_BRANCH: ${{ needs.guard.outputs.pr_branch }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+        with:
+          script: |
+            const icon = r => r === 'success' ? '✅' : r === 'skipped' ? '⏭️' : '❌';
+            const api   = process.env.RESULT_DEPLOY_API;
+            const web   = process.env.RESULT_DEPLOY_WEB;
+            const smoke = process.env.RESULT_SMOKE;
+            const vUrl  = process.env.VERCEL_URL || '(not available)';
+            const sha   = process.env.PR_SHA.slice(0, 7);
+            const branch = process.env.PR_BRANCH;
+            const ref   = process.env.SUPABASE_PROJECT_REF;
+            const apiUrl = ref ? `https://${ref}.supabase.co/functions/v1/mcp` : '(not available)';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const ok    = [api, smoke].every(r => r === 'success');
+            const body  = [
+              `### ${ok ? '✅ Preview deploy succeeded' : '❌ Preview deploy failed'}`,
+              '',
+              `Branch: \`${branch}\` @ \`${sha}\``,
+              '',
+              '| Step | Result |',
+              '| ---- | ------ |',
+              `| API (Supabase edge functions + migrations) | ${icon(api)} ${api} |`,
+              `| Web (Vercel preview) | ${icon(web)} ${web} |`,
+              `| Smoke tests | ${icon(smoke)} ${smoke} |`,
+              '',
+              '**Endpoints:**',
+              `- API: ${apiUrl}`,
+              `- Web: ${vUrl}`,
+              '',
+              `[View workflow run](${runUrl})`,
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body,
+            });
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: ok ? 'rocket' : 'confused',
+            });

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -45,6 +45,7 @@ jobs:
       contains(github.event.comment.body, '/preview')
     permissions:
       pull-requests: write
+      statuses: write
     outputs:
       authorized: ${{ steps.check.outputs.authorized }}
       pr_number: ${{ github.event.issue.number }}
@@ -91,6 +92,21 @@ jobs:
             core.setOutput('sha', pr.data.head.sha);
             core.setOutput('branch', pr.data.head.ref);
 
+      - name: Set pending status check
+        if: steps.check.outputs.authorized == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: '${{ steps.pr.outputs.sha }}',
+              state: 'pending',
+              context: 'Preview Deploy',
+              description: 'Preview deploy in progress…',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
   deploy-api:
     name: Deploy API → preview
     runs-on: ubuntu-latest
@@ -119,7 +135,10 @@ jobs:
           missing=""
           [ -z "$PROJECT_REF" ] && missing="$missing SUPABASE_PROJECT_REF"
           [ -z "$SUPABASE_DB_PASSWORD" ] && missing="$missing SUPABASE_DB_PASSWORD"
-          [ -n "$missing" ] && { echo "::error::Missing secrets:$missing"; exit 1; }
+          if [ -n "$missing" ]; then
+            echo "::error::Missing secrets:$missing"
+            exit 1
+          fi
 
       - name: Tag deploy in Dash0
         run: |
@@ -241,6 +260,7 @@ jobs:
     needs: [guard, deploy-api, deploy-web, smoke]
     permissions:
       pull-requests: write
+      statuses: write
     steps:
       - name: Post deploy results to PR
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -293,4 +313,13 @@ jobs:
               repo: context.repo.repo,
               comment_id: context.payload.comment.id,
               content: ok ? 'rocket' : 'confused',
+            });
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.PR_SHA,
+              state: ok ? 'success' : 'failure',
+              context: 'Preview Deploy',
+              description: ok ? 'Preview deploy succeeded' : 'Preview deploy failed',
+              target_url: runUrl,
             });


### PR DESCRIPTION
## Summary

Adds `.github/workflows/preview.yml` — a preview-deploy pipeline triggered by a `/preview` comment on a PR.

When a maintainer (`OWNER` / `MEMBER` / `COLLABORATOR`) comments `/preview`:

1. **guard** — authorizes the commenter, adds a 👀 reaction, resolves the PR head SHA/branch, and sets a `pending` **Preview Deploy** status check on that SHA.
2. **deploy-api** — deploys Supabase migrations + edge functions to the `preview` environment from the pinned PR head SHA.
3. **deploy-web** — builds and deploys a Vercel preview (not promoted to production).
4. **smoke** — runs the MCP server smoke tests plus an onboarding `doctor --deep`, same as `deploy.yml`'s smoke-preview job.
5. **report** — posts a results-table comment with endpoint URLs, adds a 🚀/😕 reaction, and resolves the **Preview Deploy** status check to `success`/`failure`.

## Notes

- The PR head is checked out by **pinned SHA**, never a user-controllable ref; only `OWNER`/`MEMBER`/`COLLABORATOR` comments are acted on.
- `issue_comment` workflows always run the file from the **default branch** and don't attach a check to the PR on their own — so the workflow explicitly creates a commit status on the PR head SHA, and this file must land on `main` before `/preview` can fire.

## Required secrets

- `preview` environment: `SUPABASE_PROJECT_REF`, `SUPABASE_DB_PASSWORD`, `SUPABASE_ACCESS_TOKEN`, `LOREKIT_SMOKE_TOKEN`
- repository level: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrFg2XkZoDpduYr6US6Hw4)_