### PR TITLE
ci: preview deploy follow-ups — clickable preview URL + staging Supabase config

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -278,7 +278,9 @@ jobs:
             const api   = process.env.RESULT_DEPLOY_API;
             const web   = process.env.RESULT_DEPLOY_WEB;
             const smoke = process.env.RESULT_SMOKE;
-            const vUrl  = process.env.VERCEL_URL || '(not available)';
+            const vUrl  = process.env.VERCEL_URL || '';
+            const hasWeb = /^https?:\/\//.test(vUrl);
+            const webLink = hasWeb ? `[${vUrl}](${vUrl})` : '(not available)';
             const sha   = process.env.PR_SHA.slice(0, 7);
             const branch = process.env.PR_BRANCH;
             const ref   = process.env.SUPABASE_PROJECT_REF;
@@ -289,6 +291,7 @@ jobs:
               `### ${ok ? '✅ Preview deploy succeeded' : '❌ Preview deploy failed'}`,
               '',
               `Branch: \`${branch}\` @ \`${sha}\``,
+              ...(hasWeb ? ['', `🔗 **[Open preview → ${vUrl}](${vUrl})**`] : []),
               '',
               '| Step | Result |',
               '| ---- | ------ |',
@@ -298,7 +301,7 @@ jobs:
               '',
               '**Endpoints:**',
               `- API: ${apiUrl}`,
-              `- Web: ${vUrl}`,
+              `- Web: ${webLink}`,
               '',
               `[View workflow run](${runUrl})`,
             ].join('\n');

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -163,6 +163,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: guard
     if: needs.guard.outputs.authorized == 'true'
+    environment: preview
     permissions:
       contents: read
     outputs:
@@ -194,6 +195,21 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: vercel pull --yes --environment=preview
+
+      # Overrides the Vercel-pulled preview vars with staging values.
+      # .env.local has highest Next.js env precedence and is never committed,
+      # so it cleanly shadows whatever NEXT_PUBLIC_SUPABASE_* values Vercel
+      # pulled for the normal preview environment.
+      - name: Override Supabase config with staging values
+        env:
+          PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          {
+            echo "NEXT_PUBLIC_SUPABASE_URL=https://${PROJECT_REF}.supabase.co"
+            echo "NEXT_PUBLIC_SUPABASE_PROJECT_REF=${PROJECT_REF}"
+            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${ANON_KEY}"
+          } >> packages/web/.env.local
 
       - name: Build Vercel preview
         env:


### PR DESCRIPTION
## Summary

Follow-up refinements to the `/preview` deploy workflow (`.github/workflows/preview.yml`) added in #210, which is now merged.

1. **Clickable preview URL in the report comment** — the Vercel preview URL is rendered as a prominent `🔗 Open preview →` markdown link near the top of the result comment, and as a proper markdown link in the Endpoints list, instead of a bare string. Guarded so it falls back to `(not available)` when no `https://…` URL was captured.

2. **Point the preview web build at staging Supabase** — `deploy-web` gains `environment: preview` (consistent with `deploy-api` / `smoke`) and writes staging `NEXT_PUBLIC_SUPABASE_*` values into `packages/web/.env.local` between `vercel pull` and `vercel build`. `.env.local` has the highest Next.js env precedence and is runner-local (never committed), so it shadows the pulled preview vars for this deploy only — push-triggered Vercel previews are unaffected.

## Required secrets (new)

- `preview` environment: **`SUPABASE_ANON_KEY`** (the anon/publishable key from the staging Supabase project) — must be added for the override step to take effect. `SUPABASE_PROJECT_REF` already exists there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrFg2XkZoDpduYr6US6Hw4)_