### PR TITLE
fix(web): correct preview OAuth redirect when VERCEL_URL is absent in CI build

### DIFF
--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -47,13 +47,23 @@ const nextConfig: NextConfig = {
     // If the user visits the branch alias (e.g. lorekit-git-feat-*) but the
     // OAuth redirectTo points at the deployment URL (lorekit-3zw28wfrv-*),
     // Supabase rejects the callback and the auth fails with "auth_failed".
+    //
+    // Both VERCEL_BRANCH_URL and VERCEL_URL are only populated by Vercel's own
+    // cloud builds / at runtime — NOT during a manual `vercel build` in CI (the
+    // /preview workflow's prebuilt path). When neither is present we must fall
+    // back to '' so LoginButton uses window.location.origin (the actual host the
+    // user is on, where the PKCE code-verifier cookie lives). Building
+    // `https://${undefined}` here would bake a literal "https://undefined" into
+    // the bundle, breaking the OAuth redirectTo and leaving the user logged out.
     NEXT_PUBLIC_VERCEL_URL:
       process.env['VERCEL_ENV'] === 'production'
         ? (process.env['NEXT_PUBLIC_APP_URL'] ?? `https://${process.env['VERCEL_URL']}`)
         : process.env['VERCEL_ENV'] === 'preview'
           ? process.env['VERCEL_BRANCH_URL']
             ? `https://${process.env['VERCEL_BRANCH_URL']}`
-            : `https://${process.env['VERCEL_URL']}`
+            : process.env['VERCEL_URL']
+              ? `https://${process.env['VERCEL_URL']}`
+              : ''
           : '',
 
     // ── VCS resource attributes (OTel semantic conventions) ─────────────────


### PR DESCRIPTION
## Summary

Logging in via GitHub OAuth on a `/preview` deployment returned the user to the app **still logged out**. Root cause is in `next.config.ts`'s `NEXT_PUBLIC_VERCEL_URL` derivation.

In the `/preview` workflow, `vercel build` runs in CI with `VERCEL_ENV=preview` (from `vercel pull`) but **without** `VERCEL_URL` / `VERCEL_BRANCH_URL` — Vercel only populates those in its own cloud builds / at runtime, not in a manual prebuilt CI build. The preview branch then evaluated:

```
`https://${process.env['VERCEL_URL']}`  →  "https://undefined"
```

and baked that literal string into the bundle. `LoginButton` builds `redirectTo` from `NEXT_PUBLIC_VERCEL_URL || window.location.origin`, so the broken string won → `redirectTo = "https://undefined/api/auth/callback"`. Supabase rejected it, fell back to the project Site URL, and the user came back with no session (the PKCE code-verifier cookie lives on the real preview host, so the exchange could never complete anyway).

## Fix

Fall back to `''` when `VERCEL_URL` is also absent, so the client uses `window.location.origin` — the actual host the user is on, where the code-verifier cookie was set. Native Vercel builds still set `VERCEL_URL` / `VERCEL_BRANCH_URL`, so their behaviour is unchanged.

## Note

This is baked at build time, so it needs a fresh `/preview` run after merge to take effect. The Supabase **Redirect URLs** allow-list still needs a wildcard that matches the preview host (e.g. `https://lorekit-*-mads-thines-projects.vercel.app/**`) so Supabase honors the (now-correct) `redirectTo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrFg2XkZoDpduYr6US6Hw4)_