### PR TITLE
ci: retry edge function deploy on transient OOM crash

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,19 @@ jobs:
         run: supabase db push
 
       - name: Deploy edge functions (mcp + health)
-        run: supabase functions deploy --no-verify-jwt --project-ref "$PROJECT_REF"
+        # Retry up to 3 times with 10 s back-off to tolerate transient OOM
+        # crashes (exit 135 / SIGBUS) from the edge-runtime bundler container.
+        run: |
+          for attempt in 1 2 3; do
+            supabase functions deploy --no-verify-jwt --project-ref "$PROJECT_REF" && break
+            rc=$?
+            if [ $attempt -eq 3 ]; then
+              echo "::error::Edge function deploy failed after $attempt attempts (exit $rc)"
+              exit $rc
+            fi
+            echo "::warning::Edge function deploy failed (exit $rc), retrying in 10 s (attempt $attempt/3)..."
+            sleep 10
+          done
 
   # ── 2. Integration test against PREVIEW (the gate before prod) ────────────────
   smoke-preview:
@@ -193,7 +205,19 @@ jobs:
         run: supabase db push
 
       - name: Deploy edge functions (mcp + health)
-        run: supabase functions deploy --no-verify-jwt --project-ref "$PROJECT_REF"
+        # Retry up to 3 times with 10 s back-off to tolerate transient OOM
+        # crashes (exit 135 / SIGBUS) from the edge-runtime bundler container.
+        run: |
+          for attempt in 1 2 3; do
+            supabase functions deploy --no-verify-jwt --project-ref "$PROJECT_REF" && break
+            rc=$?
+            if [ $attempt -eq 3 ]; then
+              echo "::error::Edge function deploy failed after $attempt attempts (exit $rc)"
+              exit $rc
+            fi
+            echo "::warning::Edge function deploy failed (exit $rc), retrying in 10 s (attempt $attempt/3)..."
+            sleep 10
+          done
 
   # ── 4. Post-deploy verification against PRODUCTION ───────────────────────────
   smoke-production:


### PR DESCRIPTION
## What

Wrap both `supabase functions deploy` steps in `deploy.yml` (the `deploy-preview` and `deploy-production` jobs) in a retry loop — up to 3 attempts with a 10 s back-off between them.

## Why

A recent `deploy.yml` run failed at the edge-function deploy step even though the function source was **identical** to the last successful deploy (`69cbf07`). The failure was a transient **OOM crash in the Supabase edge-runtime bundler**, not a code bug:

- Both the failing and last-successful runs used the same edge-runtime image (`ghcr.io/supabase/edge-runtime:v1.74.2`) and the same function source.
- The `health` function bundled fine — only `mcp` (the larger function) failed.
- Exit code 135 = 128 + 7 = SIGBUS inside Docker, a classic OOM-kill signature.
- The commits between the two runs only touched `.github/workflows/` and `docs/` — no function code changed.

## How

Each deploy step now loops up to 3 times, breaking on success. It emits a `::warning::` on each retry and only a hard `::error::` (with the exit code) if all 3 attempts fail, so a genuine deploy failure still fails the job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXHViDUbYJs2bE8BYmMmYw

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXHViDUbYJs2bE8BYmMmYw)_