### PR TITLE
ci: notify a Dash0 Agent0 webhook on deploy/release failure

### DIFF
--- a/.github/actions/dash0-notify/action.yml
+++ b/.github/actions/dash0-notify/action.yml
@@ -1,0 +1,74 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Dash0 failure notification — one place that knows HOW to POST a CI-failure
+# event to a Dash0 Agent0 automation trigger webhook. Each workflow decides WHAT
+# failed (the human-readable stage name) and passes it in; this action builds the
+# JSON event body and posts it. The automation's unique trigger URL carries its
+# own secret key in the path, so the URL itself IS the credential — there is no
+# separate auth header.
+#
+# It is a no-op-safe primitive: if `webhook-url` is empty (the DASH0_WEBHOOK_URL
+# secret is unset) it warns and exits 0 — the underlying failure is already
+# reported loudly by the job that broke, so a missing webhook must never turn a
+# notification into a second, misleading red X.
+#
+# The event body carries a deep link to the failed run, the repository, branch,
+# workflow, short commit SHA, and who triggered it. All values flow through `env:`
+# and jq --arg (never interpolated into the shell) to avoid script injection.
+# ─────────────────────────────────────────────────────────────────────────────
+name: Dash0 failure notification
+description: POST a CI-failure event (deep link + run info) to a Dash0 Agent0 trigger webhook; no-op when the webhook URL is empty.
+
+inputs:
+  webhook-url:
+    description: Dash0 Agent0 automation trigger URL. When empty, the action warns and no-ops (never fails the run).
+    required: true
+  failed-stage:
+    description: Human-readable name of the stage that failed, e.g. "smoke test → production".
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Post failure event to Dash0
+      shell: bash
+      env:
+        DASH0_WEBHOOK_URL: ${{ inputs.webhook-url }}
+        FAILED_STAGE: ${{ inputs.failed-stage }}
+        WORKFLOW: ${{ github.workflow }}
+        COMMIT_SHA: ${{ github.sha }}
+        ACTOR: ${{ github.actor }}
+        REPO: ${{ github.repository }}
+        REF: ${{ github.ref_name }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}
+      run: |
+        if [ -z "$DASH0_WEBHOOK_URL" ]; then
+          echo "::warning::DASH0_WEBHOOK_URL is not set — skipping Dash0 notification. Add it under Settings ▸ Secrets and variables ▸ Actions."
+          exit 0
+        fi
+
+        jq -n \
+          --arg workflow "$WORKFLOW" \
+          --arg failed "$FAILED_STAGE" \
+          --arg sha "$COMMIT_SHA" \
+          --arg actor "$ACTOR" \
+          --arg url "$RUN_URL" \
+          --arg repo "$REPO" \
+          --arg ref "$REF" \
+          --arg commit_url "$COMMIT_URL" \
+          '{
+            event: "ci_failure",
+            workflow: $workflow,
+            failed_stage: $failed,
+            repository: $repo,
+            branch: $ref,
+            commit: $sha[0:7],
+            commit_url: $commit_url,
+            run_url: $url,
+            triggered_by: $actor,
+            summary: "\($workflow) failed at stage: \($failed) (\($repo)@\($sha[0:7]), branch \($ref)). Run: \($url)"
+          }' \
+        | curl -sS --fail-with-body -X POST "$DASH0_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d @-
+        echo "Dash0 failure notification sent (workflow: $WORKFLOW, failed stage: $FAILED_STAGE)."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -351,7 +351,7 @@ jobs:
   #    stage failed and passes it in. The stage name is derived via `env:` (never
   #    interpolated into the shell) to avoid workflow script injection.
   notify-failure:
-    name: Notify Discord on failure
+    name: Notify on failure (Discord + Dash0)
     runs-on: ubuntu-latest
     needs: [deploy-preview, smoke-preview, deploy-production, smoke-production, rollback-production]
     if: always() && contains(needs.*.result, 'failure')
@@ -387,4 +387,10 @@ jobs:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           username: LoreKit Deploy
           title: '🔴 Production deploy failed'
+          failed-stage: ${{ steps.stage.outputs.failed }}
+
+      - name: Post failure event to Dash0
+        uses: ./.github/actions/dash0-notify
+        with:
+          webhook-url: ${{ secrets.DASH0_WEBHOOK_URL }}
           failed-stage: ${{ steps.stage.outputs.failed }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,7 +171,7 @@ jobs:
   #    webhook secret is unset the action itself no-ops with a warning. The failed
   #    stage flows through `env:` (never interpolated) to avoid script injection.
   notify-failure:
-    name: Notify Discord on failure
+    name: Notify on failure (Discord + Dash0)
     runs-on: ubuntu-latest
     needs: [release-please, publish-cli]
     if: always() && contains(needs.*.result, 'failure')
@@ -199,4 +199,10 @@ jobs:
           webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           username: LoreKit Release
           title: '🔴 Release workflow failed'
+          failed-stage: ${{ steps.stage.outputs.failed }}
+
+      - name: Post failure event to Dash0
+        uses: ./.github/actions/dash0-notify
+        with:
+          webhook-url: ${{ secrets.DASH0_WEBHOOK_URL }}
           failed-stage: ${{ steps.stage.outputs.failed }}


### PR DESCRIPTION
## What

Add a Dash0 Agent0 failure notification alongside the existing Discord one. On any failure in `deploy.yml` or `release.yml`, the `notify-failure` job now also POSTs a CI-failure event to a Dash0 Agent0 automation trigger webhook.

## How

- New composite action `.github/actions/dash0-notify/action.yml`, mirroring the existing `discord-notify` primitive: one place that knows *how* to POST; each workflow passes in *what* failed (the human-readable stage name).
- Called from the `notify-failure` job of both `deploy.yml` and `release.yml`, right after the Discord step. The job is renamed to `Notify on failure (Discord + Dash0)`.
- The event body carries workflow name, failed stage, repository, branch, short commit (+ link), run URL, actor, and a one-line summary — all passed through `env:` + `jq --arg` (never interpolated into the shell) to avoid script injection.

## No-op-safe

The Dash0 automation's trigger URL carries its own key in the path, so the URL itself is the credential — there is no separate auth header. When the `DASH0_WEBHOOK_URL` secret is unset the action warns and exits 0, never turning a missing webhook into a second, misleading red X — the same graceful pattern as `discord-notify`.

## Setup required

Add a repository secret **`DASH0_WEBHOOK_URL`** (Settings ▸ Secrets and variables ▸ Actions) set to the Agent0 automation trigger URL. Until it's set, the step no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXHViDUbYJs2bE8BYmMmYw

---
_Generated by [Claude Code](https://claude.ai/code/session_01EXHViDUbYJs2bE8BYmMmYw)_