### PR TITLE
fix(ci): accept new Supabase 'Secret' key in integration smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,8 +200,9 @@ jobs:
         run: |
           supabase status -o json > /tmp/status.json
           # The service-role key the edge runtime injects as SUPABASE_SERVICE_ROLE_KEY.
-          # Field name varies by CLI version (legacy SERVICE_ROLE_KEY vs newer SECRET_KEY).
-          KEY="$(jq -r '.SERVICE_ROLE_KEY // .SECRET_KEY // .service_role_key // empty' /tmp/status.json)"
+          # Field name varies by CLI version (legacy SERVICE_ROLE_KEY/SECRET_KEY vs
+          # newer 'Secret', the sb_secret_... format key).
+          KEY="$(jq -r '.SERVICE_ROLE_KEY // .SECRET_KEY // .service_role_key // .Secret // empty' /tmp/status.json)"
           if [ -z "$KEY" ]; then
             echo "::error::No service-role/secret key in supabase status. Available keys:"
             jq -r 'keys[]' /tmp/status.json

--- a/supabase/functions/import_map.json
+++ b/supabase/functions/import_map.json
@@ -1,6 +1,7 @@
 {
   "imports": {
     "zod": "npm:zod@3",
+    "@asteasolutions/zod-to-openapi": "npm:@asteasolutions/zod-to-openapi@^7",
     "@lorekit/schemas": "../../packages/schemas/src/index.ts",
     "@lorekit/schemas/": "../../packages/schemas/src/",
     "@lorekit/schemas/memory": "../../packages/schemas/src/memory.ts",

--- a/supabase/functions/import_map.json
+++ b/supabase/functions/import_map.json
@@ -1,7 +1,6 @@
 {
   "imports": {
     "zod": "npm:zod@3",
-    "@asteasolutions/zod-to-openapi": "npm:@asteasolutions/zod-to-openapi@^7",
     "@lorekit/schemas": "../../packages/schemas/src/index.ts",
     "@lorekit/schemas/": "../../packages/schemas/src/",
     "@lorekit/schemas/memory": "../../packages/schemas/src/memory.ts",

--- a/supabase/functions/memories/handlers/list.ts
+++ b/supabase/functions/memories/handlers/list.ts
@@ -9,6 +9,8 @@ import type { DbClient } from '../../_shared/api/auth.ts';
 import type { Tables } from '../../_shared/database.types.ts';
 import { getMemberOrgIds, applyRestTenantScope } from '../../_shared/api/tenant.ts';
 
+type MemoryRow = Tables<'memories'>;
+
 export async function handleList(
   req: Request, auth: AuthContext, db: DbClient, span: Span,
   _params: Record<string, string>, cors: Record<string, string>,


### PR DESCRIPTION
The Supabase CLI changed the key names in `supabase status -o json`.
The legacy JWT-based keys (SERVICE_ROLE_KEY / SECRET_KEY /
service_role_key) are gone; the CLI now outputs `Secret` (the new
sb_secret_... format key). The "Capture local service-role key" step
failed with "No service-role/secret key in supabase status", failing
the required CI Summary check and blocking any PR touching
supabase/functions/ or packages/mcp-server/.

Add `.Secret` to the jq fallback chain so the step resolves the key
across old and new CLI versions.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Fd5nda6fhhVwS1LaNxjkSt