### PR TITLE
ci(deploy): unblock deploy smoke (REST test timeout) + seed script for the orgs-smoke user

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,9 @@
 # the memories suite still runs. The write-heavy REST smoke runs against preview
 # only, never production (see the note in smoke-production for why):
 #   SUPABASE_ANON_KEY, LOREKIT_SMOKE_EMAIL, LOREKIT_SMOKE_PASSWORD.
+# The fixed smoke user those name must already exist on the project — seed it
+# once with `node scripts/seed-smoke-user.mjs` (see docs/deployment.md → "Seed
+# the orgs-smoke user"); the mint signs in as it, it is never auto-created.
 # Optional repo-level secret: DISCORD_WEBHOOK_URL — when set, notify-failure posts
 # a message there on any deploy-pipeline failure. Unset → notify-failure no-ops.
 # Add a required reviewer on the `production` environment for a manual gate.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@
 # the memories suite still runs. The write-heavy REST smoke runs against preview
 # only, never production (see the note in smoke-production for why):
 #   SUPABASE_ANON_KEY, LOREKIT_SMOKE_EMAIL, LOREKIT_SMOKE_PASSWORD.
-# The fixed smoke user those name must already exist on the project — seed it
+# The fixed smoke user those secrets name must already exist on the project — seed it
 # once with `node scripts/seed-smoke-user.mjs` (see docs/deployment.md → "Seed
 # the orgs-smoke user"); the mint signs in as it, it is never auto-created.
 # Optional repo-level secret: DISCORD_WEBHOOK_URL — when set, notify-failure posts

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -120,6 +120,14 @@ right values:
 > key. The CLI `doctor --deep` write round-trip only runs for a read+write
 > `lk_*` token; a service-role key (or a JWT) classifies as an unrecognized
 > prefix and the round-trip **silently skips**, so the write path goes untested.
+>
+> Trade-off to name explicitly: with an `lk_rw_*` token, the REST smoke's
+> **`audit_log` read-back** sub-assertions self-skip — reading `audit_log`
+> directly needs the service-role key (RLS bypass) or a user JWT (its own
+> rows), which an `lk_*` API token is not. The CRUD/write path is still fully
+> exercised; only the "was an audit row written" verification is traded away.
+> The orgs audit read-back runs off `LOREKIT_SMOKE_JWT` (a user JWT) and is
+> unaffected.
 
 **Optional — the orgs REST smoke suite (`smoke-preview` only).** Unset → the
 suite is announced-skipped and the memories suite still runs; the deploy is

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -116,11 +116,54 @@ right values:
 | `SUPABASE_DB_PASSWORD` | preview DB password | production DB password |
 | `LOREKIT_SMOKE_TOKEN` | preview `lk_rw_*` token | production `lk_rw_*` token |
 
+> `LOREKIT_SMOKE_TOKEN` should be an **`lk_rw_*`** token, not the service-role
+> key. The CLI `doctor --deep` write round-trip only runs for a read+write
+> `lk_*` token; a service-role key (or a JWT) classifies as an unrecognized
+> prefix and the round-trip **silently skips**, so the write path goes untested.
+
+**Optional — the orgs REST smoke suite (`smoke-preview` only).** Unset → the
+suite is announced-skipped and the memories suite still runs; the deploy is
+never blocked. Set all three to enable it:
+
+| Secret | `preview` environment |
+|--------|-----------------------|
+| `SUPABASE_ANON_KEY` | preview anon (publishable) key |
+| `LOREKIT_SMOKE_EMAIL` | fixed smoke user's email |
+| `LOREKIT_SMOKE_PASSWORD` | fixed smoke user's password |
+
+The org endpoints require a real Supabase **user JWT** (`lk_*` tokens and the
+service-role key are rejected), so `smoke-preview` mints one per run by signing
+in as this fixed user. That user must already exist on the project —
+seed it once with [`scripts/seed-smoke-user.mjs`](#seed-the-orgs-smoke-user)
+below.
+
 Repo-level secrets (not environment-scoped): `SUPABASE_ACCESS_TOKEN` (a Supabase
 personal access token) and — optionally — `DISCORD_WEBHOOK_URL` for
 [failure notifications](#failure-notifications-discord). Add a **required
 reviewer** on the `production` environment for a manual approval gate before prod
 is touched.
+
+#### Seed the orgs-smoke user
+
+The orgs smoke signs in as a fixed user; it never creates one (a smoke run must
+not provision users in a real tenant). Create that user **once per project**
+with the idempotent seed script — it creates + email-confirms the user, resets a
+drifted password on re-run, and verifies the sign-in works end-to-end before
+exiting 0:
+
+```bash
+SUPABASE_URL=https://<preview-ref>.supabase.co \
+SUPABASE_SERVICE_ROLE_KEY=<preview-service-role-key> \
+LOREKIT_SMOKE_EMAIL=<email> \
+LOREKIT_SMOKE_PASSWORD='<password>' \
+  node scripts/seed-smoke-user.mjs
+```
+
+Run it from a trusted admin shell — **not in CI**. Creating a confirmed user
+needs the service-role key (the Auth admin API), which the recurring deploy
+smoke path deliberately does not carry; CI only ever uses the anon key +
+email/password to mint the JWT. Re-run with the production ref + key to seed the
+production project too.
 
 ### Recommended branch protection
 

--- a/packages/mcp-server/src/memories-api.integration.spec.ts
+++ b/packages/mcp-server/src/memories-api.integration.spec.ts
@@ -91,7 +91,15 @@ async function listKeys(archived: boolean): Promise<unknown[]> {
   return ((data as JsonObj).entries as JsonObj[]).map((e) => e.key);
 }
 
-describe.skipIf(SKIP)('LoreKit memories API — smoke tests (integration)', () => {
+// A generous per-test timeout: these suites run against a LIVE endpoint (the
+// deploy pipeline points them at the hosted preview project), and the archive /
+// restore cases chain 4–5 sequential HTTP round-trips. At hosted latency
+// (~0.5–1.3s each) that overruns vitest's 5s default, even though every call
+// succeeds; locally each round-trip is sub-ms so this never bites. 30s is the
+// ceiling per test, not an expected duration.
+const REMOTE_TEST_TIMEOUT = 30_000;
+
+describe.skipIf(SKIP)('LoreKit memories API — smoke tests (integration)', { timeout: REMOTE_TEST_TIMEOUT }, () => {
   let createdIdA = '';
   let createdIdB = '';
   let createdIdR = '';
@@ -474,7 +482,7 @@ describe.skipIf(SKIP)('LoreKit memories API — smoke tests (integration)', () =
  * The writes are fire-and-forget relative to the HTTP response, so every
  * read-back polls briefly rather than reading once.
  */
-describe.skipIf(SKIP)('LoreKit memories API — audit trail read-back (integration)', () => {
+describe.skipIf(SKIP)('LoreKit memories API — audit trail read-back (integration)', { timeout: REMOTE_TEST_TIMEOUT }, () => {
   const AUDIT_KEY = `${KEY_PREFIX}-audit`;
   /** Set by the capability probe in beforeAll. */
   let auditReadable = false;

--- a/packages/mcp-server/src/memories-api.integration.spec.ts
+++ b/packages/mcp-server/src/memories-api.integration.spec.ts
@@ -110,7 +110,10 @@ describe.skipIf(SKIP)('LoreKit memories API — smoke tests (integration)', { ti
     for (const id of [createdIdA, createdIdB, createdIdR, createdIdBackdated].filter(Boolean)) {
       await api('DELETE', `/${id}?force=true`).catch(() => undefined);
     }
-  });
+    // Hooks use hookTimeout (10s default), NOT the suite `timeout` above — and
+    // this cleanup chains 4 sequential DELETEs at hosted latency, so give it the
+    // same 30s ceiling as the tests.
+  }, REMOTE_TEST_TIMEOUT);
 
   // 1. list — baseline ────────────────────────────────────────────────────────
   it('GET /memories — returns a paged response', async () => {
@@ -534,7 +537,7 @@ describe.skipIf(SKIP)('LoreKit memories API — audit trail read-back (integrati
 
   afterAll(async () => {
     if (auditId) await api('DELETE', `/${auditId}?force=true`).catch(() => undefined);
-  });
+  }, REMOTE_TEST_TIMEOUT);
 
   it('the audit_log capability probe ran and reported a definite result', () => {
     // Anti-vacuity: proves beforeAll executed and reached a decision, so a

--- a/packages/mcp-server/src/orgs-api.integration.spec.ts
+++ b/packages/mcp-server/src/orgs-api.integration.spec.ts
@@ -67,9 +67,11 @@ const REMOTE_TEST_TIMEOUT = 30_000;
 
 describe.skipIf(SKIP)('LoreKit orgs API — smoke tests (integration)', { timeout: REMOTE_TEST_TIMEOUT }, () => {
   afterAll(async () => {
-    // Best-effort cleanup — delete the test org if it still exists
+    // Best-effort cleanup — delete the test org if it still exists.
+    // Hooks use hookTimeout (10s default), not the suite `timeout`; give this
+    // live-endpoint cleanup the same 30s ceiling.
     await restFetch('DELETE', `/${TEST_SLUG}`).catch(() => undefined);
-  });
+  }, REMOTE_TEST_TIMEOUT);
 
   // 1. auth: no token → 401/403 ───────────────────────────────────────────────
   it('GET /orgs — returns 401 or 403 when no auth token is provided', async () => {
@@ -250,7 +252,7 @@ describe.skipIf(SKIP)('LoreKit orgs API — audit trail read-back (integration)'
 
   afterAll(async () => {
     await restFetch('DELETE', `/${AUDIT_SLUG}`).catch(() => undefined);
-  });
+  }, REMOTE_TEST_TIMEOUT);
 
   it('the audit_log capability probe ran and reported a definite result', () => {
     expect(probeStatus, 'the probe never issued a request').toBeGreaterThan(0);

--- a/packages/mcp-server/src/orgs-api.integration.spec.ts
+++ b/packages/mcp-server/src/orgs-api.integration.spec.ts
@@ -59,7 +59,13 @@ async function restFetch(
   return { status: res.status, data };
 }
 
-describe.skipIf(SKIP)('LoreKit orgs API — smoke tests (integration)', () => {
+// Live-endpoint suite (hosted preview in the deploy pipeline): the org
+// lifecycle cases chain several sequential RPC round-trips, which overrun
+// vitest's 5s default at hosted latency though each call succeeds. Ceiling per
+// test, not an expected duration; sub-ms locally so it never bites there.
+const REMOTE_TEST_TIMEOUT = 30_000;
+
+describe.skipIf(SKIP)('LoreKit orgs API — smoke tests (integration)', { timeout: REMOTE_TEST_TIMEOUT }, () => {
   afterAll(async () => {
     // Best-effort cleanup — delete the test org if it still exists
     await restFetch('DELETE', `/${TEST_SLUG}`).catch(() => undefined);
@@ -180,7 +186,7 @@ describe.skipIf(SKIP)('LoreKit orgs API — smoke tests (integration)', () => {
  * NOTE: `.github/workflows/ci.yml` does NOT set `LOREKIT_SMOKE_JWT`, so this
  * whole file (pre-existing behaviour, unchanged here) does not run in CI.
  */
-describe.skipIf(SKIP)('LoreKit orgs API — audit trail read-back (integration)', () => {
+describe.skipIf(SKIP)('LoreKit orgs API — audit trail read-back (integration)', { timeout: REMOTE_TEST_TIMEOUT }, () => {
   const AUDIT_SLUG = `smoke-${Date.now()}-audit`;
   const ORG_NAME = 'Audit Read-Back Org';
   const startedAt = new Date().toISOString();

--- a/scripts/seed-smoke-user.mjs
+++ b/scripts/seed-smoke-user.mjs
@@ -164,15 +164,20 @@ const created = await authFetch(`${supabaseUrl}/auth/v1/admin/users`, apikey, {
 if (created.ok) {
   log('  created a new confirmed user');
 } else {
-  // Already exists (or another 4xx). Treat "already registered" as the
-  // heal-the-password path; anything else is a real, reported failure.
-  const msg = JSON.stringify(created.body ?? created.text ?? '').toLowerCase();
+  // Take the heal-the-password path ONLY for a genuine "already registered".
+  // A bare 422 is NOT a reliable signal — GoTrue also returns 422 for
+  // weak_password / invalid email, which would wrongly enter the heal branch
+  // and then die in findUserId ("already existing but was not found"). Match
+  // GoTrue's exists signal precisely (error_code email_exists /
+  // user_already_exists, or the "already been registered" message); 409
+  // Conflict is unambiguous. Anything else is a real, reported failure.
+  const errText = JSON.stringify(created.body ?? created.text ?? '').toLowerCase();
   const alreadyExists =
-    created.status === 422 ||
     created.status === 409 ||
-    msg.includes('already') ||
-    msg.includes('exists') ||
-    msg.includes('registered');
+    errText.includes('email_exists') ||
+    errText.includes('user_already_exists') ||
+    errText.includes('already been registered') ||
+    errText.includes('already registered');
   if (!alreadyExists) {
     fail(
       `admin user creation failed (HTTP ${created.status})\n` +

--- a/scripts/seed-smoke-user.mjs
+++ b/scripts/seed-smoke-user.mjs
@@ -111,19 +111,21 @@ async function trySignIn(supabaseUrl, apikey, email, password) {
 /** Find an existing user's id by email, paging through the admin list. */
 async function findUserId(supabaseUrl, apikey, serviceKey, email) {
   const wanted = email.toLowerCase();
-  const perPage = 200;
-  // Cap the paging so a large project can never spin here forever.
+  // Request 200/page, but terminate on an EMPTY page rather than a short one:
+  // GoTrue may cap `per_page` below what we ask (its default is 50), so a page
+  // shorter than requested is NOT proof it's the last one — only an empty page
+  // is. The page cap is a runaway backstop, not the normal exit.
   for (let page = 1; page <= 50; page++) {
     const { ok, status, body, text } = await authFetch(
-      `${supabaseUrl}/auth/v1/admin/users?page=${page}&per_page=${perPage}`,
+      `${supabaseUrl}/auth/v1/admin/users?page=${page}&per_page=200`,
       apikey,
       { headers: { Authorization: `Bearer ${serviceKey}` } },
     );
     if (!ok) fail(`admin user list failed (HTTP ${status})\n  ${body ? JSON.stringify(body) : text.slice(0, 300)}`);
     const users = Array.isArray(body) ? body : (body?.users ?? []);
+    if (users.length === 0) return null; // genuinely past the last page, no match
     const match = users.find((u) => String(u?.email ?? '').toLowerCase() === wanted);
     if (match?.id) return match.id;
-    if (users.length < perPage) return null; // last page reached, no match
   }
   return null;
 }

--- a/scripts/seed-smoke-user.mjs
+++ b/scripts/seed-smoke-user.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+/**
+ * Seed (idempotently) the fixed smoke user the orgs REST smoke signs in as.
+ *
+ * ## Why a script instead of creating the user by hand
+ *
+ * The orgs smoke (`smoke-rest.mjs` → `orgs-api.integration`) authenticates as a
+ * real Supabase USER (every `lorekit_org_*` RPC is SECURITY DEFINER and resolves
+ * the actor as `auth.uid()` — `lk_*` tokens and the service-role key are both
+ * rejected). `mint-smoke-jwt.mjs` mints that user's JWT in fixed-user mode by
+ * signing in with `LOREKIT_SMOKE_EMAIL`/`LOREKIT_SMOKE_PASSWORD`, but it never
+ * *creates* the user (a smoke run must not provision users in a real tenant).
+ *
+ * So the user has to exist up front. Doing that by hand in the dashboard is
+ * error-prone in exactly the way that bites silently: an unconfirmed email or a
+ * mistyped password both surface only later as `HTTP 400 invalid_credentials`
+ * at mint time — which, with the best-effort mint, is an announced-but-silent
+ * orgs skip, not a hard error. This script removes that class of mistake: it is
+ * idempotent, reproducible, identical across preview and production, and it
+ * VERIFIES the password sign-in end-to-end before reporting success — the exact
+ * thing a manual create can't confirm.
+ *
+ * ## Where to run it
+ *
+ * ONCE per project (preview, then production), from a trusted admin shell —
+ * NOT in CI. Creating a confirmed user requires the service-role key (the Auth
+ * admin API), which the recurring deploy smoke path deliberately does NOT carry
+ * (CI only ever uses the anon key + email/password to mint a JWT). Keep the
+ * service-role key on your machine / a secret store, not in a workflow.
+ *
+ * ## What it does (idempotent, self-healing)
+ *
+ *   1. Try to sign in with the configured email+password. If it already works,
+ *      the user is seeded correctly — exit 0 without touching the admin API.
+ *   2. Otherwise ensure the user via the admin API: create it with
+ *      `email_confirm: true`; if it already exists, reset its password and
+ *      re-confirm it (so a drifted/forgotten password heals on re-run).
+ *   3. Sign in again to PROVE the credential works, then exit 0. If the final
+ *      sign-in still fails, exit non-zero with an actionable message.
+ *
+ * ## Usage
+ *
+ *   SUPABASE_URL=https://<ref>.supabase.co \
+ *   SUPABASE_SERVICE_ROLE_KEY=<service-role-key> \
+ *   LOREKIT_SMOKE_EMAIL=smoke@lorekit.io \
+ *   LOREKIT_SMOKE_PASSWORD='<strong-password>' \
+ *     node scripts/seed-smoke-user.mjs
+ *
+ * Env:
+ *   SUPABASE_URL              e.g. https://<ref>.supabase.co  (or derived from
+ *                             LOREKIT_REST_BASE_URL by stripping /functions/v1)
+ *   SUPABASE_SERVICE_ROLE_KEY required — the Auth admin API (create/update user)
+ *   SUPABASE_ANON_KEY         optional; the service-role key is used as the
+ *                             `apikey` header (for sign-in) when this is unset
+ *   LOREKIT_SMOKE_EMAIL       required
+ *   LOREKIT_SMOKE_PASSWORD    required
+ *
+ * Every diagnostic goes to stderr; the script prints nothing sensitive to
+ * stdout. Exits 0 only when the user exists AND the password sign-in verifies.
+ */
+
+const log = (msg) => process.stderr.write(`${msg}\n`);
+
+function fail(msg) {
+  process.stderr.write(`error: ${msg}\n`);
+  process.exit(1);
+}
+
+/** `http://host/functions/v1` → `http://host`; a bare origin passes through. */
+function resolveSupabaseUrl() {
+  const explicit = process.env.SUPABASE_URL;
+  if (explicit) return explicit.replace(/\/$/, '');
+  const restBase = process.env.LOREKIT_REST_BASE_URL;
+  if (restBase) return restBase.replace(/\/functions\/v1\/?$/, '').replace(/\/$/, '');
+  return 'http://127.0.0.1:54321';
+}
+
+async function authFetch(url, apikey, init = {}) {
+  let res;
+  try {
+    res = await fetch(url, {
+      ...init,
+      headers: { apikey, 'Content-Type': 'application/json', ...(init.headers ?? {}) },
+    });
+  } catch (e) {
+    fail(
+      `cannot reach ${url}\n` +
+        `  ${e?.message ?? e}\n` +
+        `  Is SUPABASE_URL the API origin (no /functions/v1 suffix) and reachable?`,
+    );
+  }
+  const text = await res.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    /* non-JSON error page — surfaced verbatim by callers */
+  }
+  return { status: res.status, ok: res.ok, body, text };
+}
+
+/** Password grant. Returns the access token on success, or null on 400. */
+async function trySignIn(supabaseUrl, apikey, email, password) {
+  const { ok, body } = await authFetch(`${supabaseUrl}/auth/v1/token?grant_type=password`, apikey, {
+    method: 'POST',
+    body: JSON.stringify({ email, password }),
+  });
+  return ok && body?.access_token ? body.access_token : null;
+}
+
+/** Find an existing user's id by email, paging through the admin list. */
+async function findUserId(supabaseUrl, apikey, serviceKey, email) {
+  const wanted = email.toLowerCase();
+  const perPage = 200;
+  // Cap the paging so a large project can never spin here forever.
+  for (let page = 1; page <= 50; page++) {
+    const { ok, status, body, text } = await authFetch(
+      `${supabaseUrl}/auth/v1/admin/users?page=${page}&per_page=${perPage}`,
+      apikey,
+      { headers: { Authorization: `Bearer ${serviceKey}` } },
+    );
+    if (!ok) fail(`admin user list failed (HTTP ${status})\n  ${body ? JSON.stringify(body) : text.slice(0, 300)}`);
+    const users = Array.isArray(body) ? body : (body?.users ?? []);
+    const match = users.find((u) => String(u?.email ?? '').toLowerCase() === wanted);
+    if (match?.id) return match.id;
+    if (users.length < perPage) return null; // last page reached, no match
+  }
+  return null;
+}
+
+const supabaseUrl = resolveSupabaseUrl();
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+// GoTrue only requires `apikey` to be a valid project key; the service-role key
+// qualifies, so the anon key is optional.
+const apikey = process.env.SUPABASE_ANON_KEY || serviceKey;
+const email = process.env.LOREKIT_SMOKE_EMAIL;
+const password = process.env.LOREKIT_SMOKE_PASSWORD;
+
+if (!email || !password) {
+  fail('set LOREKIT_SMOKE_EMAIL and LOREKIT_SMOKE_PASSWORD (the fixed smoke user to seed).');
+}
+if (!serviceKey) {
+  fail('set SUPABASE_SERVICE_ROLE_KEY — creating/confirming a user needs the Auth admin API.');
+}
+
+// 1. Already seeded correctly? Then this is a no-op and we never touch admin.
+if (await trySignIn(supabaseUrl, apikey, email, password)) {
+  log(`ok — smoke user already seeded at ${supabaseUrl} (sign-in verified); nothing to do.`);
+  process.exit(0);
+}
+
+// 2. Ensure the user via the admin API.
+log(`seeding smoke user ${email} at ${supabaseUrl}`);
+const created = await authFetch(`${supabaseUrl}/auth/v1/admin/users`, apikey, {
+  method: 'POST',
+  headers: { Authorization: `Bearer ${serviceKey}` },
+  // email_confirm short-circuits the confirmation mail; without it the user
+  // exists but cannot sign in — the exact silent-skip this script prevents.
+  body: JSON.stringify({ email, password, email_confirm: true }),
+});
+
+if (created.ok) {
+  log('  created a new confirmed user');
+} else {
+  // Already exists (or another 4xx). Treat "already registered" as the
+  // heal-the-password path; anything else is a real, reported failure.
+  const msg = JSON.stringify(created.body ?? created.text ?? '').toLowerCase();
+  const alreadyExists =
+    created.status === 422 ||
+    created.status === 409 ||
+    msg.includes('already') ||
+    msg.includes('exists') ||
+    msg.includes('registered');
+  if (!alreadyExists) {
+    fail(
+      `admin user creation failed (HTTP ${created.status})\n` +
+        `  ${created.body ? JSON.stringify(created.body) : created.text.slice(0, 300)}\n` +
+        `  The key must be the SERVICE-ROLE key — the anon key cannot reach /auth/v1/admin.`,
+    );
+  }
+  log('  user already exists — resetting its password and re-confirming');
+  const id = await findUserId(supabaseUrl, apikey, serviceKey, email);
+  if (!id) {
+    fail(
+      `the user reports as already existing but was not found in the admin list for ${email}.\n` +
+        `  Cannot reset its password. Check the email and that this is the right project.`,
+    );
+  }
+  const updated = await authFetch(`${supabaseUrl}/auth/v1/admin/users/${id}`, apikey, {
+    method: 'PUT',
+    headers: { Authorization: `Bearer ${serviceKey}` },
+    body: JSON.stringify({ password, email_confirm: true }),
+  });
+  if (!updated.ok) {
+    fail(
+      `admin user update failed (HTTP ${updated.status})\n` +
+        `  ${updated.body ? JSON.stringify(updated.body) : updated.text.slice(0, 300)}`,
+    );
+  }
+}
+
+// 3. Prove the credential actually works — the whole point of the script.
+if (!(await trySignIn(supabaseUrl, apikey, email, password))) {
+  fail(
+    'the user was created/updated but the password sign-in still failed.\n' +
+      '  Check that email+password sign-in is enabled on this project (Auth ▸ Providers ▸ Email).',
+  );
+}
+
+log('ok — smoke user seeded and sign-in verified. The orgs REST smoke will now run on this project.');
+process.exit(0);


### PR DESCRIPTION
Stacked follow-up to #265/#267. Two related parts, both about making the deploy pipeline's orgs/REST smoke actually work against the hosted preview project.

## 1. Fix: the actual thing blocking production promotion 🚑

The REST smoke added in #265 first *really ran* against hosted preview in the #267 deploy — and **two `memories-api` tests timed out at vitest's 5s default**, failing `smoke-preview` and blocking `deploy-production`. Both are **pure timeouts, not assertion failures** (`GET /memories?archived=true …` and `POST /memories/restore …`): they chain 4–5 sequential HTTP round-trips, and at hosted latency (~0.5–1.3s/call, per the passing durations) that overruns 5s even though every call succeeds. Locally (CI, ~0 latency) they pass — which is why it only surfaced against a live endpoint. `smoke.integration` doesn't hit this because it makes one call per test.

**Fix:** a 30s per-test timeout on the four live-endpoint suites (memories + orgs, smoke + audit-read-back) via vitest's `describe(name, {timeout}, fn)` option — a ceiling, not an expected duration; sub-ms locally so it never bites there. I empirically verified the option raises the per-test timeout on vitest 4.0.9 (a 6s test passes under a 12s suite timeout, fails under the 5s default).

> Note: production hasn't been promoted since before #265 — every deploy since failed at `smoke-preview` (first the mint hard-fail fixed in #267, now this timeout). This part is what finally gets the pipeline green through to production; it's independent of seeding (the memories suite runs regardless).

## 2. The requested seed script for the orgs-smoke user

`scripts/seed-smoke-user.mjs` — idempotent, self-contained. It (1) tries the sign-in and no-ops if already good, (2) otherwise creates + email-confirms the user via the Auth admin API — resetting the password + re-confirming if it already exists — then (3) **verifies the sign-in end-to-end** before exiting 0. Better than a manual dashboard create: idempotent, reproducible, identical across preview/prod, self-heals a drifted password, and confirms the exact failure mode (`400 invalid_credentials`) can't recur silently. Runs locally/admin (needs the service-role key), **not in CI** — keeping service-role off the recurring deploy path.

Also: `docs/deployment.md` documents the optional orgs-smoke secrets + a "Seed the orgs-smoke user" how-to (and notes `LOREKIT_SMOKE_TOKEN` should be an `lk_rw_*` token, not the service-role key — the drift the failed run exposed); a header pointer in `deploy.yml`; and a paging-robustness fix in the seed script (page until an empty page, not a short one, since GoTrue may cap `per_page`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2aj9YRficSSPTsQHR6YQv)_