### PR TITLE
ci(deploy): unblock db push on out-of-order migrations + add a merge-time order guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,9 @@ jobs:
           fi
           # Migration-order gate: run when a migration is added/changed, or when
           # the guard/CI itself changes (so the guard is exercised on its own PR).
-          if printf '%s\n' "$CHANGED" | grep -qE '^(supabase/migrations/|scripts/check-migration-order\.mjs|\.github/workflows/ci\.yml)'; then
+          # `scripts/check-migration-order` (no extension) matches BOTH the guard
+          # and its `.test.mjs` — so a test-only edit still triggers this job.
+          if printf '%s\n' "$CHANGED" | grep -qE '^(supabase/migrations/|scripts/check-migration-order|\.github/workflows/ci\.yml)'; then
             echo "migrations=true" >> "$GITHUB_OUTPUT"
           else
             echo "migrations=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       api: ${{ steps.filter.outputs.api }}
       plugin: ${{ steps.filter.outputs.plugin }}
+      migrations: ${{ steps.filter.outputs.migrations }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -81,6 +82,13 @@ jobs:
             echo "plugin=true" >> "$GITHUB_OUTPUT"
           else
             echo "plugin=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Migration-order gate: run when a migration is added/changed, or when
+          # the guard/CI itself changes (so the guard is exercised on its own PR).
+          if printf '%s\n' "$CHANGED" | grep -qE '^(supabase/migrations/|scripts/check-migration-order\.mjs|\.github/workflows/ci\.yml)'; then
+            echo "migrations=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "migrations=false" >> "$GITHUB_OUTPUT"
           fi
 
   # ── Typecheck + Test + Lint (only affected packages) ─────────────────────────
@@ -151,6 +159,31 @@ jobs:
 
       - name: Plugin install smoke
         run: bash scripts/smoke-plugin.sh
+
+  # ── Migration-order guard — reject out-of-order migration prefixes ───────────
+  #    Fails a PR that ADDS a migration numbered <= the highest already on the
+  #    base branch — the collision that later wedges `supabase db push` on deploy
+  #    ("migration files to be inserted before the last migration on remote").
+  #    Sequential integer prefixes don't survive parallel PRs; this catches it at
+  #    review time. Path-gated, so unrelated PRs skip it (a skipped required check
+  #    is treated as passing by branch protection). See scripts/check-migration-order.mjs.
+  migration-order:
+    name: Migration order (no out-of-order prefixes)
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.migrations == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # need base + HEAD history to diff the added migrations
+
+      - name: Check migration ordering against the base branch
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/check-migration-order.mjs "$BASE"
 
   # ── Integration smoke — live stack wiring on a local Supabase ────────────────
   #    Boots a full local stack (migrations applied → serves the real Edge
@@ -320,7 +353,7 @@ jobs:
     # `always()` so the gate still runs (and reports) even when an upstream job
     # failed, was cancelled, or was skipped — otherwise it would be skipped too.
     if: always()
-    needs: [changes, check, plugin, integration]
+    needs: [changes, check, plugin, integration, migration-order]
     permissions: {}
     steps:
       - name: Aggregate job results into a pass/fail gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,17 @@ jobs:
         with:
           fetch-depth: 0 # need base + HEAD history to diff the added migrations
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      # Self-test the guard's pure logic first (node's built-in runner, zero deps)
+      # so a regression in the ordering check is caught here, not by letting a bad
+      # migration through or blocking a good PR.
+      - name: Unit-test the guard
+        run: node --test scripts/check-migration-order.test.mjs
+
       - name: Check migration ordering against the base branch
         env:
           BASE: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,7 +91,16 @@ jobs:
         run: supabase link --project-ref "$PROJECT_REF"
 
       - name: Push database migrations
-        run: supabase db push
+        # --include-all applies a migration even when a LOWER-numbered file was
+        # merged after a higher-numbered one already reached this remote — which
+        # happens when parallel PRs pick colliding sequential prefixes (e.g.
+        # #260 shipped 00042, then #266 shipped 00041). Without it `db push`
+        # aborts with "migration files to be inserted before the last migration
+        # on remote". Migrations are still applied in on-disk numeric order; the
+        # PR-time guard (scripts/check-migration-order.mjs, the `migration-order`
+        # CI job) is what stops an out-of-order file from landing in the first
+        # place, so this flag only ever applies already-reviewed, CI-tested ones.
+        run: supabase db push --include-all
 
       - name: Deploy edge functions (mcp + health)
         # Retry up to 3 times with 10 s back-off to tolerate transient OOM
@@ -273,7 +282,16 @@ jobs:
         run: supabase link --project-ref "$PROJECT_REF"
 
       - name: Push database migrations
-        run: supabase db push
+        # --include-all applies a migration even when a LOWER-numbered file was
+        # merged after a higher-numbered one already reached this remote — which
+        # happens when parallel PRs pick colliding sequential prefixes (e.g.
+        # #260 shipped 00042, then #266 shipped 00041). Without it `db push`
+        # aborts with "migration files to be inserted before the last migration
+        # on remote". Migrations are still applied in on-disk numeric order; the
+        # PR-time guard (scripts/check-migration-order.mjs, the `migration-order`
+        # CI job) is what stops an out-of-order file from landing in the first
+        # place, so this flag only ever applies already-reviewed, CI-tested ones.
+        run: supabase db push --include-all
 
       - name: Deploy edge functions (mcp + health)
         # Retry up to 3 times with 10 s back-off to tolerate transient OOM

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -179,12 +179,14 @@ Require a PR to `main` and mark the single **`CI Summary`** job as the required
 status check. It aggregates every job above — `Typecheck, Test & Lint
 (affected)`, `Integration smoke (local Supabase)`, `Plugin smoke`, and
 `Migration order (no out-of-order prefixes)` — into one pass/fail verdict.
-Require **`CI Summary`** rather than those jobs directly: they are path-gated and
-intentionally skip on unrelated PRs, and GitHub treats a *skipped* required job
-as pending forever (which would wedge a docs- or web-only PR), whereas
-`CI Summary` reports success when every job either passed or was skipped. Because
-`deploy.yml` no longer re-runs tests, this check is the sole gate that keeps
-unverified (or migration-breaking) code off `main`.
+Require **`CI Summary`** rather than those jobs directly: it always runs
+(`if: always()`) and collapses every job — including the path-gated ones that
+skip on unrelated PRs — into one definite pass/fail, so branch protection needs
+exactly one check and you never have to reason about how a *skipped* path-gated
+check is counted (GitHub's handling of that is inconsistent, which is the whole
+reason the aggregating job exists). Because `deploy.yml` no longer re-runs
+tests, this check is the sole gate that keeps unverified (or migration-breaking)
+code off `main`.
 
 Also enable **"Require branches to be up to date before merging."** It is what
 closes the last migration-ordering gap: the `migration-order` guard

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -175,10 +175,15 @@ production project too.
 
 ### Recommended branch protection
 
-Require a PR to `main` and mark the `ci.yml` **`Typecheck, Test & Lint
-(affected)`**, **`Integration smoke (local Supabase)`**, and **`Migration order
-(no out-of-order prefixes)`** jobs as required status checks. Because
-`deploy.yml` no longer re-runs tests, these checks are the sole gate that keeps
+Require a PR to `main` and mark the single **`CI Summary`** job as the required
+status check. It aggregates every job above — `Typecheck, Test & Lint
+(affected)`, `Integration smoke (local Supabase)`, `Plugin smoke`, and
+`Migration order (no out-of-order prefixes)` — into one pass/fail verdict.
+Require **`CI Summary`** rather than those jobs directly: they are path-gated and
+intentionally skip on unrelated PRs, and GitHub treats a *skipped* required job
+as pending forever (which would wedge a docs- or web-only PR), whereas
+`CI Summary` reports success when every job either passed or was skipped. Because
+`deploy.yml` no longer re-runs tests, this check is the sole gate that keeps
 unverified (or migration-breaking) code off `main`.
 
 Also enable **"Require branches to be up to date before merging."** It is what

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -176,9 +176,42 @@ production project too.
 ### Recommended branch protection
 
 Require a PR to `main` and mark the `ci.yml` **`Typecheck, Test & Lint
-(affected)`** and **`Integration smoke (local Supabase)`** jobs as required
-status checks. Because `deploy.yml` no longer re-runs tests, these checks are
-the sole gate that keeps unverified (or migration-breaking) code off `main`.
+(affected)`**, **`Integration smoke (local Supabase)`**, and **`Migration order
+(no out-of-order prefixes)`** jobs as required status checks. Because
+`deploy.yml` no longer re-runs tests, these checks are the sole gate that keeps
+unverified (or migration-breaking) code off `main`.
+
+Also enable **"Require branches to be up to date before merging."** It is what
+closes the last migration-ordering gap: the `migration-order` guard
+(below) rejects a PR whose new migration is numbered at or below `main`'s
+highest, but two PRs branched from the same base can each pass in isolation and
+still collide once both merge. Requiring an up-to-date branch forces the second
+to rebase — at which point the guard sees the now-merged higher number and
+fires.
+
+#### Migration ordering (sequential prefixes + parallel PRs)
+
+Migrations use sequential integer prefixes (`00042_…`), which **do not survive
+parallel PRs**: each branch picks "the next number" from its own base, so two
+concurrent PRs can merge a lower number *after* a higher one is already live.
+`supabase db push` then aborts on the next deploy with *"migration files to be
+inserted before the last migration on remote"* — which is exactly what happened
+when `#260` shipped `00042` and `#266` then shipped `00041`.
+
+Two layers keep this from wedging the deploy:
+
+1. **Prevention — the `migration-order` CI job** (`scripts/check-migration-order.mjs`)
+   fails any PR that adds a migration numbered ≤ the highest already on the base
+   branch, telling the author the next free number to rebase-and-renumber to.
+2. **Tolerance — `supabase db push --include-all`** in `deploy.yml` applies an
+   already-reviewed, CI-tested migration even if it sorts before one already on
+   the remote (migrations still apply in on-disk numeric order). This unwedges
+   the grandfathered `00041`/`00042` pair and any future edge case the guard
+   didn't pre-empt.
+
+The collision-proof end state is Supabase's **timestamp filenames**
+(`YYYYMMDDHHMMSS_…`), which are monotonic and parallel-safe — a larger,
+rename-everything change to consider separately.
 
 ---
 

--- a/scripts/check-migration-order.mjs
+++ b/scripts/check-migration-order.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Migration-order guard (PR-time).
+ *
+ * Fails when a pull request ADDS a migration whose numeric prefix is <= the
+ * highest migration already on the base branch — the exact mistake that wedges
+ * the deploy: #260 shipped `00042`, then a parallel PR (#266) shipped `00041`,
+ * which `supabase db push` then refused ("migration files to be inserted before
+ * the last migration on remote"). Sequential integer prefixes have no defense
+ * against parallel PRs each picking "the next number" from their own base; this
+ * catches the collision at review time so it never reaches a deploy.
+ *
+ * It checks ADDED files only (never the already-merged history — the existing
+ * out-of-order pair is grandfathered and handled by `db push --include-all`), so
+ * it is not vacuous and does not fight legitimate high-numbered additions.
+ *
+ * NOTE the residual gap: two PRs that both branch from the same base and add the
+ * same next number can each pass here and still collide once both merge, UNLESS
+ * "require branches up to date before merging" is enabled on `main` (recommended
+ * — it forces the second to rebase, at which point this guard fires). The
+ * collision-proof end state is Supabase's timestamp filenames; this guard is the
+ * cheap, no-rename interim.
+ *
+ *   node scripts/check-migration-order.mjs <base-ref>
+ *   node scripts/check-migration-order.mjs origin/main
+ *
+ * Exit 0 = ok (or no migrations added); exit 1 = an out-of-order addition.
+ */
+
+import { execFileSync } from 'node:child_process';
+
+const MIG_DIR = 'supabase/migrations';
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' });
+}
+
+/** `.../00041_org_actor_override.sql` → 41; non-migration files → null. */
+export function prefixOf(file) {
+  const m = /(?:^|\/)(\d+)_[^/]*\.sql$/.exec(file);
+  return m ? Number(m[1]) : null;
+}
+
+/** Highest migration number among a list of files (−1 when there are none). */
+export function maxPrefix(files) {
+  return files.reduce((max, f) => {
+    const n = prefixOf(f);
+    return n !== null && n > max ? n : max;
+  }, -1);
+}
+
+/**
+ * The pure core: which ADDED migrations sort at or below the base's max.
+ * Returns [{ file, num }], empty when everything is in order.
+ */
+export function misordered(addedFiles, baseMax) {
+  return addedFiles
+    .map((file) => ({ file, num: prefixOf(file) }))
+    .filter((e) => e.num !== null && e.num <= baseMax)
+    .sort((a, b) => a.num - b.num);
+}
+
+// Run the git plumbing only when invoked as a script (not when imported by a test).
+const invokedDirectly = process.argv[1] && /check-migration-order\.mjs$/.test(process.argv[1]);
+if (invokedDirectly) {
+  const base = process.argv[2] || process.env.MIGRATION_CHECK_BASE;
+  if (!base) {
+    process.stderr.write('usage: check-migration-order.mjs <base-ref>  (or set MIGRATION_CHECK_BASE)\n');
+    process.exit(2);
+  }
+
+  const added = git(['diff', '--name-only', '--diff-filter=A', `${base}...HEAD`, '--', MIG_DIR])
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (added.length === 0) {
+    process.stdout.write('migration-order: no new migrations in this change — ok\n');
+    process.exit(0);
+  }
+
+  const baseFiles = git(['ls-tree', '-r', '--name-only', base, '--', MIG_DIR])
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const baseMax = maxPrefix(baseFiles);
+
+  const bad = misordered(added, baseMax);
+  if (bad.length === 0) {
+    process.stdout.write(
+      `migration-order: ${added.length} new migration(s) all sort after the base max ` +
+        `(${String(baseMax).padStart(5, '0')}) — ok\n`,
+    );
+    process.exit(0);
+  }
+
+  const next = String(baseMax + 1).padStart(5, '0');
+  process.stderr.write(
+    '::error::Out-of-order migration(s) detected. Renumber so each sorts AFTER the ' +
+      `highest migration already on the base branch (${String(baseMax).padStart(5, '0')}):\n`,
+  );
+  for (const { file, num } of bad) {
+    process.stderr.write(`  - ${file} (${String(num).padStart(5, '0')}) must be >= ${next}\n`);
+  }
+  process.stderr.write(
+    'Rebase onto the base branch and renumber the file(s); `supabase db push` applies ' +
+      'migrations in numeric order, so a lower number added after a higher one is already ' +
+      'live cannot be applied without --include-all and risks an order the tests never saw.\n',
+  );
+  process.exit(1);
+}

--- a/scripts/check-migration-order.mjs
+++ b/scripts/check-migration-order.mjs
@@ -104,7 +104,7 @@ if (invokedDirectly) {
   }
   process.stderr.write(
     'Rebase onto the base branch and renumber the file(s); `supabase db push` applies ' +
-      'migrations in numeric order, so a lower number added after a higher one is already ' +
+      'migrations in numeric order, so a lower number added after a higher one that is already ' +
       'live cannot be applied without --include-all and risks an order the tests never saw.\n',
   );
   process.exit(1);

--- a/scripts/check-migration-order.mjs
+++ b/scripts/check-migration-order.mjs
@@ -31,6 +31,9 @@ import { execFileSync } from 'node:child_process';
 
 const MIG_DIR = 'supabase/migrations';
 
+/** Format a migration number as its zero-padded 5-digit on-disk prefix. */
+const padPrefix = (n) => String(n).padStart(5, '0');
+
 function git(args) {
   return execFileSync('git', args, { encoding: 'utf8' });
 }
@@ -89,18 +92,18 @@ if (invokedDirectly) {
   if (bad.length === 0) {
     process.stdout.write(
       `migration-order: ${added.length} new migration(s) all sort after the base max ` +
-        `(${String(baseMax).padStart(5, '0')}) — ok\n`,
+        `(${padPrefix(baseMax)}) — ok\n`,
     );
     process.exit(0);
   }
 
-  const next = String(baseMax + 1).padStart(5, '0');
+  const next = padPrefix(baseMax + 1);
   process.stderr.write(
     '::error::Out-of-order migration(s) detected. Renumber so each sorts AFTER the ' +
-      `highest migration already on the base branch (${String(baseMax).padStart(5, '0')}):\n`,
+      `highest migration already on the base branch (${padPrefix(baseMax)}):\n`,
   );
   for (const { file, num } of bad) {
-    process.stderr.write(`  - ${file} (${String(num).padStart(5, '0')}) must be >= ${next}\n`);
+    process.stderr.write(`  - ${file} (${padPrefix(num)}) must be >= ${next}\n`);
   }
   process.stderr.write(
     'Rebase onto the base branch and renumber the file(s); `supabase db push` applies ' +

--- a/scripts/check-migration-order.test.mjs
+++ b/scripts/check-migration-order.test.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// Unit tests for the pure core of the migration-order guard. Runs with the
+// built-in runner (`node --test`), no dependencies. The guard gates deploys, so
+// a regression in this logic is exactly what a test should catch. Importing the
+// module must NOT run its git plumbing — the `invokedDirectly` seam ensures that
+// (argv[1] ends in `.test.mjs`, not `check-migration-order.mjs`).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { prefixOf, maxPrefix, misordered } from './check-migration-order.mjs';
+
+test('prefixOf — parses the numeric on-disk prefix, else null', () => {
+  assert.equal(prefixOf('supabase/migrations/00041_org_actor_override.sql'), 41);
+  assert.equal(prefixOf('00042_audit.sql'), 42); // bare filename
+  assert.equal(prefixOf('supabase/migrations/00001_memories.sql'), 1); // no octal footgun
+  assert.equal(prefixOf('supabase/migrations/README.md'), null); // not a .sql
+  assert.equal(prefixOf('supabase/migrations/no_number.sql'), null); // no numeric prefix
+});
+
+test('maxPrefix — highest number, or -1 when there are none', () => {
+  assert.equal(maxPrefix(['supabase/migrations/00039_a.sql', 'supabase/migrations/00042_b.sql']), 42);
+  assert.equal(maxPrefix(['supabase/migrations/00042_b.sql', 'supabase/migrations/00039_a.sql']), 42); // order-independent
+  assert.equal(maxPrefix([]), -1);
+  assert.equal(maxPrefix(['supabase/migrations/README.md']), -1); // no migrations
+});
+
+test('misordered — rejects <= base max (incl. duplicates), allows strictly greater', () => {
+  const at = (nums) => nums.map((n) => `supabase/migrations/000${n}_x.sql`);
+  assert.deepEqual(misordered(at([43]), 42), []); // strictly greater is fine
+  assert.deepEqual(misordered(at([41]), 42).map((e) => e.num), [41]); // lower is rejected
+  assert.deepEqual(misordered(at([42]), 42).map((e) => e.num), [42]); // EQUAL is rejected (collision)
+  assert.deepEqual(misordered(at([42, 40]), 42).map((e) => e.num), [40, 42]); // multiple, returned sorted
+  assert.deepEqual(misordered([], 42), []); // nothing added
+});
+
+test('misordered — a fresh base (no prior migrations) accepts any addition', () => {
+  assert.deepEqual(misordered(['supabase/migrations/00001_first.sql'], -1), []);
+});


### PR DESCRIPTION
## The blocker (pre-existing, not from #268)

Every deploy to `main` has failed at **`supabase db push`** since `#266` — production hasn't been promoted since before `#265`. `#266` shipped `00041_org_actor_override.sql`, but `#260`'s `00042` was **already applied** to the remote DB, so `00041` sorts *before* the last-applied migration and `db push` aborts:

```
Found local migration files to be inserted before the last migration on remote database.
Rerun the command with --include-all flag to apply these migrations:
supabase/migrations/00041_org_actor_override.sql
```

**Root cause:** sequential integer prefixes don't survive **parallel PRs** — each branch picks "the next number" from its own base, so a lower number can merge after a higher one is already live.

## Fix — two layers

1. **Tolerance — `supabase db push --include-all`** (both deploy jobs). Applies an already-reviewed, CI-tested migration even when it sorts before one already on the remote (still in on-disk numeric order). Unwedges the grandfathered `00041`/`00042` pair.
2. **Prevention — a `migration-order` CI job** (`scripts/check-migration-order.mjs`). Fails a PR that **adds** a migration numbered ≤ the highest already on the base branch, naming the next free number to rebase-and-renumber to. Pure prefix logic is `export`ed and **unit-tested** (`node:test`, run in-job before the guard). Path-gated; added to the `CI Summary` aggregate gate.

## Also

- `docs/deployment.md`: documents the hazard + both layers; recommends requiring **`CI Summary`** as the single status check (not the path-gated jobs — they skip → GitHub reads that as pending-forever) and enabling **"require branches up to date before merging"** (closes the parallel-merge gap the guard alone can't). Flags Supabase **timestamp filenames** as the collision-proof end state.

Verified locally: unit tests pass; guard reports "no new migrations" on this branch and correctly rejects a simulated out-of-order `00040`; `actionlint` clean on both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2aj9YRficSSPTsQHR6YQv)_