### PR TITLE
feat(web): add "Install GitHub App" link to webhooks settings

### DIFF
--- a/docs/github-app.md
+++ b/docs/github-app.md
@@ -159,7 +159,20 @@ supabase secrets set GITHUB_APP_PRIVATE_KEY="$(cat path/to/private-key.pem)"
 supabase secrets set GITHUB_APP_ENABLED=true
 ```
 
-### 3. Verify
+### 3. Surface the install button in the dashboard
+
+The dashboard's "Install GitHub App" button (Settings → Webhooks) links to the
+App's public installation page. It is resolved from the App's slug at build
+time, so set this **web** env var (Vercel — not a Supabase secret):
+
+```bash
+NEXT_PUBLIC_GITHUB_APP_SLUG=<the-app-slug>   # e.g. lorekitbot (from github.com/apps/<slug>)
+```
+
+When unset, the dashboard falls back to the "available once `GITHUB_APP_ENABLED`
+is set" note instead of rendering a link to a non-existent App page.
+
+### 4. Verify
 
 - Install the App on a test repo.
 - Confirm a `github_installations` row appears with `status='linked'`.

--- a/packages/web/.env.example
+++ b/packages/web/.env.example
@@ -9,6 +9,14 @@ NEXT_PUBLIC_SUPABASE_PROJECT_REF=pqokxlhvnosogizsjztg
 # production set it to the real domain, e.g. https://lorekit.io.
 NEXT_PUBLIC_APP_URL=http://localhost:3001
 
+# ── GitHub App ────────────────────────────────────────────────────────────────
+# The GitHub App's slug (from github.com/apps/<slug>). Renders the "Install
+# GitHub App" button on Settings → Webhooks, linking to the public install page.
+# Leave unset until the App is registered AND GITHUB_APP_ENABLED=true is set as a
+# Supabase secret — otherwise the button offers an install the backend ignores.
+# See docs/github-app.md.
+# NEXT_PUBLIC_GITHUB_APP_SLUG=lorekitbot
+
 # ── Org invite emails (Resend) ────────────────────────────────────────────────
 # Optional. When RESEND_API_KEY is unset, org invites are in-app only (no email
 # sent) — everything still works. To send invite emails, set an API key and a

--- a/packages/web/src/app/(dashboard)/settings/webhooks/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/webhooks/page.tsx
@@ -3,6 +3,7 @@ import { Webhook, Github } from 'lucide-react';
 import { listWebhookSecrets } from '@/lib/webhook-secrets';
 import { listGithubInstallations } from '@/lib/github-installations';
 import { resolveMcpUrls } from '@/lib/mcp-url';
+import { resolveGithubAppInstallUrl } from '@/lib/github-app-url';
 import { OnboardingStepContent } from '@/components/dashboard/OnboardingStepContent';
 import { GithubAppManager } from '@/components/dashboard/GithubAppManager';
 import { SectionPanel } from '@/components/ui/SectionPanel';
@@ -16,6 +17,7 @@ export default async function WebhooksSettingsPage() {
     listGithubInstallations(),
   ]);
   const { mcpUrl, webhookUrl } = resolveMcpUrls();
+  const appInstallUrl = resolveGithubAppInstallUrl();
 
   return (
     <div className="flex flex-col gap-4">
@@ -25,7 +27,7 @@ export default async function WebhooksSettingsPage() {
         title="GitHub App"
         subtitle="Zero-configuration webhook coverage — install the App and repos are covered automatically, no per-repo secret required."
       >
-        <GithubAppManager installations={installations} />
+        <GithubAppManager installations={installations} installUrl={appInstallUrl} />
       </SectionPanel>
 
       {/* Per-repo manual webhook secrets (existing path — untouched) */}

--- a/packages/web/src/components/dashboard/GithubAppManager.tsx
+++ b/packages/web/src/components/dashboard/GithubAppManager.tsx
@@ -14,6 +14,7 @@
  * WebhookSecretManager, as the plan specifies (WRAP: sibling component).
  */
 
+import type { ReactNode } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import {
   Github,
@@ -38,28 +39,49 @@ function relativeTime(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 }
 
-// ── Install button — links to the App's public installation page ─────────────
+// ── Install link — sends the user to the App's public installation page ──────
 
 /**
- * Anchor styled as a primary button that sends the user to GitHub's public
- * "install this App" page. Renders only when an install URL is configured
- * (NEXT_PUBLIC_GITHUB_APP_SLUG is set); callers pass `null` otherwise.
+ * Anchor to GitHub's public "install this App" page. Renders only when an
+ * install URL is configured (NEXT_PUBLIC_GITHUB_APP_SLUG is set); callers pass
+ * `null` otherwise.
  *
- * `label` lets the empty state say "Install GitHub App" while an existing
- * installation says "Add repositories" (the same page manages both).
+ * One component, two variants, so the new-tab semantics (target / rel / the
+ * screen-reader cue) live in exactly one place and can't drift:
+ *   - `primary` — the empty-state "Install GitHub App" call to action.
+ *   - `ghost`   — the quieter "Add repositories" action beside the count when
+ *                 an installation already exists (the same page manages both).
  */
-function InstallAppButton({ url, label }: { url: string; label: string }) {
+function AppInstallLink({
+  url,
+  label,
+  variant,
+  icon,
+}: {
+  url: string;
+  label: string;
+  variant: 'primary' | 'ghost';
+  icon: ReactNode;
+}) {
+  const focusRing =
+    'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]';
+  const variantClass =
+    variant === 'primary'
+      ? 'gap-2 border border-[var(--color-accent-glow)] bg-[var(--color-accent-subtle)] px-3.5 py-2 text-xs text-[var(--color-accent)] hover:bg-[var(--color-accent)]/15'
+      : 'ml-auto gap-1.5 border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-[11px] text-[var(--color-content-secondary)] hover:border-[var(--color-accent-glow)] hover:text-[var(--color-accent)]';
   return (
     <a
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-[var(--color-accent-glow)] bg-[var(--color-accent-subtle)] px-3.5 py-2 text-xs font-medium text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent)]/15 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
+      className={`inline-flex min-h-11 items-center rounded-lg font-medium transition-colors ${variantClass} ${focusRing}`}
     >
-      <Github className="size-3.5 shrink-0" aria-hidden />
+      {icon}
       {label}
       <span className="sr-only"> (opens in a new tab)</span>
-      <ExternalLink className="size-3 shrink-0 opacity-70" aria-hidden />
+      {variant === 'primary' && (
+        <ExternalLink className="size-3 shrink-0 opacity-70" aria-hidden />
+      )}
     </a>
   );
 }
@@ -160,7 +182,12 @@ function NoInstallations({ installUrl }: { installUrl: string | null }) {
         is covered instantly.
       </p>
       {installUrl ? (
-        <InstallAppButton url={installUrl} label="Install GitHub App" />
+        <AppInstallLink
+          url={installUrl}
+          label="Install GitHub App"
+          variant="primary"
+          icon={<Github className="size-3.5 shrink-0" aria-hidden />}
+        />
       ) : (
         <p className="text-[10px] text-[var(--color-content-tertiary)]">
           The App is available once GITHUB_APP_ENABLED is set post-merge.
@@ -203,16 +230,12 @@ export function GithubAppManager({ installations, installUrl }: GithubAppManager
         </span>
         {/* Add-repos action, shown beside the count once at least one install exists */}
         {installUrl && installations.length > 0 && (
-          <a
-            href={installUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="ml-auto inline-flex min-h-11 items-center gap-1.5 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-[11px] font-medium text-[var(--color-content-secondary)] transition-colors hover:border-[var(--color-accent-glow)] hover:text-[var(--color-accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
-          >
-            <Plus className="size-3 shrink-0" aria-hidden />
-            Add repositories
-            <span className="sr-only"> (opens in a new tab)</span>
-          </a>
+          <AppInstallLink
+            url={installUrl}
+            label="Add repositories"
+            variant="ghost"
+            icon={<Plus className="size-3 shrink-0" aria-hidden />}
+          />
         )}
       </div>
 

--- a/packages/web/src/components/dashboard/GithubAppManager.tsx
+++ b/packages/web/src/components/dashboard/GithubAppManager.tsx
@@ -54,10 +54,11 @@ function InstallAppButton({ url, label }: { url: string; label: string }) {
       href={url}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex min-h-9 items-center gap-2 rounded-lg border border-[var(--color-accent-glow)] bg-[var(--color-accent-subtle)] px-3 py-1.5 text-xs font-medium text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent)]/15 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
+      className="inline-flex min-h-11 items-center gap-2 rounded-lg border border-[var(--color-accent-glow)] bg-[var(--color-accent-subtle)] px-3.5 py-2 text-xs font-medium text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent)]/15 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
     >
       <Github className="size-3.5 shrink-0" aria-hidden />
       {label}
+      <span className="sr-only"> (opens in a new tab)</span>
       <ExternalLink className="size-3 shrink-0 opacity-70" aria-hidden />
     </a>
   );
@@ -206,10 +207,11 @@ export function GithubAppManager({ installations, installUrl }: GithubAppManager
             href={installUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="ml-auto inline-flex min-h-8 items-center gap-1.5 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-2.5 py-1 text-[11px] font-medium text-[var(--color-content-secondary)] transition-colors hover:border-[var(--color-accent-glow)] hover:text-[var(--color-accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
+            className="ml-auto inline-flex min-h-11 items-center gap-1.5 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-2 text-[11px] font-medium text-[var(--color-content-secondary)] transition-colors hover:border-[var(--color-accent-glow)] hover:text-[var(--color-accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
           >
             <Plus className="size-3 shrink-0" aria-hidden />
             Add repositories
+            <span className="sr-only"> (opens in a new tab)</span>
           </a>
         )}
       </div>

--- a/packages/web/src/components/dashboard/GithubAppManager.tsx
+++ b/packages/web/src/components/dashboard/GithubAppManager.tsx
@@ -22,6 +22,8 @@ import {
   User,
   CircleCheck,
   Info,
+  Plus,
+  ExternalLink,
 } from 'lucide-react';
 import type { GithubInstallation } from '@/lib/github-installations';
 
@@ -34,6 +36,31 @@ function relativeTime(iso: string): string {
   if (days === 1) return 'yesterday';
   if (days < 30) return `${days}d ago`;
   return new Date(iso).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+// ── Install button — links to the App's public installation page ─────────────
+
+/**
+ * Anchor styled as a primary button that sends the user to GitHub's public
+ * "install this App" page. Renders only when an install URL is configured
+ * (NEXT_PUBLIC_GITHUB_APP_SLUG is set); callers pass `null` otherwise.
+ *
+ * `label` lets the empty state say "Install GitHub App" while an existing
+ * installation says "Add repositories" (the same page manages both).
+ */
+function InstallAppButton({ url, label }: { url: string; label: string }) {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex min-h-9 items-center gap-2 rounded-lg border border-[var(--color-accent-glow)] bg-[var(--color-accent-subtle)] px-3 py-1.5 text-xs font-medium text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent)]/15 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
+    >
+      <Github className="size-3.5 shrink-0" aria-hidden />
+      {label}
+      <ExternalLink className="size-3 shrink-0 opacity-70" aria-hidden />
+    </a>
+  );
 }
 
 // ── Repo row — one App-covered repository ────────────────────────────────────
@@ -119,7 +146,7 @@ function InstallationCard({ installation }: { installation: GithubInstallation }
 
 // ── Empty / not-connected state ───────────────────────────────────────────────
 
-function NoInstallations() {
+function NoInstallations({ installUrl }: { installUrl: string | null }) {
   return (
     <div className="flex flex-col items-start gap-3 rounded-xl border border-dashed border-[var(--color-border)] bg-[var(--color-bg-raised)] p-4 text-sm text-[var(--color-content-secondary)]">
       <div className="flex items-center gap-2">
@@ -131,10 +158,14 @@ function NoInstallations() {
         no manual webhook secret needed. Each repo added to the App installation
         is covered instantly.
       </p>
-      <p className="text-[10px] text-[var(--color-content-tertiary)]">
-        The App is available once GITHUB_APP_ENABLED is set post-merge.
-        See <code className="font-mono">docs/github-app.md</code> for the setup runbook.
-      </p>
+      {installUrl ? (
+        <InstallAppButton url={installUrl} label="Install GitHub App" />
+      ) : (
+        <p className="text-[10px] text-[var(--color-content-tertiary)]">
+          The App is available once GITHUB_APP_ENABLED is set post-merge.
+          See <code className="font-mono">docs/github-app.md</code> for the setup runbook.
+        </p>
+      )}
     </div>
   );
 }
@@ -143,6 +174,11 @@ function NoInstallations() {
 
 interface GithubAppManagerProps {
   installations: GithubInstallation[];
+  /**
+   * Public "install this App" URL (github.com/apps/<slug>/installations/new),
+   * or null when the App slug is not configured yet — see resolveGithubAppInstallUrl.
+   */
+  installUrl: string | null;
 }
 
 /**
@@ -152,7 +188,7 @@ interface GithubAppManagerProps {
  * are visually distinct from manually secret-configured repos (which are
  * rendered by the adjacent WebhookSecretManager under the same SectionPanel).
  */
-export function GithubAppManager({ installations }: GithubAppManagerProps) {
+export function GithubAppManager({ installations, installUrl }: GithubAppManagerProps) {
   return (
     <div className="flex flex-col gap-3">
       {/* Section label */}
@@ -164,11 +200,23 @@ export function GithubAppManager({ installations }: GithubAppManagerProps) {
         <span className="rounded-full border border-[var(--color-accent-glow)] bg-[var(--color-accent-subtle)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--color-accent)]">
           {installations.length}
         </span>
+        {/* Add-repos action, shown beside the count once at least one install exists */}
+        {installUrl && installations.length > 0 && (
+          <a
+            href={installUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-auto inline-flex min-h-8 items-center gap-1.5 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] px-2.5 py-1 text-[11px] font-medium text-[var(--color-content-secondary)] transition-colors hover:border-[var(--color-accent-glow)] hover:text-[var(--color-accent)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-accent)]"
+          >
+            <Plus className="size-3 shrink-0" aria-hidden />
+            Add repositories
+          </a>
+        )}
       </div>
 
       {/* Installation cards or empty state */}
       {installations.length === 0 ? (
-        <NoInstallations />
+        <NoInstallations installUrl={installUrl} />
       ) : (
         <div className="flex flex-col gap-3">
           <AnimatePresence>

--- a/packages/web/src/lib/github-app-url.spec.ts
+++ b/packages/web/src/lib/github-app-url.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveGithubAppInstallUrl } from './github-app-url';
+
+// resolveGithubAppInstallUrl reads NEXT_PUBLIC_GITHUB_APP_SLUG at call time.
+// Snapshot and restore it around every case so the tests don't leak env state
+// into each other (or into the rest of the suite).
+const KEY = 'NEXT_PUBLIC_GITHUB_APP_SLUG';
+const original = process.env[KEY];
+
+afterEach(() => {
+  if (original === undefined) delete process.env[KEY];
+  else process.env[KEY] = original;
+});
+
+describe('resolveGithubAppInstallUrl', () => {
+  it('builds the public install URL from the slug', () => {
+    process.env[KEY] = 'lorekitbot';
+    expect(resolveGithubAppInstallUrl()).toBe(
+      'https://github.com/apps/lorekitbot/installations/new',
+    );
+  });
+
+  it('returns null when the slug is unset', () => {
+    delete process.env[KEY];
+    expect(resolveGithubAppInstallUrl()).toBeNull();
+  });
+
+  it('returns null when the slug is an empty string', () => {
+    process.env[KEY] = '';
+    expect(resolveGithubAppInstallUrl()).toBeNull();
+  });
+
+  it('returns null when the slug is whitespace only', () => {
+    process.env[KEY] = '   ';
+    expect(resolveGithubAppInstallUrl()).toBeNull();
+  });
+
+  it('trims surrounding whitespace before building the URL', () => {
+    process.env[KEY] = '  lorekitbot  ';
+    expect(resolveGithubAppInstallUrl()).toBe(
+      'https://github.com/apps/lorekitbot/installations/new',
+    );
+  });
+
+  it('percent-encodes the slug so it cannot break out of the path segment', () => {
+    process.env[KEY] = 'weird slug/../x';
+    expect(resolveGithubAppInstallUrl()).toBe(
+      `https://github.com/apps/${encodeURIComponent('weird slug/../x')}/installations/new`,
+    );
+  });
+});

--- a/packages/web/src/lib/github-app-url.ts
+++ b/packages/web/src/lib/github-app-url.ts
@@ -10,6 +10,12 @@
  *
  * Returns null when the slug is unset — the App is not registered yet, so the
  * UI falls back to the docs-runbook note instead of linking to a dead page.
+ *
+ * Ordering caveat: webhook coverage also requires `GITHUB_APP_ENABLED=true`, a
+ * Supabase secret the web app cannot read. Set this slug only after that flag
+ * is on; otherwise the button offers an install the backend silently ignores.
+ * The runbook (docs/github-app.md) sequences the flag before the slug for this
+ * reason.
  */
 export function resolveGithubAppInstallUrl(): string | null {
   const slug = process.env['NEXT_PUBLIC_GITHUB_APP_SLUG']?.trim();

--- a/packages/web/src/lib/github-app-url.ts
+++ b/packages/web/src/lib/github-app-url.ts
@@ -1,0 +1,18 @@
+/**
+ * Resolve the public "install this GitHub App" URL from the App's slug.
+ *
+ * A GitHub App's public installation page is always
+ *   https://github.com/apps/<slug>/installations/new
+ * where <slug> is the App's URL-safe name (public — it appears in the URL any
+ * installer sees). We read it from NEXT_PUBLIC_GITHUB_APP_SLUG via a literal
+ * member expression so Next.js can inline it at build time (the otel-origins.ts
+ * pattern).
+ *
+ * Returns null when the slug is unset — the App is not registered yet, so the
+ * UI falls back to the docs-runbook note instead of linking to a dead page.
+ */
+export function resolveGithubAppInstallUrl(): string | null {
+  const slug = process.env['NEXT_PUBLIC_GITHUB_APP_SLUG']?.trim();
+  if (!slug) return null;
+  return `https://github.com/apps/${encodeURIComponent(slug)}/installations/new`;
+}


### PR DESCRIPTION
## Why

The GitHub App section on Settings → Webhooks described how to install the App but gave the user no way to actually start an install — the empty state was text-only.

## What changed

- Add a primary "Install GitHub App" button in the empty state and an "Add repositories" action beside the installations count when an install already exists — both link to the App's public installation page
- Resolve the install URL from `NEXT_PUBLIC_GITHUB_APP_SLUG` via a new `resolveGithubAppInstallUrl()` helper (mirrors `resolveMcpUrls`); falls back to the docs-runbook note when the slug is unset, so no dead link renders before the App is registered
- Document `NEXT_PUBLIC_GITHUB_APP_SLUG` in the github-app runbook (web env var, not a Supabase secret)

## How to verify

- `pnpm nx test web -- github-app-url` (6 cases: null on unset/empty/whitespace, `encodeURIComponent` URL shape)

## Notes for reviewers

Links use `min-h-11` touch targets and an `sr-only` new-tab cue per the dashboard's a11y conventions.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ep9mCdSie5HDVwH5Y8XraQ)_