### PR TITLE
ci: bump all Dependabot GitHub Actions (checkout, cache, github-script, create-github-app-token, release-please-action)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
         run: echo "version=$(node -p "require('playwright/package.json').version")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
@@ -231,7 +231,7 @@ jobs:
       # Cache the Vite/Storybook dep-optimizer so a warm run skips the cold
       # pre-bundle (the slow part of the first browser boot).
       - name: Cache Vite/Storybook optimizer
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             packages/web/node_modules/.vite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       migrations: ${{ steps.filter.outputs.migrations }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
@@ -114,7 +114,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0 # NX affected needs history to diff against the base
 
@@ -158,7 +158,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -195,7 +195,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0 # `vitest --changed <base>` needs history to diff
 
@@ -263,7 +263,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0 # need base + HEAD history to diff the added migrations
 
@@ -307,7 +307,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
       PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v3
@@ -134,7 +134,7 @@ jobs:
       HAVE_ORG_SMOKE_CREDS: ${{ secrets.LOREKIT_SMOKE_EMAIL != '' && secrets.LOREKIT_SMOKE_PASSWORD != '' && secrets.SUPABASE_ANON_KEY != '' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
@@ -252,7 +252,7 @@ jobs:
       PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v3
@@ -318,7 +318,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
@@ -428,7 +428,7 @@ jobs:
       PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
     steps:
       - name: Checkout repository (with previous commit)
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 2
 
@@ -472,7 +472,7 @@ jobs:
       contents: read # checkout, so the local composite action is available
     steps:
       - name: Checkout repository (for the composite action)
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Identify the failed stage
         id: stage

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -121,7 +121,7 @@ jobs:
       PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.guard.outputs.pr_sha }}
 
@@ -170,7 +170,7 @@ jobs:
       vercel_url: ${{ steps.deploy.outputs.url }}
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.guard.outputs.pr_sha }}
 
@@ -262,7 +262,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.guard.outputs.pr_sha }}
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Add 👀 reaction
         if: steps.check.outputs.authorized == 'true'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -81,7 +81,7 @@ jobs:
       - name: Resolve PR head SHA and branch
         if: steps.check.outputs.authorized == 'true'
         id: pr
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -94,7 +94,7 @@ jobs:
 
       - name: Set pending status check
         if: steps.check.outputs.authorized == 'true'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.repos.createCommitStatus({
@@ -304,7 +304,7 @@ jobs:
       statuses: write
     steps:
       - name: Post deploy results to PR
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RESULT_DEPLOY_API: ${{ needs.deploy-api.result }}
           RESULT_DEPLOY_WEB: ${{ needs.deploy-web.result }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: Mint a GitHub App token (so the release PR triggers required CI)
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Run release-please
         id: rp
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
       id-token: write # mint the OIDC token npm trades for publish rights
     steps:
       - name: Checkout the release commit (version already bumped on main)
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -179,7 +179,7 @@ jobs:
       contents: read # checkout, so the local composite action is available
     steps:
       - name: Checkout repository (for the composite action)
-        uses: actions/checkout@v7
+        uses: actions/checkout@v7.0.1
 
       - name: Identify the failed stage
         id: stage


### PR DESCRIPTION
Consolidates all five open Dependabot GitHub Actions bumps into one PR. Supersedes #277, #278, #279, #280, #282.

## Bumps

| Action | Change | Workflows touched |
|--------|--------|-------------------|
| `actions/checkout` | **preview.yml: 4.2.2 → 7.0.1** (real major bump); ci/deploy/release: `@v7` → `@v7.0.1` (narrows the floating major to a pinned patch — same commit `3d3c42e`) | ci, deploy, preview, release |
| `actions/cache` | 4 → 6 | ci |
| `actions/github-script` | 7.0.1 → 9.0.0 | preview |
| `actions/create-github-app-token` | 2 → 3 | release |
| `googleapis/release-please-action` | 4 → 5 | release |

> Note: Dependabot titled #280 "4.2.2 → 7.0.1" because it reports the lowest version found across files (preview.yml's v4.2.2) as the "from". In practice only preview.yml was still on v4; ci/deploy/release were already on `@v7` and are only narrowed to the exact patch tag.

## Notes

- Each source branch merged cleanly with no conflicts (the bumps touch disjoint `uses:` lines).
- `checkout` (4→7) and `github-script` (7→9) are the major-version jumps of interest; the substantive change across all five is the runner Node runtime moving to Node 24. No workflow uses a removed input (verified by diffing each action's `action.yml` old vs new ref).
- Per-action pinning style is preserved as-is from the repo's existing convention (preview.yml checkout stays SHA-pinned with a `# vX.Y.Z` comment; ci/deploy/release checkout and cache stay tag-pinned) — this PR does not re-standardise pinning.
- Non-Dependabot open PRs are untouched.