### PR TITLE
test(otel): prove cross-service traceparent correlation + telemetry-quality guards

### DIFF
--- a/.github/workflows/emit-trace.yml
+++ b/.github/workflows/emit-trace.yml
@@ -1,0 +1,70 @@
+name: Emit correlated trace (manual)
+
+# Manual-only. Fire this to push ONE real, correlated cross-service trace to
+# Dash0 — cli → api (edge SERVER) → Postgres (edge CLIENT), plus the MCP hop
+# (mcp-node SERVER → api SERVER) — as a single trace_id, so you can visually
+# confirm cross-service correlation in the backend that the offline unit suites
+# (otel-correlation.spec.ts / otel-conventions.spec.ts) can only prove in code.
+#
+# Every span is stamped `deployment.environment.name=<environment>` (default
+# `test`) so these traces are trivially filtered/routed and never pollute
+# production telemetry. Reuses the SAME `LOREKIT_TELEMETRY_TOKEN` secret the
+# release job bakes into the CLI tarball — no new secret to configure.
+#
+# NOTE: workflow_dispatch buttons only appear once this file is on the default
+# branch, so it becomes runnable from the Actions tab after PR #287 merges.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "deployment.environment.name to tag every span with (isolates these traces in Dash0)"
+        required: false
+        default: test
+      dataset:
+        description: "Dash0 dataset to route to (blank = the token's default dataset)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  emit-trace:
+    name: Emit one correlated trace to Dash0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      # The harness strips TS types at runtime via --experimental-transform-types,
+      # which needs Node >= 22.7 (the rest of CI runs on 20).
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      # The harness no-ops (exit 0) when it finds no OTLP token — which would look
+      # like a green run that emitted nothing. Fail loudly instead so a missing
+      # secret is unmistakable.
+      - name: Verify telemetry token is present
+        env:
+          LOREKIT_TELEMETRY_TOKEN: ${{ secrets.LOREKIT_TELEMETRY_TOKEN }}
+        run: |
+          if [ -z "${LOREKIT_TELEMETRY_TOKEN}" ]; then
+            echo "::error::LOREKIT_TELEMETRY_TOKEN secret is not set — cannot emit to Dash0." >&2
+            exit 1
+          fi
+
+      # No `pnpm install`: the harness imports only self-contained / zero-dep
+      # source (edge _shared/otel.ts, cli telemetry.mjs, mcp-core trace-context.ts),
+      # so `pnpm run` executes the underlying `node` command with no dependencies.
+      - name: Emit correlated trace
+        env:
+          LOREKIT_TELEMETRY_TOKEN: ${{ secrets.LOREKIT_TELEMETRY_TOKEN }}
+          DEPLOYMENT_ENVIRONMENT: ${{ inputs.environment }}
+          DASH0_DATASET: ${{ inputs.dataset }}
+        run: pnpm emit-trace

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 | [api-tokens.md](./api-tokens.md) | Developers | Token types, permissions, generation, CI usage |
 | [limits.md](./limits.md) | Agents + developers | Memory cap, rate limiting, per-user overrides, 429 semantics |
 | [otel.md](./otel.md) | Developers | Dash0 setup, custom spans, environment variables |
+| [telemetry-quality-review.md](./telemetry-quality-review.md) | Developers | Cross-service `traceparent` correlation contract, telemetry-quality review vs OTel semantic conventions, and the tests that guard it |
 | [deployment.md](./deployment.md) | Developers | Step-by-step deployment for all three pieces |
 | [storybook.md](./storybook.md) | Developers | Web Storybook: MSW-mocked full-page stories, determinism, and deploying Storybook as a second Vercel project |
 | [releasing.md](./releasing.md) | Developers | Automated `@lorekit/cli` npm releases via release-please + conventional commits |

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -252,7 +252,7 @@ All signals carry these resource attributes:
 | `service.namespace` | `lorekit` |
 | `service.name` | `api` (Edge Functions), `web` (Next.js), `mcp-node` (Node MCP server), or `cli` (CLI) |
 | `service.version` | Git SHA (`VERCEL_GIT_COMMIT_SHA`) or `unknown`; the package version for the CLI |
-| `deployment.environment.name` | `production` / `preview` / `development` / `local` (not set by the CLI) |
+| `deployment.environment.name` | `production` / `preview` / `development` / `local`; the CLI omits it unless overridden. An explicit `DEPLOYMENT_ENVIRONMENT` env var overrides the ambient value on every component (used by `scripts/emit-correlated-trace.mts` to stamp `test`). |
 
 ---
 

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -13,6 +13,11 @@ LoreKit emits traces, metrics, and logs to Dash0 from every layer of the stack.
 
 All signals carry `service.namespace=lorekit` so you can filter the full stack in one Dash0 query.
 
+> For how the four services correlate into one trace (W3C `traceparent`
+> propagation), a review of telemetry quality against the OTel semantic
+> conventions, and the tests that guard both, see
+> [telemetry-quality-review.md](./telemetry-quality-review.md).
+
 ---
 
 ## Custom spans (Edge Function)

--- a/docs/telemetry-quality-review.md
+++ b/docs/telemetry-quality-review.md
@@ -1,0 +1,114 @@
+# Telemetry quality & cross-service correlation review
+
+_Reviewed: 2026-07 · Scope: traces, metrics, and W3C context propagation across
+`cli`, `api` (edge), `mcp-node`, and `web`._
+
+This review answers two questions: **(1) is LoreKit's telemetry actually
+generated correctly and correlated across services?** and **(2) does it meet
+OTel semantic-convention and instrumentation best practices?** It was graded
+against the Dash0 `otel-semantic-conventions` and `otel-instrumentation` skills.
+
+Verdict: **the correlation architecture is sound and now regression-guarded by
+tests.** One clear semantic-convention bug was found and fixed; the rest are
+lower-severity recommendations.
+
+---
+
+## How correlation works (verified)
+
+Every component propagates one W3C `traceparent` through a single pure seam:
+`parseTraceparent` (receiver) and `formatTraceparent` (sender), which live in
+`packages/mcp-core/src/trace-context.ts` and are mirrored verbatim into every
+edge function (`supabase/functions/_shared/trace-context.ts`). The zero-dep CLI
+re-implements the same header format in `packages/cli/src/telemetry.mjs`.
+
+```
+agent ─traceparent→ mcp-node ─traceparent→ api (edge) ─→ Postgres
+  cli ─traceparent→ api (edge)
+  web ─traceparent→ api (edge)          (browser + server, via @vercel/otel)
+```
+
+- **CLI → api / MCP → api**: the receiver continues the inbound trace (same
+  `trace_id`, fresh `span_id`, `parent_span_id` = caller's span) or, if the
+  header is invalid, starts a **new root** rather than emitting a corrupt span.
+- **Response echo**: the edge echoes its SERVER span back as a `traceparent`
+  response header (`Access-Control-Expose-Headers: traceparent`) so the caller
+  can link to it.
+- **Sampled flag** is recorded (`flags`) and propagated but never gates export —
+  export is AlwaysOn, sampling is deferred to the Dash0 pipeline.
+
+### Tests added
+
+| File | Proves |
+|------|--------|
+| `packages/mcp-core/src/otel-correlation.spec.ts` | CLI→api and MCP→api join one trace with correct parent/child linkage; N REST calls become siblings under the command span; the echoed header points back at the server span; a 3-service chain preserves one `trace_id`; invalid inbound → fresh root; the sampled flag is data, not an export gate; the zero-dep CLI header is byte-identical to `formatTraceparent`. |
+| `packages/mcp-core/src/otel-conventions.spec.ts` | Drift guards: the four components declare **distinct** `service.name` values (`cli`/`api`/`mcp-node`/`web`); `service.namespace=lorekit` everywhere; edge span kinds SERVER(root)/CLIENT(db)/INTERNAL(child) with OTLP wire values; `faas.name` distinguishes the five edge functions; export never branches on `sampled`; every tool span carries `lorekit.tool.name` and feeds the `lorekit.tool.duration` histogram with low-cardinality attributes. Plus unit coverage of the histogram accessor (name, memoization, no-throw record). |
+| `packages/cli/test/telemetry.test.mjs` (extended) | `os.type` / `host.arch` emit OTel-registry values (see bug below). |
+
+These complement the pre-existing suites: `trace-context.spec.ts` (strict W3C
+parse/format), `edge-parity.spec.ts` (the CLI/edge mirror can't drift),
+`packages/mcp-server/src/otel-propagation.spec.ts` (OTel context API), and the
+existing `telemetry.test.mjs` (config, opt-out, payload shape, PII posture).
+
+---
+
+## Bug fixed
+
+**`os.type` / `host.arch` emitted Node spellings, not OTel-registry values**
+(`packages/cli/src/telemetry.mjs`). The CLI resource set `os.type` from
+`process.platform` (`win32`, `sunos`) and `host.arch` from `process.arch`
+(`x64`, `ia32`, `arm`). Those Node spellings are **not** members of the OTel
+`os.type` / `host.arch` registries (`windows`, `solaris` / `amd64`, `x86`,
+`arm32`), so a Dash0/OTel-native backend can't group them with telemetry from
+other SDKs. Fixed with pure `normalizeOsType` / `normalizeHostArch` mappings
+(canonical/unknown values pass through) plus tests. Low blast radius: CLI
+resource attributes only.
+
+---
+
+## Recommendations (not applied — design/judgment calls)
+
+1. **`db.query.text` and DB span names inline literal filter values**
+   (`_shared/otel.ts` `buildSql`). Span names like
+   `SELECT ... FROM memories WHERE scope = 'repo::acme/x' AND key = '...'` are
+   **high-cardinality** (an anti-pattern for span names, which should group) and
+   put user-controlled values (scope, key, filter args) into `db.query.text`,
+   which the semantic conventions define as the **parameterized/sanitized**
+   statement. Recommend: name the span by operation + table
+   (`SELECT memories`) and set `db.query.text` to the statement with
+   placeholders (`... WHERE scope = $1 AND key = $2`), keeping literal values off
+   the span. This is a deliberate design change to all edge DB spans, so it is
+   left for maintainer sign-off rather than auto-applied.
+
+2. **`error.message` is a non-registry attribute.** `Span.error()` /
+   `clientError()` set `error.message`; the conventions use `exception.message`
+   (with `exception.type`) or `error.type`. Also, PostgREST error strings placed
+   there can carry incidental detail. Recommend migrating to `error.type` +
+   `exception.message`, and confirming no user data reaches the message.
+
+3. **Unhandled throws skip the response `traceparent` echo.** `traceRequest`'s
+   `catch` path rethrows without `withTraceparent`, so a caller can't correlate a
+   truly-thrown 500. Most handlers return error `Response`s (which are echoed),
+   so impact is small; consider echoing on the throw path too.
+
+4. **Successful spans set status `OK` explicitly.** The spec recommends leaving
+   status `UNSET` for success unless there's a reason to assert `OK`. Cosmetic;
+   consistent across CLI and edge, so low priority.
+
+---
+
+## What's already good
+
+- One `service.namespace=lorekit`; distinct, documented `service.name` per
+  component; the "five edge functions are one `api` service, told apart by
+  `faas.name`" decision is correct and now guarded.
+- Correct span kinds for service-map edges (SERVER/CLIENT), with the API-enum vs
+  OTLP-wire kind values used correctly in each layer.
+- Strong **no-PII posture** in CLI telemetry: bounded flag allow-list, bounded
+  error labels (`err.code` / constructor name, never `err.message`), opt-out via
+  `LOREKIT_TELEMETRY` / `DO_NOT_TRACK`.
+- `lorekit.tool.duration` histogram uses unit `s` and low-cardinality dimensions
+  (`lorekit.tool.name`, `lorekit.scope.type`); the CLI counter is a monotonic
+  DELTA sum — both appropriate.
+- Context propagation is **decoupled from export**: even a telemetry-disabled
+  CLI still sends `traceparent` so server-side traces correlate.

--- a/docs/telemetry-quality-review.md
+++ b/docs/telemetry-quality-review.md
@@ -73,6 +73,16 @@ It prints the emitted `trace_id`, the endpoint host, the dataset, and the
 Dash0 filter to use. With no endpoint/token configured it **no-ops** with a
 clear message (never crashes, never needs a secret in git).
 
+**From CI (no local secret needed).** The `Emit correlated trace (manual)`
+workflow (`.github/workflows/emit-trace.yml`) runs the same harness on demand
+from the Actions tab (`workflow_dispatch`). It reuses the existing
+`LOREKIT_TELEMETRY_TOKEN` secret (the one the release job bakes into the CLI
+tarball), so the endpoint/auth are already wired — just click **Run workflow**.
+Two optional inputs: `environment` (the `deployment.environment.name` tag,
+default `test`) and `dataset` (blank → the token's default dataset). The
+`trace_id` appears in the job log. The button only shows once the workflow file
+is on the default branch.
+
 **What it emits** — one trace covering all three production correlation paths:
 
 ```

--- a/docs/telemetry-quality-review.md
+++ b/docs/telemetry-quality-review.md
@@ -41,14 +41,80 @@ agent ─traceparent→ mcp-node ─traceparent→ api (edge) ─→ Postgres
 
 | File | Proves |
 |------|--------|
-| `packages/mcp-core/src/otel-correlation.spec.ts` | CLI→api and MCP→api join one trace with correct parent/child linkage; N REST calls become siblings under the command span; the echoed header points back at the server span; a 3-service chain preserves one `trace_id`; invalid inbound → fresh root; the sampled flag is data, not an export gate; the zero-dep CLI header is byte-identical to `formatTraceparent`. |
-| `packages/mcp-core/src/otel-conventions.spec.ts` | Drift guards: the four components declare **distinct** `service.name` values (`cli`/`api`/`mcp-node`/`web`); `service.namespace=lorekit` everywhere; edge span kinds SERVER(root)/CLIENT(db)/INTERNAL(child) with OTLP wire values; `faas.name` distinguishes the five edge functions; export never branches on `sampled`; every tool span carries `lorekit.tool.name` and feeds the `lorekit.tool.duration` histogram with low-cardinality attributes. Plus unit coverage of the histogram accessor (name, memoization, no-throw record). |
-| `packages/cli/test/telemetry.test.mjs` (extended) | `os.type` / `host.arch` emit OTel-registry values (see bug below). |
+| `packages/mcp-core/src/otel-correlation.spec.ts` | CLI→api and MCP→api join one trace with correct parent/child linkage; N REST calls become siblings under the command span; the echoed header points back at the server span; a 3-service chain preserves one `trace_id`; invalid inbound → fresh root; the sampled flag is data, not an export gate; the zero-dep CLI header — source-scanned from the shipped `getActiveTraceparent` — renders byte-identically to `formatTraceparent`. |
+| `packages/mcp-core/src/otel-conventions.spec.ts` | Drift guards: the four components declare **distinct** `service.name` values (`cli`/`api`/`mcp-node`/`web`); `service.namespace=lorekit` everywhere; edge span kinds SERVER(root)/CLIENT(db)/INTERNAL(child) with OTLP wire values; `faas.name` distinguishes the five edge functions; the edge (`extractTraceContext`/`withTraceparent`) and CLI (`getActiveTraceparent`) source keeps routing propagation through the shared `parseTraceparent`/`formatTraceparent` seam; export never branches on `sampled`; every tool span carries `lorekit.tool.name` and feeds the `lorekit.tool.duration` histogram with low-cardinality attributes. Plus unit coverage of the histogram accessor (name, memoization, no-throw record). |
+| `packages/mcp-core/src/otel-harness.spec.ts` | The correlated-trace harness's pure builder emits three service blocks (`cli`/`api`/`mcp-node`) under ONE `trace_id`, each resource stamped `deployment.environment.name=test`; correct span kinds; and the real parentage — CLI→api, MCP→api, and every DB CLIENT span under an api SERVER span — all off the CLI root. |
+| `packages/cli/test/telemetry.test.mjs` (extended) | `os.type` / `host.arch` emit OTel-registry values, incl. `ppc`→`ppc32` (see bug below); `deployment.environment.name` is omitted by default and emitted only under an explicit `DEPLOYMENT_ENVIRONMENT` override. |
 
 These complement the pre-existing suites: `trace-context.spec.ts` (strict W3C
 parse/format), `edge-parity.spec.ts` (the CLI/edge mirror can't drift),
 `packages/mcp-server/src/otel-propagation.spec.ts` (OTel context API), and the
 existing `telemetry.test.mjs` (config, opt-out, payload shape, PII posture).
+
+---
+
+## Emitting a real correlated trace to Dash0 (the harness)
+
+The suites above run **offline** — they never boot an exporter, so nothing they
+run reaches Dash0. That is correct for a fast CI, but it leaves no way to
+**visually** confirm correlation in the backend. `scripts/emit-correlated-trace.mts`
+is the on-demand tool for exactly that: it emits **one** real, correlated
+cross-service trace to Dash0 and prints its `trace_id`.
+
+```bash
+# Point it at Dash0 (any OTLP endpoint + auth works; env only, no committed secret):
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://ingress.europe-west4.gcp.dash0-dev.com
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=Bearer <ingesting-only-token>, Dash0-Dataset=lorekit-test'
+
+pnpm emit-trace          # → node --experimental-transform-types scripts/emit-correlated-trace.mts
+```
+
+It prints the emitted `trace_id`, the endpoint host, the dataset, and the
+Dash0 filter to use. With no endpoint/token configured it **no-ops** with a
+clear message (never crashes, never needs a secret in git).
+
+**What it emits** — one trace covering all three production correlation paths:
+
+```
+cli (INTERNAL, service=cli)                       ← the CLI command span (root)
+├─ api SERVER (POST /memories, service=api)        ← CLI → api
+│   └─ api CLIENT (INSERT … memories)              ← multi-hop edge chain (server → db)
+└─ mcp-node SERVER (tools/call, service=mcp-node)  ← the MCP hop
+    └─ api SERVER (GET /memories, service=api)     ← MCP → api
+        └─ api CLIENT (SELECT … memories)          ← multi-hop edge chain
+```
+
+**Why it is faithful, not a mock.** Each span is built with the component's own
+emission code — the CLI's real `buildTracePayload`, the edge's real `Span` /
+`buildOtlpPayload` (`supabase/functions/_shared/otel.ts`) — and every parent→child
+edge is derived through the **real** W3C seam (`formatTraceparent` →
+`parseTraceparent`), exactly as the edge's `extractTraceContext` does on the
+wire. It runs in Node via `--experimental-transform-types` and shims `Deno.env`
+onto `process.env` so the edge code runs unmodified. (The `mcp-node` span is the
+one approximation: the Node MCP server emits through the OTel SDK, which can't be
+driven single-shot cross-package, so its span is produced by the same edge
+builder with `service.name=mcp-node` — identical OTLP wire shape.)
+
+### Isolating the `test` dataset in Dash0
+
+Every span the harness emits carries `deployment.environment.name=test` as a
+**global resource attribute** across all four service identities. This is the
+existing semconv attribute (elsewhere `production` / `preview` / `development` /
+`local`), so nothing new needs indexing — filter or route on it:
+
+- **Filter**: in any Dash0 view, add `deployment.environment.name = test`, then
+  open the printed `trace_id` to see the full waterfall.
+- **Isolate**: send it to a dedicated dataset with a `Dash0-Dataset` header (see
+  the `OTEL_EXPORTER_OTLP_HEADERS` above), and/or add a Dash0 routing rule keyed
+  on `deployment.environment.name = test` so these traces never mix with
+  production telemetry.
+
+The marker is wired through **one env-driven path** every component honours:
+`DEPLOYMENT_ENVIRONMENT` (the harness sets it to `test`). The edge's
+`resolveDeploymentEnv()` and the CLI's `resolveDeploymentEnvironment()` both read
+it first, ahead of the ambient `VERCEL_ENV` mapping; the Node `mcp-node` server
+reaches the same value natively via `OTEL_RESOURCE_ATTRIBUTES`. The CLI otherwise
+still omits the attribute by default (it has no ambient deployment).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "prepare": "husky"
+    "prepare": "husky",
+    "emit-trace": "node --experimental-transform-types scripts/emit-correlated-trace.mts"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",

--- a/packages/cli/src/telemetry.mjs
+++ b/packages/cli/src/telemetry.mjs
@@ -165,6 +165,27 @@ function toOtlpAttributes(attributes) {
   return Object.entries(attributes).map(([key, value]) => ({ key, value: toOtlpValue(value) }));
 }
 
+// OTel `os.type` / `host.arch` use their own bounded enum vocabularies, which
+// are NOT identical to Node's `process.platform` / `process.arch` spellings.
+// Node's `win32` / `sunos` and `x64` / `ia32` / `arm` are the ones that differ;
+// emitting them verbatim produces off-registry attribute values that a Dash0 /
+// OTel-native backend can't group with telemetry from other SDKs. Map the known
+// divergences and pass anything already-canonical (or unknown) through.
+//   os.type:   https://opentelemetry.io/docs/specs/semconv/registry/attributes/os/
+//   host.arch: https://opentelemetry.io/docs/specs/semconv/registry/attributes/host/
+const OS_TYPE_BY_PLATFORM = { win32: 'windows', sunos: 'solaris' };
+const HOST_ARCH_BY_PROCESS_ARCH = { x64: 'amd64', ia32: 'x86', arm: 'arm32' };
+
+/** Map a Node `process.platform` value to an OTel `os.type` registry value. */
+export function normalizeOsType(platform) {
+  return OS_TYPE_BY_PLATFORM[platform] ?? platform;
+}
+
+/** Map a Node `process.arch` value to an OTel `host.arch` registry value. */
+export function normalizeHostArch(arch) {
+  return HOST_ARCH_BY_PROCESS_ARCH[arch] ?? arch;
+}
+
 function resourceAttributes(version) {
   return [
     { key: 'service.name', value: { stringValue: 'cli' } },
@@ -172,8 +193,8 @@ function resourceAttributes(version) {
     { key: 'service.version', value: { stringValue: String(version) } },
     { key: 'process.runtime.name', value: { stringValue: 'nodejs' } },
     { key: 'process.runtime.version', value: { stringValue: process.versions.node } },
-    { key: 'os.type', value: { stringValue: process.platform } },
-    { key: 'host.arch', value: { stringValue: process.arch } },
+    { key: 'os.type', value: { stringValue: normalizeOsType(process.platform) } },
+    { key: 'host.arch', value: { stringValue: normalizeHostArch(process.arch) } },
   ];
 }
 

--- a/packages/cli/src/telemetry.mjs
+++ b/packages/cli/src/telemetry.mjs
@@ -188,8 +188,24 @@ export function normalizeHostArch(arch) {
   return HOST_ARCH_BY_PROCESS_ARCH[arch] ?? arch;
 }
 
-function resourceAttributes(version) {
-  return [
+/**
+ * Resolve the `deployment.environment.name` resource value, or `undefined` when
+ * none is set. The CLI runs on end-users' machines, so — unlike the edge/web/
+ * mcp-node deployments — it has no ambient environment and deliberately OMITS
+ * the attribute by default. It is emitted ONLY when explicitly overridden via
+ * `DEPLOYMENT_ENVIRONMENT` (falling back to `OTEL_DEPLOYMENT_ENVIRONMENT`) — the
+ * same single, env-driven knob the edge honours, which the correlated-trace
+ * harness (`scripts/emit-correlated-trace.mts`) uses to stamp `test`.
+ * @param {object} [env]  defaults to process.env
+ */
+export function resolveDeploymentEnvironment(env = process.env) {
+  const raw = env.DEPLOYMENT_ENVIRONMENT ?? env.OTEL_DEPLOYMENT_ENVIRONMENT;
+  const value = raw !== undefined ? String(raw).trim() : '';
+  return value || undefined;
+}
+
+function resourceAttributes(version, env = process.env) {
+  const attrs = [
     { key: 'service.name', value: { stringValue: 'cli' } },
     { key: 'service.namespace', value: { stringValue: 'lorekit' } },
     { key: 'service.version', value: { stringValue: String(version) } },
@@ -198,6 +214,9 @@ function resourceAttributes(version) {
     { key: 'os.type', value: { stringValue: normalizeOsType(process.platform) } },
     { key: 'host.arch', value: { stringValue: normalizeHostArch(process.arch) } },
   ];
+  const deploymentEnv = resolveDeploymentEnvironment(env);
+  if (deploymentEnv) attrs.push({ key: 'deployment.environment.name', value: { stringValue: deploymentEnv } });
+  return attrs;
 }
 
 // ── Payload builders (pure — unit-tested) ─────────────────────────────────────

--- a/packages/cli/src/telemetry.mjs
+++ b/packages/cli/src/telemetry.mjs
@@ -174,7 +174,9 @@ function toOtlpAttributes(attributes) {
 //   os.type:   https://opentelemetry.io/docs/specs/semconv/registry/attributes/os/
 //   host.arch: https://opentelemetry.io/docs/specs/semconv/registry/attributes/host/
 const OS_TYPE_BY_PLATFORM = { win32: 'windows', sunos: 'solaris' };
-const HOST_ARCH_BY_PROCESS_ARCH = { x64: 'amd64', ia32: 'x86', arm: 'arm32' };
+// Node's `process.arch` reports `ppc` for 32-bit PowerPC; the OTel `host.arch`
+// registry value for it is `ppc32` (its `ppc64` spelling already matches Node).
+const HOST_ARCH_BY_PROCESS_ARCH = { x64: 'amd64', ia32: 'x86', arm: 'arm32', ppc: 'ppc32' };
 
 /** Map a Node `process.platform` value to an OTel `os.type` registry value. */
 export function normalizeOsType(platform) {

--- a/packages/cli/test/telemetry.test.mjs
+++ b/packages/cli/test/telemetry.test.mjs
@@ -187,6 +187,8 @@ test('normalizeHostArch maps Node arches to the OTel host.arch vocabulary', () =
   assert.equal(normalizeHostArch('x64'), 'amd64');
   assert.equal(normalizeHostArch('ia32'), 'x86');
   assert.equal(normalizeHostArch('arm'), 'arm32');
+  // Node reports `ppc` for 32-bit PowerPC; the OTel registry value is `ppc32`.
+  assert.equal(normalizeHostArch('ppc'), 'ppc32');
   // Already-canonical / unmapped values pass through unchanged.
   for (const v of ['arm64', 's390x', 'ppc64']) {
     assert.equal(normalizeHostArch(v), v);

--- a/packages/cli/test/telemetry.test.mjs
+++ b/packages/cli/test/telemetry.test.mjs
@@ -13,6 +13,7 @@ import {
   getActiveTraceparent,
   normalizeOsType,
   normalizeHostArch,
+  resolveDeploymentEnvironment,
 } from '../src/telemetry.mjs';
 import { TELEMETRY_TOKEN } from '../src/telemetry-token.mjs';
 import { injectToken } from '../../../scripts/inject-telemetry-token.mjs';
@@ -192,6 +193,52 @@ test('normalizeHostArch maps Node arches to the OTel host.arch vocabulary', () =
   // Already-canonical / unmapped values pass through unchanged.
   for (const v of ['arm64', 's390x', 'ppc64']) {
     assert.equal(normalizeHostArch(v), v);
+  }
+});
+
+// ── resource attributes: deployment.environment.name (opt-in override) ────────
+
+test('resolveDeploymentEnvironment is undefined by default (CLI has no ambient env)', () => {
+  assert.equal(resolveDeploymentEnvironment({}), undefined);
+  // Whitespace-only override is treated as absent.
+  assert.equal(resolveDeploymentEnvironment({ DEPLOYMENT_ENVIRONMENT: '   ' }), undefined);
+});
+
+test('resolveDeploymentEnvironment reads DEPLOYMENT_ENVIRONMENT then OTEL_DEPLOYMENT_ENVIRONMENT', () => {
+  assert.equal(resolveDeploymentEnvironment({ DEPLOYMENT_ENVIRONMENT: 'test' }), 'test');
+  assert.equal(resolveDeploymentEnvironment({ OTEL_DEPLOYMENT_ENVIRONMENT: 'staging' }), 'staging');
+  // DEPLOYMENT_ENVIRONMENT wins when both are set.
+  assert.equal(
+    resolveDeploymentEnvironment({ DEPLOYMENT_ENVIRONMENT: 'test', OTEL_DEPLOYMENT_ENVIRONMENT: 'staging' }),
+    'test',
+  );
+});
+
+test('buildTracePayload omits deployment.environment.name unless overridden', () => {
+  const prev = process.env.DEPLOYMENT_ENVIRONMENT;
+  delete process.env.DEPLOYMENT_ENVIRONMENT;
+  try {
+    const p = buildTracePayload({ version: '1', name: 'lorekit.cli.list', attributes: {}, startMs: 1, endMs: 2, status: 'ok' });
+    const keys = p.resourceSpans[0].resource.attributes.map((a) => a.key);
+    assert.ok(!keys.includes('deployment.environment.name'));
+  } finally {
+    if (prev === undefined) delete process.env.DEPLOYMENT_ENVIRONMENT;
+    else process.env.DEPLOYMENT_ENVIRONMENT = prev;
+  }
+});
+
+test('buildTracePayload emits deployment.environment.name=test when overridden (harness path)', () => {
+  const prev = process.env.DEPLOYMENT_ENVIRONMENT;
+  process.env.DEPLOYMENT_ENVIRONMENT = 'test';
+  try {
+    const p = buildTracePayload({ version: '1', name: 'lorekit.cli.list', attributes: {}, startMs: 1, endMs: 2, status: 'ok' });
+    const resAttrs = Object.fromEntries(
+      p.resourceSpans[0].resource.attributes.map((a) => [a.key, a.value.stringValue]),
+    );
+    assert.equal(resAttrs['deployment.environment.name'], 'test');
+  } finally {
+    if (prev === undefined) delete process.env.DEPLOYMENT_ENVIRONMENT;
+    else process.env.DEPLOYMENT_ENVIRONMENT = prev;
   }
 });
 

--- a/packages/cli/test/telemetry.test.mjs
+++ b/packages/cli/test/telemetry.test.mjs
@@ -11,6 +11,8 @@ import {
   exportInvocation,
   traceCommand,
   getActiveTraceparent,
+  normalizeOsType,
+  normalizeHostArch,
 } from '../src/telemetry.mjs';
 import { TELEMETRY_TOKEN } from '../src/telemetry-token.mjs';
 import { injectToken } from '../../../scripts/inject-telemetry-token.mjs';
@@ -167,6 +169,43 @@ test('commandAttributes merges extraAttrs into the attribute bag', () => {
     extraAttrs: { 'lorekit.cli.doctor.failed_checks': 'connectivity,token' },
   });
   assert.equal(attrs['lorekit.cli.doctor.failed_checks'], 'connectivity,token');
+});
+
+// ── resource attributes: OTel-registry os.type / host.arch ────────────────────
+
+test('normalizeOsType maps Node platforms to the OTel os.type vocabulary', () => {
+  // The two Node spellings that are NOT valid os.type registry values.
+  assert.equal(normalizeOsType('win32'), 'windows');
+  assert.equal(normalizeOsType('sunos'), 'solaris');
+  // Already-canonical values pass through unchanged.
+  for (const v of ['linux', 'darwin', 'freebsd', 'openbsd', 'aix']) {
+    assert.equal(normalizeOsType(v), v);
+  }
+});
+
+test('normalizeHostArch maps Node arches to the OTel host.arch vocabulary', () => {
+  assert.equal(normalizeHostArch('x64'), 'amd64');
+  assert.equal(normalizeHostArch('ia32'), 'x86');
+  assert.equal(normalizeHostArch('arm'), 'arm32');
+  // Already-canonical / unmapped values pass through unchanged.
+  for (const v of ['arm64', 's390x', 'ppc64']) {
+    assert.equal(normalizeHostArch(v), v);
+  }
+});
+
+test('buildTracePayload emits os.type / host.arch as OTel-registry values', () => {
+  const p = buildTracePayload({
+    version: '1', name: 'lorekit.cli.list', attributes: {}, startMs: 1, endMs: 2, status: 'ok',
+  });
+  const resAttrs = Object.fromEntries(
+    p.resourceSpans[0].resource.attributes.map((a) => [a.key, a.value.stringValue]),
+  );
+  // Whatever this test host reports, the emitted value is never a Node-only
+  // spelling that the registry doesn't define.
+  assert.equal(resAttrs['os.type'], normalizeOsType(process.platform));
+  assert.equal(resAttrs['host.arch'], normalizeHostArch(process.arch));
+  assert.ok(!['win32', 'sunos'].includes(resAttrs['os.type']));
+  assert.ok(!['x64', 'ia32', 'arm'].includes(resAttrs['host.arch']));
 });
 
 // ── payload shape ──────────────────────────────────────────────────────────────

--- a/packages/mcp-core/src/otel-conventions.spec.ts
+++ b/packages/mcp-core/src/otel-conventions.spec.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import {
+  TRACER_NAME,
+  METER_NAME,
+  getTracer,
+  getMeter,
+  getToolDurationHistogram,
+} from './telemetry.js';
+
+/**
+ * Drift guards for the telemetry-quality invariants that make cross-service
+ * correlation legible, plus unit coverage of the `lorekit.tool.duration`
+ * accessor module.
+ *
+ * The correlation behaviour itself is proven in `otel-correlation.spec.ts`;
+ * this file protects the wiring around it — the properties that, if they
+ * silently drift, would fragment the service map or gate export on the sampled
+ * flag. Same source-scan idiom as `edge-parity.spec.ts`,
+ * `tenant-scope-usage.spec.ts`, and `org-actor-usage.spec.ts`.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url)); // packages/mcp-core/src
+const repoRoot = path.resolve(here, '../../..');
+const read = (rel: string) => readFileSync(path.join(repoRoot, rel), 'utf8');
+
+// The four LoreKit components that emit telemetry and where each declares its
+// `service.name` default. A collision here collapses two components into one
+// indistinguishable node in the Dash0 service map (root CLAUDE.md, "service.name
+// inventory").
+const SERVICE_NAME_SITES: ReadonlyArray<readonly [string, string, RegExp, string]> = [
+  ['cli', 'packages/cli/src/telemetry.mjs', /service\.name',\s*value:\s*\{\s*stringValue:\s*'([^']+)'/, 'cli'],
+  ['api (edge)', 'supabase/functions/_shared/otel.ts', /SERVICE_NAME'\)\s*\?\?\s*'([^']+)'/, 'api'],
+  ['mcp-node', 'packages/mcp-server/src/instrumentation.ts', /OTEL_SERVICE_NAME'\]\s*\?\?\s*'([^']+)'/, 'mcp-node'],
+  ['web', 'packages/web/src/instrumentation.ts', /serviceName:\s*'([^']+)'/, 'web'],
+];
+
+// Every place a `service.namespace` is declared — must be `lorekit` everywhere
+// so all components aggregate under one namespace.
+const NAMESPACE_SITES = [
+  'packages/cli/src/telemetry.mjs',
+  'supabase/functions/_shared/otel.ts',
+  'packages/mcp-server/src/instrumentation.ts',
+  'packages/web/src/instrumentation.ts',
+  'packages/web/src/instrumentation-client.ts',
+  'packages/web/src/components/providers/Dash0Provider.tsx',
+];
+
+describe('service.name inventory', () => {
+  it.each(SERVICE_NAME_SITES)('%s declares its documented service name', (_label, file, pattern, expected) => {
+    const match = read(file).match(pattern);
+    expect(match, `no service.name default found in ${file}`).not.toBeNull();
+    expect(match![1]).toBe(expected);
+  });
+
+  it('every component reports a DISTINCT service.name (no service-map collision)', () => {
+    const names = SERVICE_NAME_SITES.map(([, file, pattern]) => read(file).match(pattern)?.[1]);
+    expect(names).toEqual(['cli', 'api', 'mcp-node', 'web']);
+    expect(new Set(names).size).toBe(SERVICE_NAME_SITES.length);
+  });
+});
+
+describe('service.namespace', () => {
+  it.each(NAMESPACE_SITES)('%s pins service.namespace to "lorekit"', (file) => {
+    // Matches both the OTLP key/value form (cli, edge) and the object form (web).
+    expect(read(file)).toMatch(/service\.namespace'[^\n]*'lorekit'/);
+  });
+});
+
+describe('edge span-kind assignment (SERVER root / CLIENT db / INTERNAL child)', () => {
+  const otel = read('supabase/functions/_shared/otel.ts');
+
+  it('uses the OTLP wire values (INTERNAL=1, SERVER=2, CLIENT=3)', () => {
+    expect(otel).toMatch(/SPAN_KIND_INTERNAL\s*=\s*1\b/);
+    expect(otel).toMatch(/SPAN_KIND_SERVER\s*=\s*2\b/);
+    expect(otel).toMatch(/SPAN_KIND_CLIENT\s*=\s*3\b/);
+  });
+
+  it('makes the root request span a SERVER span', () => {
+    // Without SERVER on the root, no APM can draw the inbound service edge.
+    expect(otel).toMatch(/new Span\(operationName, ctx, batch, SPAN_KIND_SERVER\)/);
+  });
+
+  it('makes every DB query a CLIENT span', () => {
+    // The CLIENT span is the outbound edge to Postgres.
+    expect(otel).toMatch(/SPAN_KIND_CLIENT\)/);
+    expect(otel).toMatch(/this\.parent\.child\(sql,[\s\S]*?SPAN_KIND_CLIENT\)/);
+  });
+
+  it('defaults child spans to INTERNAL', () => {
+    expect(otel).toMatch(/kind: number = SPAN_KIND_INTERNAL/);
+  });
+});
+
+describe('faas.name distinguishes the five edge functions', () => {
+  const otel = read('supabase/functions/_shared/otel.ts');
+
+  it('root span sets faas.name derived from the operation name', () => {
+    expect(otel).toMatch(/'faas\.name':\s*faasNameFrom\(operationName\)/);
+  });
+
+  it('faasNameFrom strips the lorekit. prefix', () => {
+    expect(otel).toMatch(/operationName\.startsWith\('lorekit\.'\)/);
+  });
+});
+
+describe('AlwaysOn: the sampled flag is recorded, never an export gate', () => {
+  const otel = read('supabase/functions/_shared/otel.ts');
+
+  it('records the W3C sampled bit as OTLP span flags', () => {
+    expect(otel).toMatch(/flags:\s*s\.ctx\.sampled\s*\?\s*1\s*:\s*0/);
+  });
+
+  it('the export flush path does not branch on the sampled flag', () => {
+    // Extract the ExportBatch.flush() body and assert export is unconditional
+    // on `sampled` — turning the flag into a drop condition is the regression
+    // this guards (root CLAUDE.md: "never turn this into a drop condition").
+    const flush = otel.match(/flush\(\):\s*void\s*\{([\s\S]*?)\n {2}\}/);
+    expect(flush, 'could not locate ExportBatch.flush()').not.toBeNull();
+    expect(flush![1]).toMatch(/fetch\(/); // it does export
+    expect(flush![1]).not.toMatch(/sampled/); // but never consults the flag
+  });
+});
+
+describe('lorekit.* tool span + histogram attributes', () => {
+  const toolsDir = path.join(here, 'tools');
+  const toolFiles = readdirSync(toolsDir).filter((f) => f.endsWith('.ts') && !f.endsWith('.spec.ts'));
+
+  it('there is at least one instrumented tool handler', () => {
+    expect(toolFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(toolFiles)('%s sets the correlation attributes and records the duration histogram', (file) => {
+    const src = readFileSync(path.join(toolsDir, file), 'utf8');
+    // Every tool span is named `lorekit.memory.<op>` and identified by a bounded
+    // tool name on the span itself.
+    expect(src).toMatch(/startActiveSpan\(\s*'lorekit\.memory\./);
+    expect(src).toMatch(/setAttribute\('lorekit\.tool\.name'/);
+    // …and feeds the duration histogram keyed by the two low-cardinality attrs
+    // the metric is defined over. `lorekit.scope.type` is `scopeType(...)` for a
+    // single-scope tool and a bounded literal ('global' / 'mixed') for a
+    // cross-scope one — both are low-cardinality, which is what the metric needs.
+    expect(src).toMatch(/getToolDurationHistogram\(\)/);
+    expect(src).toMatch(/hist\.record\(/);
+    expect(src).toMatch(/'lorekit\.tool\.name':/);
+    expect(src).toMatch(/'lorekit\.scope\.type':/);
+  });
+});
+
+describe('lorekit.tool.duration histogram accessor', () => {
+  it('exposes the shared tracer/meter under the lorekit name', () => {
+    expect(TRACER_NAME).toBe('lorekit');
+    expect(METER_NAME).toBe('lorekit');
+    expect(typeof getTracer().startActiveSpan).toBe('function');
+    expect(typeof getMeter().createHistogram).toBe('function');
+  });
+
+  it('memoizes the histogram instance (one instrument, not one per call)', () => {
+    // A fresh histogram per call would register duplicate instruments and
+    // fragment the metric — the accessor must return the same object.
+    expect(getToolDurationHistogram()).toBe(getToolDurationHistogram());
+  });
+
+  it('records a duration with the documented low-cardinality attributes without throwing', () => {
+    const hist = getToolDurationHistogram();
+    expect(() =>
+      hist.record(0.012, { 'lorekit.tool.name': 'memory.list', 'lorekit.scope.type': 'repo' }),
+    ).not.toThrow();
+  });
+});

--- a/packages/mcp-core/src/otel-conventions.spec.ts
+++ b/packages/mcp-core/src/otel-conventions.spec.ts
@@ -106,6 +106,43 @@ describe('faas.name distinguishes the five edge functions', () => {
   });
 });
 
+describe('edge + CLI route trace propagation through the shared W3C seam', () => {
+  // The correlation contract (otel-correlation.spec.ts) is proven against
+  // reference COPIES of the wiring. These source-scans keep those copies honest
+  // by asserting the shipped edge/CLI code still routes propagation through the
+  // single `parseTraceparent` / `formatTraceparent` seam — the property the
+  // correlation proofs assume. If a component stopped using the seam (or
+  // hand-rolled a divergent header/parser), CLI/MCP traces could silently
+  // orphan and no behavioural copy-test would notice.
+  const edge = read('supabase/functions/_shared/otel.ts');
+  const cli = read('packages/cli/src/telemetry.mjs');
+
+  it('the edge receiver (extractTraceContext) parses inbound context via parseTraceparent', () => {
+    const fn = edge.match(/function extractTraceContext\([\s\S]*?\n\}/);
+    expect(fn, 'extractTraceContext not found').not.toBeNull();
+    expect(fn![0]).toMatch(/parseTraceparent\(/);
+  });
+
+  it('the edge sender (withTraceparent) formats the response header via formatTraceparent', () => {
+    const fn = edge.match(/function withTraceparent<[\s\S]*?\n\}/);
+    expect(fn, 'withTraceparent not found').not.toBeNull();
+    expect(fn![0]).toMatch(/formatTraceparent\(/);
+  });
+
+  it('the edge imports both seam functions from the shared trace-context module', () => {
+    expect(edge).toMatch(/import\s*\{[^}]*\bformatTraceparent\b[^}]*\bparseTraceparent\b[^}]*\}\s*from\s*'\.\/trace-context\.ts'/);
+  });
+
+  it('the CLI (getActiveTraceparent) emits a version-00 W3C header from the active ids', () => {
+    const fn = cli.match(/export function getActiveTraceparent\(\)\s*\{[\s\S]*?\n\}/);
+    expect(fn, 'getActiveTraceparent not found').not.toBeNull();
+    // A version-00, four-field traceparent driven by the active trace/span ids
+    // and the sampled bit — the byte-identity to formatTraceparent is proven in
+    // otel-correlation.spec.ts by rendering this exact template.
+    expect(fn![0]).toMatch(/`00-\$\{_activeTraceId\}-\$\{_activeSpanId\}-\$\{_activeSampled \? '01' : '00'\}`/);
+  });
+});
+
 describe('AlwaysOn: the sampled flag is recorded, never an export gate', () => {
   const otel = read('supabase/functions/_shared/otel.ts');
 

--- a/packages/mcp-core/src/otel-correlation.spec.ts
+++ b/packages/mcp-core/src/otel-correlation.spec.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { randomBytes } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
 import { formatTraceparent, parseTraceparent } from './trace-context.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const readRepo = (rel: string) => readFileSync(path.join(repoRoot, rel), 'utf8');
 
 /**
  * Cross-service trace-context correlation contract.
@@ -17,14 +23,21 @@ import { formatTraceparent, parseTraceparent } from './trace-context.js';
  * `getActiveTraceparent`). So the correlation contract is provable purely from
  * that seam, without booting a Deno isolate or an OTel SDK.
  *
- * The reference helpers below mirror the wiring in
- * `supabase/functions/_shared/otel.ts` exactly:
+ * The reference helpers below RE-STATE the wiring in
+ * `supabase/functions/_shared/otel.ts` so the correlation *semantics* can be
+ * asserted without a Deno isolate:
  *   - `serverContinue`  ≡ `extractTraceContext` (continue inbound, or new root)
  *   - `echoTraceparent` ≡ `withTraceparent`     (server → response header)
  *   - `cliTraceparent`  ≡ CLI `getActiveTraceparent`
- * A drift guard (`otel-conventions.spec.ts`) asserts the edge/CLI source keeps
- * using this seam, so these behavioural proofs cannot silently detach from the
- * shipped code.
+ * Because they are copies, two drift guards keep them honest against the SHIPPED
+ * code rather than against themselves:
+ *   - the "zero-dep CLI header" test below source-scans the CLI's ACTUAL
+ *     `getActiveTraceparent` template and proves it renders byte-identically to
+ *     `formatTraceparent`;
+ *   - `otel-conventions.spec.ts` ("edge + CLI route propagation through the
+ *     shared W3C seam") source-scans that `extractTraceContext` /
+ *     `withTraceparent` / `getActiveTraceparent` still route through
+ *     `parseTraceparent` / `formatTraceparent`.
  */
 
 // Fresh, spec-valid ids — mirrors `randHex(16)` (trace) / `randHex(8)` (span).
@@ -56,7 +69,11 @@ function echoTraceparent(ctx: { traceId: string; spanId: string; sampled: boolea
   return formatTraceparent(ctx.traceId, ctx.spanId, ctx.sampled);
 }
 
-/** Byte-for-byte re-implementation of the CLI's `getActiveTraceparent`. */
+/**
+ * Reference re-statement of the CLI's `getActiveTraceparent` header, used by the
+ * behavioural correlation proofs below. It is a COPY — the "zero-dep CLI header"
+ * test guards it against the shipped CLI source, so it can't silently drift.
+ */
 const cliTraceparent = (traceId: string, spanId: string, sampled: boolean) =>
   `00-${traceId}-${spanId}-${sampled ? '01' : '00'}`;
 
@@ -186,15 +203,39 @@ describe('sender/receiver seam is self-consistent', () => {
     expect(parsed).toEqual({ traceId: TRACE_ID, parentSpanId: SPAN_ID, sampled });
   });
 
-  it('the zero-dep CLI header is byte-identical to formatTraceparent', () => {
+  it('the zero-dep CLI header (shipped source) is byte-identical to formatTraceparent', () => {
     // The CLI cannot import the TS module (it is zero-dependency .mjs), so it
     // hand-rolls the header. If these two ever diverge, a CLI-emitted header
     // could stop parsing server-side and silently orphan every CLI trace.
+    //
+    // Guard the ACTUAL shipped code, not a copy: pull the template literal out
+    // of the CLI's real `getActiveTraceparent` and prove that RENDERING it with
+    // concrete ids yields exactly what `formatTraceparent` produces. If the CLI
+    // source drifts (version prefix, field order, the sampled ternary) this
+    // fails — which a byte-comparison of two in-file copies never would.
+    const cliSrc = readRepo('packages/cli/src/telemetry.mjs');
+    const fnBody = cliSrc.match(/export function getActiveTraceparent\(\)\s*\{([\s\S]*?)\n\}/);
+    expect(fnBody, 'getActiveTraceparent not found in telemetry.mjs').not.toBeNull();
+    const tpl = fnBody![1].match(/return\s*`([^`]*)`/);
+    expect(tpl, 'no returned template literal in getActiveTraceparent').not.toBeNull();
+    const template = tpl![1];
+
+    // Sanity: it is a version-00, four-field header driven by the trace/span ids.
+    expect(template.startsWith('00-')).toBe(true);
+    expect(template).toContain('${_activeTraceId}');
+    expect(template).toContain('${_activeSpanId}');
+
+    const render = (t: string, s: string, sampled: boolean) =>
+      template
+        .replace('${_activeTraceId}', t)
+        .replace('${_activeSpanId}', s)
+        .replace(/\$\{_activeSampled[^}]*\}/, sampled ? '01' : '00');
+
     for (const sampled of [true, false]) {
       for (let i = 0; i < 32; i++) {
         const t = freshTraceId();
         const s = freshSpanId();
-        expect(cliTraceparent(t, s, sampled)).toBe(formatTraceparent(t, s, sampled));
+        expect(render(t, s, sampled)).toBe(formatTraceparent(t, s, sampled));
       }
     }
   });

--- a/packages/mcp-core/src/otel-correlation.spec.ts
+++ b/packages/mcp-core/src/otel-correlation.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import { randomBytes } from 'node:crypto';
+import { formatTraceparent, parseTraceparent } from './trace-context.js';
+
+/**
+ * Cross-service trace-context correlation contract.
+ *
+ * The user question this suite answers: "when the CLI calls the api, or MCP
+ * calls the api, do the spans actually join into ONE trace, and is the
+ * parent/child linkage correct?"
+ *
+ * Every LoreKit component propagates W3C `traceparent` through the SAME two
+ * pure functions — `parseTraceparent` (receiver) and `formatTraceparent`
+ * (sender) — which are the single seam mirrored verbatim into every edge
+ * function (`supabase/functions/_shared/trace-context.ts`) and re-implemented
+ * byte-for-byte by the zero-dep CLI (`packages/cli/src/telemetry.mjs`
+ * `getActiveTraceparent`). So the correlation contract is provable purely from
+ * that seam, without booting a Deno isolate or an OTel SDK.
+ *
+ * The reference helpers below mirror the wiring in
+ * `supabase/functions/_shared/otel.ts` exactly:
+ *   - `serverContinue`  ≡ `extractTraceContext` (continue inbound, or new root)
+ *   - `echoTraceparent` ≡ `withTraceparent`     (server → response header)
+ *   - `cliTraceparent`  ≡ CLI `getActiveTraceparent`
+ * A drift guard (`otel-conventions.spec.ts`) asserts the edge/CLI source keeps
+ * using this seam, so these behavioural proofs cannot silently detach from the
+ * shipped code.
+ */
+
+// Fresh, spec-valid ids — mirrors `randHex(16)` (trace) / `randHex(8)` (span).
+const freshTraceId = () => randomBytes(16).toString('hex');
+const freshSpanId = () => randomBytes(8).toString('hex');
+
+/**
+ * Receiver seam — mirrors `extractTraceContext` in `_shared/otel.ts`.
+ * A valid inbound header CONTINUES the trace (same trace id, fresh span id,
+ * parent = inbound span). Anything invalid starts a NEW root (AlwaysOn).
+ */
+function serverContinue(inboundHeader: string | null | undefined) {
+  const parsed = parseTraceparent(inboundHeader);
+  if (parsed) {
+    return {
+      traceId: parsed.traceId,
+      spanId: freshSpanId(),
+      parentSpanId: parsed.parentSpanId,
+      sampled: parsed.sampled,
+      isRoot: false,
+    };
+  }
+  // Locally-originated root — today's AlwaysOn behaviour.
+  return { traceId: freshTraceId(), spanId: freshSpanId(), parentSpanId: undefined, sampled: true, isRoot: true };
+}
+
+/** Sender seam — the header a server echoes back / a caller injects downstream. */
+function echoTraceparent(ctx: { traceId: string; spanId: string; sampled: boolean }): string {
+  return formatTraceparent(ctx.traceId, ctx.spanId, ctx.sampled);
+}
+
+/** Byte-for-byte re-implementation of the CLI's `getActiveTraceparent`. */
+const cliTraceparent = (traceId: string, spanId: string, sampled: boolean) =>
+  `00-${traceId}-${spanId}-${sampled ? '01' : '00'}`;
+
+describe('CLI → api correlation', () => {
+  it('the api server span joins the CLI command trace as a child', () => {
+    // A CLI command generates one root span for the whole command.
+    const cli = { traceId: freshTraceId(), spanId: freshSpanId(), sampled: true };
+    const outgoing = cliTraceparent(cli.traceId, cli.spanId, cli.sampled);
+
+    const server = serverContinue(outgoing);
+
+    expect(server.isRoot).toBe(false);
+    // Same trace → both spans render under one waterfall in Dash0.
+    expect(server.traceId).toBe(cli.traceId);
+    // The server span is a NEW span, parented on the CLI command span.
+    expect(server.spanId).not.toBe(cli.spanId);
+    expect(server.parentSpanId).toBe(cli.spanId);
+    // The sampled decision rides along unchanged.
+    expect(server.sampled).toBe(cli.sampled);
+  });
+
+  it('every REST call in one command lands under the same command span (siblings)', () => {
+    // The CLI reuses one command span id for the whole run, so N REST calls
+    // produce N sibling server spans that all point back at it.
+    const cli = { traceId: freshTraceId(), spanId: freshSpanId(), sampled: true };
+    const header = cliTraceparent(cli.traceId, cli.spanId, cli.sampled);
+
+    const call1 = serverContinue(header);
+    const call2 = serverContinue(header);
+    const call3 = serverContinue(header);
+
+    for (const c of [call1, call2, call3]) {
+      expect(c.traceId).toBe(cli.traceId);
+      expect(c.parentSpanId).toBe(cli.spanId);
+    }
+    // Each server span is distinct — no accidental id sharing.
+    expect(new Set([call1.spanId, call2.spanId, call3.spanId]).size).toBe(3);
+  });
+
+  it('carries the un-sampled decision through unchanged (telemetry-disabled CLI)', () => {
+    // A CLI with no OTLP endpoint still propagates context; only the flag clears.
+    const cli = { traceId: freshTraceId(), spanId: freshSpanId(), sampled: false };
+    const server = serverContinue(cliTraceparent(cli.traceId, cli.spanId, cli.sampled));
+
+    expect(server.isRoot).toBe(false);
+    expect(server.traceId).toBe(cli.traceId);
+    expect(server.sampled).toBe(false);
+  });
+});
+
+describe('response echo — caller can correlate back to the server span', () => {
+  it('the echoed traceparent names the server span, in the same trace', () => {
+    const cli = { traceId: freshTraceId(), spanId: freshSpanId(), sampled: true };
+    const server = serverContinue(cliTraceparent(cli.traceId, cli.spanId, cli.sampled));
+
+    // `withTraceparent` echoes the SERVER span so the caller can link to it.
+    const echoed = echoTraceparent({ traceId: server.traceId, spanId: server.spanId, sampled: server.sampled });
+    const readBack = parseTraceparent(echoed);
+
+    expect(readBack).not.toBeNull();
+    expect(readBack!.traceId).toBe(cli.traceId); // still one trace end-to-end
+    expect(readBack!.parentSpanId).toBe(server.spanId); // points at the server span
+  });
+});
+
+describe('MCP → api and api → api multi-hop chains', () => {
+  it('preserves one trace id across a 3-service chain with correct parentage', () => {
+    // agent → mcp (server span) → api (server span). Each hop continues the
+    // previous hop's trace and parents on the previous hop's span.
+    const agent = { traceId: freshTraceId(), spanId: freshSpanId(), sampled: true };
+
+    const mcp = serverContinue(cliTraceparent(agent.traceId, agent.spanId, agent.sampled));
+    // The MCP tool handler's outgoing fetch carries the MCP span as parent.
+    const mcpOutgoing = echoTraceparent({ traceId: mcp.traceId, spanId: mcp.spanId, sampled: mcp.sampled });
+    const api = serverContinue(mcpOutgoing);
+
+    // One trace id from agent all the way to the api.
+    expect(mcp.traceId).toBe(agent.traceId);
+    expect(api.traceId).toBe(agent.traceId);
+    // The parent chain is agent-span ← mcp-span ← api-span.
+    expect(mcp.parentSpanId).toBe(agent.spanId);
+    expect(api.parentSpanId).toBe(mcp.spanId);
+    // Three genuinely distinct spans.
+    expect(new Set([agent.spanId, mcp.spanId, api.spanId]).size).toBe(3);
+  });
+});
+
+describe('invalid inbound context never corrupts a trace', () => {
+  it.each([
+    ['a non-hex trace id', `00-${'z'.repeat(32)}-${'00f067aa0ba902b7'}-01`],
+    ['an all-zero trace id', `00-${'0'.repeat(32)}-00f067aa0ba902b7-01`],
+    ['the forbidden ff version', `ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`],
+    ['a truncated header', `00-4bf92f3577b34da6a3ce929d0e0e4736`],
+    ['a garbage string', 'not-a-traceparent'],
+    ['an absent header', null],
+  ])('starts a fresh root trace for %s (no parent, sampled default)', (_label, header) => {
+    const server = serverContinue(header);
+    expect(server.isRoot).toBe(true);
+    // A new root: fresh, valid trace id and no parent linkage to a corrupt id.
+    expect(server.traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(server.parentSpanId).toBeUndefined();
+    // AlwaysOn: a locally-originated root is sampled.
+    expect(server.sampled).toBe(true);
+  });
+});
+
+describe('sampled flag is recorded-and-propagated, never an export gate', () => {
+  it.each([true, false])('continues the trace identically regardless of the flag (sampled=%s)', (sampled) => {
+    const upstream = { traceId: freshTraceId(), spanId: freshSpanId(), sampled };
+    const server = serverContinue(cliTraceparent(upstream.traceId, upstream.spanId, sampled));
+
+    // The trace is continued the SAME way whether or not it is sampled — the
+    // flag is data that rides along, not a decision that drops the span.
+    expect(server.isRoot).toBe(false);
+    expect(server.traceId).toBe(upstream.traceId);
+    expect(server.parentSpanId).toBe(upstream.spanId);
+    expect(server.sampled).toBe(sampled);
+  });
+});
+
+describe('sender/receiver seam is self-consistent', () => {
+  const TRACE_ID = '4bf92f3577b34da6a3ce929d0e0e4736';
+  const SPAN_ID = '00f067aa0ba902b7';
+
+  it.each([true, false])('parse(format(x)) round-trips (sampled=%s)', (sampled) => {
+    const parsed = parseTraceparent(formatTraceparent(TRACE_ID, SPAN_ID, sampled));
+    expect(parsed).toEqual({ traceId: TRACE_ID, parentSpanId: SPAN_ID, sampled });
+  });
+
+  it('the zero-dep CLI header is byte-identical to formatTraceparent', () => {
+    // The CLI cannot import the TS module (it is zero-dependency .mjs), so it
+    // hand-rolls the header. If these two ever diverge, a CLI-emitted header
+    // could stop parsing server-side and silently orphan every CLI trace.
+    for (const sampled of [true, false]) {
+      for (let i = 0; i < 32; i++) {
+        const t = freshTraceId();
+        const s = freshSpanId();
+        expect(cliTraceparent(t, s, sampled)).toBe(formatTraceparent(t, s, sampled));
+      }
+    }
+  });
+});

--- a/packages/mcp-core/src/otel-harness.spec.ts
+++ b/packages/mcp-core/src/otel-harness.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+// The harness is a repo-level, cross-package dev tool (like scripts/sync-edge-
+// schemas.mjs); it deliberately lives outside any single package, so this test
+// reaches it by path. Not a package-to-package internal import.
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { buildCorrelatedTrace, HARNESS_ENVIRONMENT } from '../../../scripts/emit-correlated-trace.mts';
+
+/**
+ * The correlated-trace harness (`scripts/emit-correlated-trace.mts`) is the
+ * on-demand tool that emits ONE real, correlated cross-service trace to Dash0
+ * for visual validation. This suite exercises its pure builder (no network) and
+ * asserts the emitted OTLP is a genuinely correlated, `test`-tagged trace built
+ * from each component's real emission code — so the tool can't silently start
+ * producing an un-joined or un-isolatable trace.
+ */
+
+type OtlpPayload = {
+  resourceSpans: {
+    resource: { attributes: { key: string; value: { stringValue?: string } }[] };
+    scopeSpans: {
+      spans: { name: string; kind: number; traceId: string; spanId: string; parentSpanId?: string; flags?: number }[];
+    }[];
+  }[];
+};
+
+const resourceAttrs = (p: OtlpPayload) =>
+  Object.fromEntries(p.resourceSpans[0].resource.attributes.map((a) => [a.key, a.value.stringValue]));
+const spansOf = (p: OtlpPayload) => p.resourceSpans[0].scopeSpans.flatMap((s) => s.spans);
+
+describe('correlated-trace harness — buildCorrelatedTrace', () => {
+  it('emits three service blocks (cli, api, mcp-node) under ONE trace id', () => {
+    const { traceId, payloads } = buildCorrelatedTrace();
+    expect(traceId).toMatch(/^[0-9a-f]{32}$/);
+    expect(payloads.map((p) => p.serviceName)).toEqual(['cli', 'api', 'mcp-node']);
+
+    for (const { payload } of payloads) {
+      const spans = spansOf(payload as OtlpPayload);
+      expect(spans.length).toBeGreaterThan(0);
+      for (const s of spans) expect(s.traceId).toBe(traceId); // one trace end-to-end
+    }
+  });
+
+  it('stamps every resource block with service.namespace=lorekit and the test marker', () => {
+    const { payloads } = buildCorrelatedTrace();
+    for (const { serviceName, payload } of payloads) {
+      const attrs = resourceAttrs(payload as OtlpPayload);
+      expect(attrs['service.name']).toBe(serviceName);
+      expect(attrs['service.namespace']).toBe('lorekit');
+      expect(attrs['deployment.environment.name']).toBe(HARNESS_ENVIRONMENT);
+    }
+  });
+
+  it('honours an explicit deployment-environment override', () => {
+    const { payloads } = buildCorrelatedTrace({ deploymentEnvironment: 'staging' });
+    for (const { payload } of payloads) {
+      expect(resourceAttrs(payload as OtlpPayload)['deployment.environment.name']).toBe('staging');
+    }
+  });
+
+  it('uses correct OTel span kinds: INTERNAL cli root, SERVER edge/mcp, CLIENT db', () => {
+    const { payloads } = buildCorrelatedTrace();
+    const byService = Object.fromEntries(payloads.map((p) => [p.serviceName, spansOf(p.payload as OtlpPayload)]));
+
+    // cli root is a single INTERNAL(1) span.
+    expect(byService.cli.map((s) => s.kind)).toEqual([1]);
+    // mcp-node hop is a SERVER(2) span.
+    expect(byService['mcp-node'].map((s) => s.kind)).toEqual([2]);
+    // api block carries both SERVER(2) request spans and CLIENT(3) db spans.
+    const apiKinds = new Set(byService.api.map((s) => s.kind));
+    expect(apiKinds.has(2)).toBe(true);
+    expect(apiKinds.has(3)).toBe(true);
+  });
+
+  it('links the hops correctly: CLI→api, MCP→api, and SERVER→db, all off the cli root', () => {
+    const { payloads } = buildCorrelatedTrace();
+    const cliSpans = spansOf(payloads[0].payload as OtlpPayload);
+    const apiSpans = spansOf(payloads[1].payload as OtlpPayload);
+    const mcpSpans = spansOf(payloads[2].payload as OtlpPayload);
+
+    const cliRoot = cliSpans[0];
+    expect(cliRoot.parentSpanId).toBeUndefined(); // the CLI command span is the root
+
+    const mcp = mcpSpans[0];
+    expect(mcp.parentSpanId).toBe(cliRoot.spanId); // MCP hop hangs off the cli root
+
+    const servers = apiSpans.filter((s) => s.kind === 2);
+    const dbs = apiSpans.filter((s) => s.kind === 3);
+    // One api SERVER continues the CLI command span; the other continues the MCP span.
+    const serverParents = servers.map((s) => s.parentSpanId);
+    expect(serverParents).toContain(cliRoot.spanId); // CLI → api
+    expect(serverParents).toContain(mcp.spanId); // MCP → api
+    // Every db CLIENT span is parented on an api SERVER span (the multi-hop edge chain).
+    const serverIds = new Set(servers.map((s) => s.spanId));
+    for (const db of dbs) expect(serverIds.has(db.parentSpanId as string)).toBe(true);
+  });
+
+  it('records the sampled flag on the exported edge spans (AlwaysOn)', () => {
+    const { payloads } = buildCorrelatedTrace();
+    for (const s of spansOf(payloads[1].payload as OtlpPayload)) expect(s.flags).toBe(1);
+  });
+
+  it('does not leak DEPLOYMENT_ENVIRONMENT / SERVICE_NAME into the ambient env', () => {
+    const beforeDeploy = process.env.DEPLOYMENT_ENVIRONMENT;
+    const beforeService = process.env.SERVICE_NAME;
+    buildCorrelatedTrace({ deploymentEnvironment: 'test' });
+    expect(process.env.DEPLOYMENT_ENVIRONMENT).toBe(beforeDeploy);
+    expect(process.env.SERVICE_NAME).toBe(beforeService);
+  });
+});

--- a/scripts/emit-correlated-trace.mts
+++ b/scripts/emit-correlated-trace.mts
@@ -1,0 +1,283 @@
+/**
+ * Correlated-trace emission harness (manual / on-demand — NOT part of CI).
+ *
+ * The unit suites that prove correlation (`otel-correlation.spec.ts`,
+ * `otel-conventions.spec.ts`, `telemetry.test.mjs`) never boot an exporter, so
+ * nothing they run shows up in Dash0 — correct for a fast, offline CI, but it
+ * leaves no way to *visually* confirm cross-service correlation in the backend.
+ * This harness fills that gap: it emits ONE real, correlated trace to Dash0 on
+ * demand, covering the three production correlation paths —
+ *
+ *     cli ──▶ api (edge SERVER) ──▶ Postgres (edge CLIENT)      [CLI → api]
+ *      └───▶ mcp-node (SERVER) ──▶ api (SERVER) ──▶ Postgres    [MCP → api + multi-hop]
+ *
+ * — as a single trace so the whole thing renders as one waterfall.
+ *
+ * Fidelity: every span is built with the component's OWN emission code, not a
+ * re-implementation:
+ *   • the `cli` span   → the CLI's real `buildTracePayload` (packages/cli)
+ *   • the `api` spans  → the edge's real `Span` / `buildOtlpPayload`
+ *     (supabase/functions/_shared/otel.ts)
+ *   • the `mcp-node` span → the same edge builder with `service.name=mcp-node`
+ *     (the Node MCP server emits via the OTel SDK, which can't be driven
+ *     single-shot cross-package; the wire shape is identical)
+ * Parent→child linkage is derived through the REAL W3C seam
+ * (`formatTraceparent` → `parseTraceparent`, packages/mcp-core) exactly as the
+ * edge's `extractTraceContext` does on the wire.
+ *
+ * Isolation: every span carries `deployment.environment.name=test` as a global
+ * resource attribute, so these traces can be filtered/routed into a separate
+ * Dash0 dataset and never pollute production telemetry.
+ *
+ * Config: reuses the CLI's own `resolveTelemetryConfig` — the exact
+ * endpoint/token/dataset resolution the CLI ships (OTEL_EXPORTER_OTLP_ENDPOINT
+ * + OTEL_EXPORTER_OTLP_HEADERS / LOREKIT_TELEMETRY_TOKEN, Dash0-Dataset). When
+ * nothing is configured it no-ops with a clear message — never crashes, never
+ * needs a committed secret.
+ *
+ * Run:  node --experimental-transform-types scripts/emit-correlated-trace.mts
+ * See:  docs/telemetry-quality-review.md → "Emitting a real correlated trace".
+ */
+
+// The edge module (`_shared/otel.ts`) reads `Deno.env` when it builds a payload.
+// Shim it onto Node's process.env so the edge's REAL code runs unmodified here.
+// (Assigned before any harness call touches the edge builder.)
+(globalThis as unknown as { Deno?: unknown }).Deno ??= {
+  env: { get: (key: string) => process.env[key] },
+};
+
+import process from 'node:process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import path from 'node:path';
+
+import { formatTraceparent, parseTraceparent } from '../packages/mcp-core/src/trace-context.ts';
+import {
+  Span,
+  ExportBatch,
+  buildOtlpPayload,
+  SPAN_KIND_SERVER,
+  SPAN_KIND_CLIENT,
+} from '../supabase/functions/_shared/otel.ts';
+import {
+  resolveTelemetryConfig,
+  buildTracePayload,
+  randHex,
+} from '../packages/cli/src/telemetry.mjs';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/** The environment marker every harness span carries, so `test` is isolatable. */
+export const HARNESS_ENVIRONMENT = 'test';
+
+interface TraceCtx {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  sampled: boolean;
+}
+
+/**
+ * Continue a trace from a parent span, routing through the REAL W3C seam
+ * (`formatTraceparent` → `parseTraceparent`) exactly as the edge's
+ * `extractTraceContext` does when it receives an inbound request.
+ */
+function continueTrace(parentTraceId: string, parentSpanId: string, sampled: boolean): TraceCtx {
+  const parsed = parseTraceparent(formatTraceparent(parentTraceId, parentSpanId, sampled));
+  if (!parsed) throw new Error('harness: the traceparent seam produced an unparseable header');
+  return {
+    traceId: parsed.traceId,
+    spanId: randHex(8),
+    parentSpanId: parsed.parentSpanId,
+    sampled: parsed.sampled,
+  };
+}
+
+export interface CorrelatedTrace {
+  traceId: string;
+  /** One OTLP `/v1/traces` payload per service identity (cli, api, mcp-node). */
+  payloads: { serviceName: string; payload: unknown }[];
+}
+
+/**
+ * Build (but do not send) one correlated cross-service trace. Pure w.r.t. the
+ * network — used both by `main()` and by the harness's own test. All spans
+ * share one `trace_id`; every resource is stamped `deployment.environment.name`.
+ */
+export function buildCorrelatedTrace(
+  { version = '0.0.0-harness', deploymentEnvironment = HARNESS_ENVIRONMENT }: { version?: string; deploymentEnvironment?: string } = {},
+): CorrelatedTrace {
+  const prevDeploy = process.env.DEPLOYMENT_ENVIRONMENT;
+  const prevService = process.env.SERVICE_NAME;
+  process.env.DEPLOYMENT_ENVIRONMENT = deploymentEnvironment;
+  try {
+    const traceId = randHex(16);
+    const cliSpanId = randHex(8);
+    const startMs = Date.now();
+
+    // 1) CLI root span — the CLI's REAL OTLP builder (service.name = cli).
+    const cliPayload = buildTracePayload({
+      version,
+      name: 'lorekit.cli.list',
+      attributes: {
+        'lorekit.cli.command': 'list',
+        'lorekit.cli.outcome': 'ok',
+        'lorekit.harness': true,
+      },
+      startMs,
+      endMs: startMs + 40,
+      status: 'ok',
+      traceId,
+      spanId: cliSpanId,
+    });
+
+    // 2) + 3) edge / mcp-node spans — the edge's REAL Span + buildOtlpPayload.
+    const apiBatch = new ExportBatch();
+    const mcpBatch = new ExportBatch();
+
+    // CLI → api: a SERVER span continuing the CLI command span, then its DB call.
+    const apiServer1 = new Span('lorekit.memories', continueTrace(traceId, cliSpanId, true), apiBatch, SPAN_KIND_SERVER);
+    apiServer1.setAttributes({
+      'http.request.method': 'POST',
+      'url.path': '/memories',
+      'faas.name': 'memories',
+      'lorekit.tool.name': 'memory.write',
+      'http.response.status_code': 200,
+    });
+    apiServer1
+      .child('INSERT INTO memories (scope, key, value)', {
+        'db.system': 'postgresql',
+        'db.operation.name': 'INSERT',
+        'db.collection.name': 'memories',
+      }, SPAN_KIND_CLIENT)
+      .end();
+    apiServer1.end();
+
+    // MCP → api: a mcp-node SERVER span continuing the trace, which then calls api.
+    const mcpCtx = continueTrace(traceId, cliSpanId, true);
+    const mcpServer = new Span('lorekit.mcp', mcpCtx, mcpBatch, SPAN_KIND_SERVER);
+    mcpServer.setAttributes({
+      'rpc.system': 'jsonrpc',
+      'rpc.method': 'tools/call',
+      'faas.name': 'mcp',
+      'lorekit.tool.name': 'memory.read',
+    });
+
+    const apiServer2 = new Span('lorekit.memories', continueTrace(mcpCtx.traceId, mcpCtx.spanId, mcpCtx.sampled), apiBatch, SPAN_KIND_SERVER);
+    apiServer2.setAttributes({
+      'http.request.method': 'GET',
+      'url.path': '/memories',
+      'faas.name': 'memories',
+      'lorekit.tool.name': 'memory.read',
+      'http.response.status_code': 200,
+    });
+    apiServer2
+      .child('SELECT scope, key, value FROM memories', {
+        'db.system': 'postgresql',
+        'db.operation.name': 'SELECT',
+        'db.collection.name': 'memories',
+      }, SPAN_KIND_CLIENT)
+      .end();
+    apiServer2.end();
+    mcpServer.end();
+
+    // Group by service.name (buildOtlpPayload reads SERVICE_NAME) so each hop
+    // renders under its own service node in the map.
+    process.env.SERVICE_NAME = 'api';
+    const apiPayload = buildOtlpPayload(apiBatch.drain());
+    process.env.SERVICE_NAME = 'mcp-node';
+    const mcpPayload = buildOtlpPayload(mcpBatch.drain());
+
+    return {
+      traceId,
+      payloads: [
+        { serviceName: 'cli', payload: cliPayload },
+        { serviceName: 'api', payload: apiPayload },
+        { serviceName: 'mcp-node', payload: mcpPayload },
+      ],
+    };
+  } finally {
+    if (prevDeploy === undefined) delete process.env.DEPLOYMENT_ENVIRONMENT;
+    else process.env.DEPLOYMENT_ENVIRONMENT = prevDeploy;
+    if (prevService === undefined) delete process.env.SERVICE_NAME;
+    else process.env.SERVICE_NAME = prevService;
+  }
+}
+
+/** Resolve the CLI package version for a realistic `service.version`. */
+function cliVersion(): string {
+  try {
+    const pkg = JSON.parse(readFileSync(path.join(here, '../packages/cli/package.json'), 'utf8'));
+    return String(pkg.version ?? '0.0.0-harness');
+  } catch {
+    return '0.0.0-harness';
+  }
+}
+
+/** Read the Dash0 dataset from the resolved headers (case-insensitive). */
+function datasetOf(headers: Record<string, string>): string | undefined {
+  const key = Object.keys(headers).find((k) => k.toLowerCase() === 'dash0-dataset');
+  return key ? headers[key] : undefined;
+}
+
+async function postTraces(
+  config: { endpoint: string; headers: Record<string, string> },
+  payload: unknown,
+  label: string,
+): Promise<void> {
+  const res = await fetch(`${config.endpoint}/v1/traces`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', ...config.headers },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    console.error(`[emit-correlated-trace] ${label}: OTLP export returned HTTP ${res.status} ${res.statusText}`);
+  }
+}
+
+export async function main(): Promise<number> {
+  const config = resolveTelemetryConfig();
+  if (!config.enabled) {
+    console.error(
+      '[emit-correlated-trace] No OTLP endpoint/token configured — nothing emitted.\n' +
+        'Set OTEL_EXPORTER_OTLP_ENDPOINT and OTEL_EXPORTER_OTLP_HEADERS\n' +
+        '(or LOREKIT_TELEMETRY_TOKEN for the baked-in endpoint), then re-run.',
+    );
+    return 0;
+  }
+
+  const deploymentEnvironment = process.env.DEPLOYMENT_ENVIRONMENT?.trim() || HARNESS_ENVIRONMENT;
+  const { traceId, payloads } = buildCorrelatedTrace({ version: cliVersion(), deploymentEnvironment });
+
+  for (const { serviceName, payload } of payloads) {
+    await postTraces(config, payload, serviceName);
+  }
+
+  const host = (() => {
+    try {
+      return new URL(config.endpoint).host;
+    } catch {
+      return config.endpoint;
+    }
+  })();
+  const dataset = datasetOf(config.headers) ?? '(default)';
+
+  console.log('[emit-correlated-trace] Correlated trace emitted to Dash0.');
+  console.log(`  trace_id   : ${traceId}`);
+  console.log(`  services   : cli, api, mcp-node (${payloads.length} resource blocks)`);
+  console.log(`  endpoint   : ${host}`);
+  console.log(`  dataset    : ${dataset}`);
+  console.log(`  filter in Dash0: deployment.environment.name = ${deploymentEnvironment}`);
+  console.log(`  then open trace_id ${traceId} to see the CLI→api and MCP→api waterfall.`);
+  return 0;
+}
+
+// Run only when invoked directly (never on import, e.g. from the test).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main()
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error('[emit-correlated-trace] failed:', err);
+      process.exit(1);
+    });
+}

--- a/supabase/functions/_shared/otel.ts
+++ b/supabase/functions/_shared/otel.ts
@@ -190,14 +190,23 @@ function toOtlpValue(v: string | number | boolean) {
 }
 
 /**
- * Resolve deployment environment from Supabase secrets.
- * Set VERCEL_ENV as a Supabase secret matching the Vercel-injected value:
- *   production  → production deployment
- *   preview     → preview/staging deployment
- *   development → local `vercel dev` or staging
- *   (absent)    → 'local'
+ * Resolve deployment environment for the `deployment.environment.name` resource
+ * attribute.
+ *
+ * Priority:
+ *   1. `DEPLOYMENT_ENVIRONMENT` — an explicit override. This is the single,
+ *      env-driven path every LoreKit component honours so a correlated-trace
+ *      run can stamp `test` uniformly (see `scripts/emit-correlated-trace.mts`)
+ *      and any deployment can name its environment directly.
+ *   2. `VERCEL_ENV` — mapped to production / preview / development.
+ *   3. (absent) → 'local'.
+ *
+ * Set either as a Supabase secret. The override wins so it can pin the value
+ * regardless of the ambient Vercel signal.
  */
 function resolveDeploymentEnv(): string {
+  const override = Deno.env.get('DEPLOYMENT_ENVIRONMENT');
+  if (override) return override;
   const env = Deno.env.get('VERCEL_ENV');
   if (env === 'production') return 'production';
   if (env === 'preview') return 'preview';
@@ -205,7 +214,7 @@ function resolveDeploymentEnv(): string {
   return 'local';
 }
 
-function buildOtlpPayload(spans: SpanPayload[]): unknown {
+export function buildOtlpPayload(spans: SpanPayload[]): unknown {
   // Build vcs.* resource attributes once per payload (they are constant for
   // the lifetime of the isolate — resolved from Supabase secrets at startup).
   const vcsAttrs = getVcsResourceAttributes();
@@ -266,10 +275,22 @@ function buildOtlpPayload(spans: SpanPayload[]): unknown {
   };
 }
 
-class ExportBatch {
+export class ExportBatch {
   private spans: SpanPayload[] = [];
 
   add(span: SpanPayload): void { this.spans.push(span); }
+
+  /**
+   * Remove and return the collected spans. Used by the offline correlated-trace
+   * harness to hand the real, edge-built spans to `buildOtlpPayload` without
+   * going through the fire-and-forget `flush()` (which reads Deno secrets and
+   * posts). Not used on the request path.
+   */
+  drain(): SpanPayload[] {
+    const spans = this.spans;
+    this.spans = [];
+    return spans;
+  }
 
   /** Fire-and-forget flush — use EdgeRuntime.waitUntil when available. */
   flush(): void {


### PR DESCRIPTION
Adds unit tests proving the W3C `traceparent` correlation contract across CLI→api, MCP→api, and multi-hop edge chains, plus source-scan drift guards for the telemetry-quality invariants (distinct `service.name`, `service.namespace=lorekit`, SERVER/CLIENT/INTERNAL span kinds, `faas.name`, AlwaysOn export, `lorekit.tool.duration`). Fixes a semantic-convention bug where the CLI emitted non-registry `os.type`/`host.arch` values. Includes a written telemetry-quality review (`docs/telemetry-quality-review.md`) grounded in the Dash0 OTel skills.

## Tests added

- **`packages/mcp-core/src/otel-correlation.spec.ts`** — proves the W3C `traceparent` correlation contract on the pure seam (`parseTraceparent`/`formatTraceparent`, mirrored into every edge function and re-implemented by the CLI): CLI→api and MCP→api join one trace with correct parent/child linkage; N REST calls become siblings under the command span; the echoed response header points back at the server span; a 3-service chain preserves one `trace_id`; invalid inbound context starts a fresh root (never a corrupt span); the sampled flag is propagated but never gates export; the zero-dep CLI header is byte-identical to `formatTraceparent`.
- **`packages/mcp-core/src/otel-conventions.spec.ts`** — source-scan drift guards for distinct `service.name` per component (`cli`/`api`/`mcp-node`/`web`), `service.namespace=lorekit`, edge SERVER/CLIENT/INTERNAL span kinds (OTLP wire values), `faas.name` derivation, AlwaysOn export, and the `lorekit.tool.duration` histogram wiring — plus histogram-accessor unit tests.
- **`packages/cli/test/telemetry.test.mjs`** — extended to cover the bug fix below.

## Bug fixed

`packages/cli/src/telemetry.mjs` set `os.type` from `process.platform` (`win32`, `sunos`) and `host.arch` from `process.arch` (`x64`, `ia32`, `arm`) — none of which are members of the OTel `os.type`/`host.arch` registries, so an OTel-native backend can't group them with other SDKs' telemetry. Fixed with pure, tested `normalizeOsType`/`normalizeHostArch` mappings (canonical/unknown values pass through).

## Analysis

Full write-up in `docs/telemetry-quality-review.md` (linked from `docs/README.md` and `docs/otel.md`). The correlation architecture is sound and now regression-guarded. Recommendations left for maintainer sign-off (design/judgment calls, not auto-applied):
1. Edge `db.query.text` / DB span names inline literal filter values → high-cardinality span names + user data in `db.query.text`; semconv wants parameterized.
2. `error.message` is a non-registry attribute (prefer `error.type` / `exception.message`).
3. `traceRequest`'s throw path skips the response `traceparent` echo.
4. Successful spans set status `OK` explicitly where the spec prefers `UNSET`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0122w9z9xHSV3hSj9fWNATYp)_