### PR TITLE
fix(cli): rename OTel instrumentation scope to cli

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,7 +436,7 @@ unique.
 | `service.name` | Component | Set in |
 |---|---|---|
 | `api` | **All** Supabase Edge Functions (`memories`, `orgs`, `openapi`, `mcp`, `health`) | Hard-coded in `supabase/functions/_shared/otel.ts`. No configuration required. |
-| `mcp-node` | Node MCP server (Fly.io) | `OTEL_SERVICE_NAME`, default in `packages/mcp-server/src/instrumentation.ts` |
+| `mcp` | Node MCP server (Fly.io) | `OTEL_SERVICE_NAME`, default in `packages/mcp-server/src/instrumentation.ts` |
 | `web` | Next.js (server + browser) | `packages/web/src/instrumentation.ts`, `packages/web/src/instrumentation-client.ts`, `packages/web/src/components/providers/Dash0Provider.tsx` |
 | `cli` | CLI | `packages/cli/src/telemetry.mjs` |
 
@@ -454,8 +454,10 @@ unique.
 - `service.namespace` is **`lorekit`** everywhere — hard-coded in each component's resource
   (including `packages/mcp-server/src/instrumentation.ts`, which no longer delegates it to
   `OTEL_RESOURCE_ATTRIBUTES`), never env-dependent.
-- The Node MCP server is `mcp-node`, deliberately distinct from the edge `api`: it is a
-  separate deployment (Fly.io) with its own lifecycle, so it stays its own service.
+- The Node MCP server is `mcp`: the `lorekit` namespace already carries the product, and the
+  edge functions report `api` (told apart by `faas.name`), so `mcp` names this Fly.io
+  deployment cleanly with no service-map collision. It stays its own service, distinct from the
+  edge `api`, because it is a separate deployment (Fly.io) with its own lifecycle.
 - The Supabase origin pattern used for browser + server trace-context propagation lives in one
   place: `packages/web/src/lib/otel-origins.ts`.
 

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -237,7 +237,7 @@ All signals carry these resource attributes:
 | Attribute | Value |
 |-----------|-------|
 | `service.namespace` | `lorekit` |
-| `service.name` | `api` (Edge Functions), `web` (Next.js), `mcp-node` (Node MCP server), or `cli` (CLI) |
+| `service.name` | `api` (Edge Functions), `web` (Next.js), `mcp` (Node MCP server), or `cli` (CLI) |
 | `service.version` | Git SHA (`VERCEL_GIT_COMMIT_SHA`) or `unknown`; the package version for the CLI |
 | `deployment.environment.name` | `production` / `preview` / `development` / `local` (not set by the CLI) |
 
@@ -296,7 +296,7 @@ change. The endpoint (`DEFAULT_ENDPOINT`) and dataset (`DEFAULT_DATASET`, now
 (`_shared/otel.ts`) follow the same order.
 
 > **Note:** the CLI `service.name` was `lorekit-cli` before this and is now `cli`
-> (aligning with the namespace-grouped `api` / `web` / `mcp-node` names). This is a
+> (aligning with the namespace-grouped `api` / `web` / `mcp` names). This is a
 > rename, not an alias — CLI telemetry emitted before and after the change lives
 > under two distinct `service.name` values in Dash0. Query `service.namespace = lorekit`
 > to see the CLI across both, or union `service.name in (cli, lorekit-cli)` for history.

--- a/packages/cli/src/telemetry.mjs
+++ b/packages/cli/src/telemetry.mjs
@@ -200,7 +200,7 @@ export function buildTracePayload({ version, name, attributes, startMs, endMs, s
         resource: { attributes: resourceAttributes(version) },
         scopeSpans: [
           {
-            scope: { name: 'lorekit-cli', version: String(version) },
+            scope: { name: 'cli', version: String(version) },
             spans: [
               {
                 traceId: traceId ?? randHex(16),
@@ -230,7 +230,7 @@ export function buildMetricsPayload({ version, attributes, startMs, endMs }) {
         resource: { attributes: resourceAttributes(version) },
         scopeMetrics: [
           {
-            scope: { name: 'lorekit-cli', version: String(version) },
+            scope: { name: 'cli', version: String(version) },
             metrics: [
               {
                 name: 'lorekit.cli.invocations',

--- a/packages/cli/test/telemetry.test.mjs
+++ b/packages/cli/test/telemetry.test.mjs
@@ -195,6 +195,7 @@ test('buildTracePayload produces a valid single-span OTLP structure', () => {
   assert.equal(resAttrs['service.name'], 'cli');
   assert.equal(resAttrs['service.namespace'], 'lorekit');
   assert.equal(resAttrs['service.version'], '9.9.9');
+  assert.equal(p.resourceSpans[0].scopeSpans[0].scope.name, 'cli');
 });
 
 test('buildTracePayload uses provided traceId and spanId when given', () => {
@@ -232,6 +233,7 @@ test('buildMetricsPayload emits a monotonic delta counter of 1', () => {
     startMs: 1,
     endMs: 2,
   });
+  assert.equal(p.resourceMetrics[0].scopeMetrics[0].scope.name, 'cli');
   const metric = p.resourceMetrics[0].scopeMetrics[0].metrics[0];
   assert.equal(metric.name, 'lorekit.cli.invocations');
   assert.equal(metric.sum.isMonotonic, true);

--- a/packages/mcp-server/src/instrumentation.ts
+++ b/packages/mcp-server/src/instrumentation.ts
@@ -6,10 +6,11 @@
  * Exporter: OTLP HTTP/protobuf → Dash0 (or any OTLP endpoint)
  *
  * Required env vars:
- *   OTEL_SERVICE_NAME            defaults to "mcp-node" (deliberately distinct
- *                                from the Deno Edge Function's "mcp" — they are
- *                                two deployments of the same logical service
- *                                and must be separable in the service map)
+ *   OTEL_SERVICE_NAME            defaults to "mcp". The Supabase Edge Functions
+ *                                (including supabase/functions/mcp/) all report
+ *                                service.name = "api", differentiated by
+ *                                faas.name — so this Fly.io Node deployment owns
+ *                                the "mcp" name outright, no collision.
  *   OTEL_TRACES_EXPORTER         set to "otlp" to enable
  *   OTEL_METRICS_EXPORTER        set to "otlp" to enable
  *   OTEL_LOGS_EXPORTER           set to "otlp" to enable
@@ -39,11 +40,11 @@ import { SpanStatusCode, trace } from '@opentelemetry/api';
 
 // Read service version from package.json at startup
 const SERVICE_VERSION = process.env['npm_package_version'] ?? '0.0.1';
-// 'mcp-node' — deliberately NOT 'mcp'. The Deno Edge Function at
-// supabase/functions/mcp/ reports service.name = 'mcp'; this Fly.io Node
-// deployment is a separate runtime of the same logical service and must be a
-// distinct node in the service map.
-const SERVICE_NAME = process.env['OTEL_SERVICE_NAME'] ?? 'mcp-node';
+// 'mcp' — the namespace ('lorekit') already carries the product. The Deno Edge
+// Functions (including supabase/functions/mcp/) all report service.name = 'api'
+// and are told apart by faas.name, so this Fly.io Node deployment owns 'mcp'
+// with no service-map collision.
+const SERVICE_NAME = process.env['OTEL_SERVICE_NAME'] ?? 'mcp';
 
 /**
  * Resolve vcs.* OTel resource attributes from environment variables.


### PR DESCRIPTION
The CLI service.name resource attribute is already 'cli', but the OTLP
instrumentation scope name was still 'lorekit-cli', which surfaces as the
scope/library label in Dash0. Rename both the trace and metrics scope
names to 'cli' — the namespace ('lorekit') already carries the product,
so the scope only needs to name the component.

Lock the value with scope-name assertions in the trace and metrics tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mha5MkkcFCHfRx3FrStZf9