### PR TITLE
fix(security): revoke anon EXECUTE on clearly-safe read/service RPCs + deferred-findings backlog

### DIFF
--- a/docs/tasks/security-review-deferred-findings.md
+++ b/docs/tasks/security-review-deferred-findings.md
@@ -1,0 +1,329 @@
+# Security review — deferred findings
+
+Backlog of security findings from the per-project security review (July 2026) that were
+**deliberately not fixed** in the two shipped PRs, plus the design-level follow-ups the
+[agent-memory-atlas analysis](https://neoneye.github.io/agent-memory-atlas/systems/lorekit/)
+raised. Each item below is written to convert 1:1 into a Linear issue.
+
+## Context — what already shipped
+
+| PR | Merged | Scope |
+|----|--------|-------|
+| #288 | `725f5f3` | DB access-control IDOR family — actor guard on `archive_memory`, `restore_memory`, `purge_archived_memories`, `purge_expired_memories`, **`memory_delete`** (migration `00046`), least-privilege grants, `migrations.test.sql` §60. |
+| #293 | `2dd5f88` | App-layer — PostgREST filter-injection closed at scope validation; `mcp-server` pre-auth body-size DoS cap. |
+
+Everything below is **out of scope of those two PRs** and still open.
+
+## The one big caveat before you action these
+
+Several fixes are a **`REVOKE … FROM public/anon` grant sweep**. That is mechanically simple but
+**not uniformly safe**: some of these SECURITY DEFINER functions are called **inside RLS policies**
+(`lorekit_member_org_ids`, `lorekit_org_role`, `lorekit_org_can`) or on the **rate-limit hot path**
+(`lorekit_check_rate_limit`). Revoking the wrong role there is a **production-availability incident**
+(RLS on `memories`/`orgs` stops evaluating for real users). Every grant change needs an
+`migrations.test.sql` assertion that the affected RLS read path still returns the right rows.
+
+Items are tagged **[safe-sweep]** (isolated, procedural — low risk) or **[rls/hot-path]** (needs
+per-function caller analysis + RLS-path test).
+
+---
+
+## SEC-1 — [HIGH] CLI API-token exfiltration via committed repo config
+
+- **Severity:** High · **Component:** `@lorekit/cli` · **Labels:** security, cli, supply-chain
+- **Files:** `packages/cli/src/config.mjs` (`resolveProjectConnection`, ~L351-380), `stores.mjs`, `src/store/remote.mjs` (`restFetch`), `src/store/index.mjs`, `src/hook.mjs`
+
+**Problem.** The remote endpoint is read verbatim from repo-committed config (`.mcp.json`
+`mcpServers.lorekit.args`, or `.lorekit.json` `mcp.endpoint`) with **no host allow-list** (the only
+check rejects the literal `<project-ref>` placeholder). Worse, when the committed endpoint carries no
+token the code falls back to `token: token || process.env.LOREKIT_TOKEN`.
+
+**Exploit (no user action).** A malicious repo commits a `.mcp.json` pointing `lorekit` at
+`https://evil.com/functions/v1/mcp`. A victim who has `LOREKIT_TOKEN` set (shell profile / CI) opens
+the repo → the **SessionStart hook** (`hook.mjs` → `fetchLessons` → `RemoteStore.list` → `restFetch`)
+fires automatically and sends the victim's real `lk_rw_*` token to `evil.com`. Every read command does
+the same. Even without the env token, a committed URL carrying the *attacker's* token silently reroutes
+the victim's memory reads/writes to attacker-controlled storage (prompt-injection in + capture out).
+
+**Fix.** (1) Constrain the remote host to an allow-list (mirror the web `otel-origins.ts` posture:
+production `*.supabase.co` ref; explicit opt-in for a self-hosted host). (2) **Never pair an env/global
+token with a repo-tier endpoint** — a repo-supplied endpoint may only use a token supplied in the same
+trust tier; drop the `|| process.env.LOREKIT_TOKEN` fallback for repo-sourced endpoints.
+
+**Effort:** M · behaviour-sensitive (must not break legit self-hosted setups) — needs tests.
+
+---
+
+## SEC-2 — [HIGH] GitHub App installation RPCs are anon-writable
+
+- **Severity:** High (dormant until `GITHUB_APP_ENABLED=true`, but deployed) · **Labels:** security, database, github-app · **[safe-sweep]**
+- **Files:** `supabase/migrations/00037_github_installations.sql` — `lorekit_installation_upsert` (grant ~L173), `lorekit_installation_remove_repos` (~L195), `lorekit_installation_remove` (~L219)
+
+**Problem.** All three are SECURITY DEFINER, granted `to service_role` but **PUBLIC EXECUTE never
+revoked**, so `anon`/`authenticated` can call them over PostgREST, bypassing `github_installations` RLS.
+
+**Exploit.** `lorekit_installation_upsert(installation_id, github_account_id, …, p_user_id=<self|victim>,
+status='linked', repos)` **forges/hijacks** an installation→user link; `lorekit_installation_remove(id)`
+**disables** a victim's integration. Barrier is only knowing a non-secret `installation_id`.
+
+**Fix.** `revoke execute … from public` on all three (service-role only; no `authenticated` grant needed).
+
+**Effort:** S · low risk (not RLS-embedded).
+
+---
+
+## SEC-3 — [MEDIUM] Info-disclosure: caller-supplied `p_user_id` read RPCs anon-reachable
+
+> **This is the item flagged by the atlas analysis and a second session** ("`lorekit_memory_scopes`
+> likely has the same latent anon-execute gap"). Same shape as the #288 mutation family, but read-only.
+
+- **Severity:** Medium · **Labels:** security, database · mixed **[safe-sweep]** / **[rls/hot-path]**
+- **Files:**
+  - `lorekit_memory_scopes(uuid)` — `00039_memory_scopes.sql` (grant ~L81) **[safe]**
+  - `lorekit_memory_count(uuid)` — `00036_fix_memory_count.sql` (grant ~L86, explicit `anon`) **[safe]**
+  - `find_user_by_github_id(text)` — `00037_github_installations.sql` (grant ~L241) **[safe]**
+  - `lorekit_member_org_ids(uuid)` — `00014_orgs.sql` (grant ~L78) **[rls/hot-path — used in `memories` RLS read policy]**
+
+**Problem.** Each is SECURITY DEFINER, takes a bare `p_user_id` (or github id), never compares it to
+`auth.uid()`, and retains `anon` EXECUTE. Their comments claim "NOT granted to anon" but no
+`revoke from public` exists.
+
+**Exploit.** Over PostgREST an **anon (or any authenticated) caller** reads *another user's* scope names
+(which embed repo/project names) + active counts (`memory_scopes`), memory count + plan tier
+(`memory_count`), GitHub-id → internal-UUID mapping (`find_user_by_github_id`), or org-membership UUIDs
+(`member_org_ids`).
+
+**Fix.** For the three **[safe]** functions: apply the `00046`/`00041` **actor guard** (honour
+`p_user_id` only under `service_role`, else `auth.uid()`) — this closes both the anon *and* the
+authenticated cross-user read, and the edge always calls them service-role so it's behaviour-preserving.
+For `lorekit_member_org_ids` **[rls/hot-path]**: it is called inside the `memories` RLS read policy with
+`auth.uid()`, so `revoke from public` is fine (keep the explicit `authenticated`/`anon` grants the
+policy needs) but **do not** add an actor guard without proving the RLS read path still returns rows.
+
+**Effort:** M · the safe three are quick; `member_org_ids` needs an RLS-path assertion.
+
+---
+
+## SEC-4 — [MEDIUM] `lorekit_purge_old_usage_events` — anon global analytics wipe
+
+- **Severity:** Medium · **Labels:** security, database · **[safe-sweep]**
+- **File:** `supabase/migrations/00034_usage_events.sql` (grant ~L83, `to service_role`, PUBLIC not revoked)
+
+**Exploit.** `POST /rpc/lorekit_purge_old_usage_events { "p_older_than": "0 seconds" }` runs
+`delete from usage_events where created_at < now()` → **wipes every usage/analytics row for all users**.
+
+**Fix.** `revoke execute … from public` (cron/service-role only).
+
+**Effort:** S.
+
+---
+
+## SEC-5 — [MEDIUM] MCP dispatcher returns raw DB/internal error text to callers
+
+- **Severity:** Medium · **Labels:** security, edge, info-leak
+- **File:** `supabase/functions/mcp/mcp-handler.ts` (~L465-467, the `-32603` path); tool handlers `throw new Error(error.message)` (`tools.ts:172,199,271,345,…`)
+
+**Problem.** Verbatim PostgREST error text (parse errors, column/constraint/RPC signatures) is returned
+to any authenticated client. The REST surface already funnels unknowns to a generic `internalError`;
+the MCP surface does not — an asymmetry that also turns a filter-injection attempt into a usable oracle.
+
+**Fix.** On the `-32603` path, log detail to the span (already done) but return a generic message; keep
+specific messages only for the discriminated client-error classes (`UserInputError`/`OrgPermissionError`/`LimitError`).
+
+**Effort:** S.
+
+---
+
+## SEC-6 — [MEDIUM] CLI repo-committed `store` path escapes the repo
+
+- **Severity:** Medium · **Component:** `@lorekit/cli` · **Labels:** security, cli
+- **File:** `packages/cli/src/control.mjs` (`projectDirFrom`, ~L177-180); consumed by `localStoreDirs`/`resolveControl`
+
+**Problem.** `projectDirFrom` does `path.isAbsolute(raw) ? raw : path.join(root, raw)` where `raw` can
+come from a repo-committed `.lorekit.json` `"store"`. A malicious repo sets `"store": "/home/victim/.ssh"`
+or `"../../.."`, redirecting the local store base outside the repo → writes/reads markdown in any
+writable dir (filenames are slug-sanitized, so no arbitrary-named overwrite, but directory litter +
+scanning of an attacker-chosen tree).
+
+**Fix.** Reject absolute paths and `..` segments in a **repo-tier** `store` value (allow them only from
+env / user-global config), or resolve and assert containment within `root`.
+
+**Effort:** S-M.
+
+---
+
+## SEC-7 — [MEDIUM] CLI prompt-injection via repo-committed `hooks.instructions`
+
+- **Severity:** Medium (trust-model) · **Component:** `@lorekit/cli` · **Labels:** security, cli, prompt-injection
+- **Files:** `packages/cli/src/control.mjs` (`hooksInstructions`, ~L145-159), `src/hook.mjs` (SessionStart/Stop injection)
+
+**Problem.** A repo's committed `.lorekit.json` can set `hooks.instructions.SessionStart` (etc.) to
+arbitrary text emitted into the coding agent's context on session start with **no consent gate** — same
+trust class as a malicious `CLAUDE.md`, but LoreKit widens it to two more committed files a user may not
+realize are executable-in-effect. Compounds with SEC-1 (attacker-controlled *lesson* content injected).
+
+**Fix.** Document the trust boundary explicitly, and/or add a one-time trust prompt before honouring
+repo-supplied hook instructions (and repo-supplied endpoints, cf. SEC-1).
+
+**Effort:** M (UX decision).
+
+---
+
+## SEC-8 — [MEDIUM/LOW] Rate-limit RPCs anon-callable (targeted DoS)
+
+- **Severity:** Medium/Low · **Labels:** security, database · **[rls/hot-path — verify caller role first]**
+- **File:** `supabase/migrations/00004_limits.sql` — `lorekit_check_rate_limit` (~L138, no explicit grant → PUBLIC), `lorekit_purge_rate_limit_counters` (~L182)
+
+**Exploit.** Anon calls `lorekit_check_rate_limit(p_user_id=<victim>)` repeatedly to drive the victim's
+fixed-window counter to the limit → the victim's legit requests get HTTP 429. `lorekit_purge_rate_limit_counters('0')`
+deletes all counters (momentarily disables rate limiting globally).
+
+**Fix.** `revoke execute … from public` (transport-layer/service-role only). **Verify first** which DB
+role the transport actually calls `lorekit_check_rate_limit` with — the edge calls it right after auth;
+if any JWT/`authenticated` path invokes it as `authenticated`, keep that grant.
+
+**Effort:** M (caller analysis required).
+
+---
+
+## SEC-9 — [LOW] `lorekit_record_usage_event` anon analytics injection
+
+- **Severity:** Low (append-only, no read of others) · **Labels:** security, database · **[verify caller role]**
+- **File:** `supabase/migrations/00034_usage_events.sql` (grant ~L138, explicit `anon`)
+
+**Exploit.** Anon inserts arbitrary `usage_events` for any `user_id`/`org_id` with arbitrary
+`tool_name`/`outcome`/counts (bypasses RLS via DEFINER) → pollutes analytics / inflates a target's usage.
+
+**Fix.** Revoke from `public`/`anon`; keep `authenticated` + `service_role` only if a JWT edge path
+records usage as `authenticated` (verify).
+
+**Effort:** S-M.
+
+---
+
+## SEC-10 — [LOW] Cursor `id` not UUID-validated (bounded filter injection)
+
+- **Severity:** Low · **Labels:** security, edge
+- **File:** `supabase/functions/_shared/api/paginate.ts` (`decodeCursor`, ~L5-15); consumers `memories/handlers/list.ts:61`, `search.ts:47`
+
+**Problem.** `decodeCursor` regex-validates `updated_at` *because* it's interpolated into the keyset
+`.or(...)`, but leaves `id` as an arbitrary string. Cursors are opaque base64 but **unsigned**, so a
+forged `id` injects into the filter. Bounded (the tenant predicate is a separate AND; REST returns a
+generic error), but it defeats the exact hardening the `updated_at` regex added.
+
+**Fix.** Validate `id` as a UUID in `decodeCursor` (return `null` otherwise), matching the `updated_at` guard.
+
+**Effort:** S.
+
+---
+
+## SEC-11 — [LOW] Webhook comments become cap-exempt, un-rate-limited, author-less durable memory
+
+- **Severity:** Low · **Labels:** security, edge, memory-poisoning · (overlaps the atlas "provenance" point)
+- **File:** `supabase/functions/mcp/webhook.ts` (~L491-506, `toolWrite(db, {...}, null, span)`)
+
+**Problem.** Once a delivery HMAC-verifies, any commenter on a watched repo (incl. external PR
+contributors) has their comment body written as a `repo::owner/name` memory with `userId = null` →
+lands in the **service partition** (cap-exempt via `enforce_memory_cap`), **skips**
+`lorekit_check_rate_limit`, keys on `Date.now()` (no upsert dedup → unbounded growth), and carries **no
+author identity** → an attacker who can comment can inject "lesson" text later sessions ingest.
+
+**Fix.** Attribute webhook writes to the repo-owner's user id (so cap + rate limit apply), capture the
+comment author into `metadata`/`tags` for provenance, and add a per-repo write ceiling.
+
+**Effort:** M.
+
+---
+
+## SEC-12 — [LOW] Defense-in-depth `user_id` filter on archive/restore/read/list
+
+- **Severity:** Low · **Labels:** security, mcp-core, defense-in-depth
+- **Files:** `packages/mcp-core/src/tools/archive.ts` (~L52-57, 109-114), `read.ts` (~L28-38), `list.ts` (~L34-41)
+
+**Problem.** `delete.ts` deliberately adds `user_id` to `.match()` ("without it a service-role client
+would match any user's row with the same (scope,key)"); `archiveMemory`/`restoreMemory` (called with no
+`userId` in the Node server) and the read tools have no equivalent guard. For JWT callers RLS covers it,
+but the asymmetry means one RLS-policy regression silently becomes cross-tenant on these paths where
+`delete` would still be protected.
+
+**Fix.** Mirror `delete.ts`'s `if (userId) match.user_id = userId` across these tools.
+
+**Effort:** S.
+
+---
+
+## SEC-13 — [LOW] Assorted anon-reachable DEFINER probes / global purge
+
+- **Severity:** Low · **Labels:** security, database · mixed **[safe]** / **[rls/hot-path]**
+- **Files & functions:**
+  - `lorekit_purge_all_expired_memories()` — `00033` (~L88) — anon triggers a global expired-purge (only read-invisible rows; ≈ running the nightly cron early). **[safe]**
+  - `lorekit_org_role(uuid,uuid)` / `lorekit_org_can(uuid,uuid,text)` — `00017` (~L48/L81, explicit `anon`) — boolean/text oracle of any user's role/capability in any org. **[rls/hot-path — used in org RLS + capability checks]**
+  - `lorekit_get_limit` / `lorekit_get_org_limit` (`00032`/`00018` ~L60) / `lorekit_default_limit` — leak a user's/org's numeric limit (≈ plan tier). **[safe]**
+
+**Fix.** `revoke execute … from public`, granting only the roles that need them; **do not** touch
+`lorekit_org_role`/`_can` grants without an RLS-path assertion (they gate `memories`/`orgs` policies).
+
+**Effort:** M (mostly for the RLS-embedded pair).
+
+---
+
+## SEC-14 — [LOW] Web `/api-docs/proxy` — unauthenticated same-origin relay, no throttle
+
+- **Severity:** Low (abuse-amplification only; SSRF-locked, upstream enforces auth+rate-limit) · **Labels:** security, web
+- **File:** `packages/web/src/app/api-docs/proxy/route.ts` (~L51-96)
+
+**Problem.** Public route (no `getUser()`) forwards a caller-supplied `Authorization` header to the
+LoreKit REST API. Lets an attacker brute-force/probe `lk_*` tokens **through the `lorekit.io` origin**
+(source-IP laundering) with no proxy-side rate limit. Not a data-exposure vector (origin/path locked;
+cookies never forwarded).
+
+**Fix.** Require an authenticated session on the proxy route, or add a lightweight per-IP rate limit.
+
+**Effort:** S.
+
+---
+
+## SEC-15 — [INFO] Hardening batch (low priority, group into one ticket)
+
+- **CORS fail-open** — `supabase/functions/_shared/api/cors.ts` (~L1-3,19): defaults to `Allow-Origin: *`
+  unless `ALLOWED_ORIGINS` set or `VERCEL_ENV=production`. Mitigated (Bearer auth, no `Allow-Credentials`).
+  Confirm the deploy sets one of those in production.
+- **Non-constant-time secret compare** — `token === SERVICE_KEY` in `_shared/api/auth.ts` (~L41),
+  `mcp/auth.ts` (~L51). Theoretical timing side-channel on a long static secret; use `timingSafeEqual`.
+- **Telemetry PII** — `createTracedClient` records interpolated filter values (scope, key, `user_id`,
+  raw search `q`) in `db.query.text` (`_shared/otel.ts` ~L483-524). Goes to the operator's Dash0, not
+  users, and excludes memory *values*, but is more PII than the "no-PII attrs" posture implies.
+- **CLI `__proto__` frontmatter** — `packages/cli/src/store/format.mjs` (`parseEntry`, ~L31-42):
+  `meta[key] = …` assigns through `__proto__`. Not exploitable today (no deep-merge of the parsed object),
+  but skip `__proto__`/`constructor`/`prototype` keys to remove the footgun.
+- **Web broad CORS preflight `*`** — `packages/web/src/middleware.ts` (~L21-39). Not exploitable (no
+  credentials, `SameSite=Lax` httpOnly cookies). Hardening note.
+- **Attacker-controllable `state` in `audit_log`** — `packages/web/src/lib/github-installations.ts`
+  (~L195). Stored untrusted data, React-escaped, own-`user_id` scoped — non-exploitable; noted.
+
+---
+
+## Non-security design follow-ups from the atlas analysis (separate track)
+
+Not vulnerabilities — product/quality items the analysis raised. Listed so they don't get lost.
+
+- **Audit log preserves no prior value.** `memory.update` audit metadata is `{scope,key}` only; the
+  in-place upsert keeps no version history, so the log proves *that* a memory changed, never *what it
+  was*. If the value matters, put the old value in the log or keep a version chain.
+- **`seen_count >= 3` recurrence gate is prose-only.** The entrenchment guard governing promotion lives
+  in skill markdown with no column and no enforcement. Either give the guard a mechanism (a recurrence
+  counter) or describe it explicitly as advice.
+- **Archive frees the address.** The partial unique index (`00003`, `where archived_at is null`) lets the
+  same `(user_id,scope,key)` be re-created after archive — so an archived "this was wrong" lesson can be
+  silently re-asserted with no record of the prior rejection. If archive is used as rejection, record it.
+- (Webhook author provenance is tracked above as **SEC-11**.)
+
+---
+
+## Suggested triage order
+
+1. **SEC-1** (High, real token exfil, no user action) and **SEC-2** (High, anon installation hijack).
+2. The **[safe-sweep]** grant revokes: **SEC-2, SEC-4, SEC-3** (the three safe read fns), **SEC-13** (safe subset) — batchable into one small, well-tested migration.
+3. **SEC-5, SEC-6, SEC-10** (small, isolated code fixes).
+4. **SEC-3** (`member_org_ids`), **SEC-8, SEC-9, SEC-13** (`org_role`/`_can`) — the **[rls/hot-path]** grant changes, each with an RLS-path assertion in `migrations.test.sql`. **Do these carefully.**
+5. **SEC-7, SEC-11, SEC-12, SEC-14** and the **SEC-15** hardening batch.

--- a/docs/tasks/security-review-deferred-findings.md
+++ b/docs/tasks/security-review-deferred-findings.md
@@ -11,8 +11,18 @@ raised. Each item below is written to convert 1:1 into a Linear issue.
 |----|--------|-------|
 | #288 | `725f5f3` | DB access-control IDOR family — actor guard on `archive_memory`, `restore_memory`, `purge_archived_memories`, `purge_expired_memories`, **`memory_delete`** (migration `00046`), least-privilege grants, `migrations.test.sql` §60. |
 | #293 | `2dd5f88` | App-layer — PostgREST filter-injection closed at scope validation; `mcp-server` pre-auth body-size DoS cap. |
+| _readfn hardening_ | migration `00047` | **The clearly-safe half of this backlog.** Actor guard + anon-revoke on `lorekit_memory_scopes`/`lorekit_memory_count`; `revoke ... from public` on `lorekit_find_user_by_github_id`, the 3 installation RPCs, `lorekit_purge_old_usage_events`, `lorekit_purge_all_expired_memories`. `migrations.test.sql` §61. |
 
-Everything below is **out of scope of those two PRs** and still open.
+Everything below is **out of scope of those PRs** and still open.
+
+### ✅ Resolved in the `00047` read-function grant-hardening pass
+
+Struck from the backlog — do **not** open Linear issues for these:
+
+- **SEC-2** — GitHub App installation RPCs anon-writable → revoked to service-role only.
+- **SEC-3 (safe subset)** — `lorekit_memory_scopes`, `lorekit_memory_count` (actor guard + anon-revoke), `lorekit_find_user_by_github_id` (service-role only). *`lorekit_member_org_ids` remains — see SEC-3 below.*
+- **SEC-4** — `lorekit_purge_old_usage_events` anon global wipe → service-role only.
+- **SEC-13 (safe subset)** — `lorekit_purge_all_expired_memories` → service-role only. *`lorekit_org_role`/`_can` and `lorekit_get_limit`/`_org_limit`/`default_limit` remain — see SEC-13 below.*
 
 ## The one big caveat before you action these
 
@@ -54,67 +64,26 @@ trust tier; drop the `|| process.env.LOREKIT_TOKEN` fallback for repo-sourced en
 
 ---
 
-## SEC-2 — [HIGH] GitHub App installation RPCs are anon-writable
+## SEC-3 — [MEDIUM→LOW] `lorekit_member_org_ids` anon-reachable (remaining half)
 
-- **Severity:** High (dormant until `GITHUB_APP_ENABLED=true`, but deployed) · **Labels:** security, database, github-app · **[safe-sweep]**
-- **Files:** `supabase/migrations/00037_github_installations.sql` — `lorekit_installation_upsert` (grant ~L173), `lorekit_installation_remove_repos` (~L195), `lorekit_installation_remove` (~L219)
+> The `memory_scopes` / `memory_count` / `find_user_by_github_id` parts of this finding — flagged by
+> the atlas analysis and a second session — were **fixed in `00047`**. Only the RLS-embedded
+> `lorekit_member_org_ids` remains.
 
-**Problem.** All three are SECURITY DEFINER, granted `to service_role` but **PUBLIC EXECUTE never
-revoked**, so `anon`/`authenticated` can call them over PostgREST, bypassing `github_installations` RLS.
+- **Severity:** Low (org-membership UUIDs only) · **Labels:** security, database · **[rls/hot-path]**
+- **File:** `lorekit_member_org_ids(uuid)` — `00014_orgs.sql` (grant ~L78)
 
-**Exploit.** `lorekit_installation_upsert(installation_id, github_account_id, …, p_user_id=<self|victim>,
-status='linked', repos)` **forges/hijacks** an installation→user link; `lorekit_installation_remove(id)`
-**disables** a victim's integration. Barrier is only knowing a non-secret `installation_id`.
+**Problem.** SECURITY DEFINER, bare `p_user_id`, retains `anon`/`authenticated` EXECUTE → anon
+enumerates any user's org-membership UUIDs.
 
-**Fix.** `revoke execute … from public` on all three (service-role only; no `authenticated` grant needed).
+**Fix.** `revoke execute … from public` (and `anon` if not needed) — **but** this function is called
+**inside the `memories`/`orgs` RLS read policies** with `auth.uid()`, so the querying role must keep
+EXECUTE for RLS to evaluate. **Do NOT add an actor guard** and do **not** revoke `authenticated`/`anon`
+without an `migrations.test.sql` assertion proving the `memories` RLS read path still returns rows for a
+normal user. Because RLS always passes `auth.uid()` (never request input), the practical leak is small;
+weigh the change against the RLS-regression risk.
 
-**Effort:** S · low risk (not RLS-embedded).
-
----
-
-## SEC-3 — [MEDIUM] Info-disclosure: caller-supplied `p_user_id` read RPCs anon-reachable
-
-> **This is the item flagged by the atlas analysis and a second session** ("`lorekit_memory_scopes`
-> likely has the same latent anon-execute gap"). Same shape as the #288 mutation family, but read-only.
-
-- **Severity:** Medium · **Labels:** security, database · mixed **[safe-sweep]** / **[rls/hot-path]**
-- **Files:**
-  - `lorekit_memory_scopes(uuid)` — `00039_memory_scopes.sql` (grant ~L81) **[safe]**
-  - `lorekit_memory_count(uuid)` — `00036_fix_memory_count.sql` (grant ~L86, explicit `anon`) **[safe]**
-  - `find_user_by_github_id(text)` — `00037_github_installations.sql` (grant ~L241) **[safe]**
-  - `lorekit_member_org_ids(uuid)` — `00014_orgs.sql` (grant ~L78) **[rls/hot-path — used in `memories` RLS read policy]**
-
-**Problem.** Each is SECURITY DEFINER, takes a bare `p_user_id` (or github id), never compares it to
-`auth.uid()`, and retains `anon` EXECUTE. Their comments claim "NOT granted to anon" but no
-`revoke from public` exists.
-
-**Exploit.** Over PostgREST an **anon (or any authenticated) caller** reads *another user's* scope names
-(which embed repo/project names) + active counts (`memory_scopes`), memory count + plan tier
-(`memory_count`), GitHub-id → internal-UUID mapping (`find_user_by_github_id`), or org-membership UUIDs
-(`member_org_ids`).
-
-**Fix.** For the three **[safe]** functions: apply the `00046`/`00041` **actor guard** (honour
-`p_user_id` only under `service_role`, else `auth.uid()`) — this closes both the anon *and* the
-authenticated cross-user read, and the edge always calls them service-role so it's behaviour-preserving.
-For `lorekit_member_org_ids` **[rls/hot-path]**: it is called inside the `memories` RLS read policy with
-`auth.uid()`, so `revoke from public` is fine (keep the explicit `authenticated`/`anon` grants the
-policy needs) but **do not** add an actor guard without proving the RLS read path still returns rows.
-
-**Effort:** M · the safe three are quick; `member_org_ids` needs an RLS-path assertion.
-
----
-
-## SEC-4 — [MEDIUM] `lorekit_purge_old_usage_events` — anon global analytics wipe
-
-- **Severity:** Medium · **Labels:** security, database · **[safe-sweep]**
-- **File:** `supabase/migrations/00034_usage_events.sql` (grant ~L83, `to service_role`, PUBLIC not revoked)
-
-**Exploit.** `POST /rpc/lorekit_purge_old_usage_events { "p_older_than": "0 seconds" }` runs
-`delete from usage_events where created_at < now()` → **wipes every usage/analytics row for all users**.
-
-**Fix.** `revoke execute … from public` (cron/service-role only).
-
-**Effort:** S.
+**Effort:** M · needs an RLS-path assertion; low value.
 
 ---
 
@@ -252,18 +221,21 @@ but the asymmetry means one RLS-policy regression silently becomes cross-tenant 
 
 ---
 
-## SEC-13 — [LOW] Assorted anon-reachable DEFINER probes / global purge
+## SEC-13 — [LOW] Assorted anon-reachable DEFINER probes (remaining)
 
-- **Severity:** Low · **Labels:** security, database · mixed **[safe]** / **[rls/hot-path]**
+> `lorekit_purge_all_expired_memories` was **fixed in `00047`**. The functions below all touch the RLS
+> policies or the memory-insert/rate-limit hot path, so they were deliberately left here.
+
+- **Severity:** Low · **Labels:** security, database · **[rls/hot-path]**
 - **Files & functions:**
-  - `lorekit_purge_all_expired_memories()` — `00033` (~L88) — anon triggers a global expired-purge (only read-invisible rows; ≈ running the nightly cron early). **[safe]**
-  - `lorekit_org_role(uuid,uuid)` / `lorekit_org_can(uuid,uuid,text)` — `00017` (~L48/L81, explicit `anon`) — boolean/text oracle of any user's role/capability in any org. **[rls/hot-path — used in org RLS + capability checks]**
-  - `lorekit_get_limit` / `lorekit_get_org_limit` (`00032`/`00018` ~L60) / `lorekit_default_limit` — leak a user's/org's numeric limit (≈ plan tier). **[safe]**
+  - `lorekit_org_role(uuid,uuid)` / `lorekit_org_can(uuid,uuid,text)` — `00017` (~L48/L81, explicit `anon`) — boolean/text oracle of any user's role/capability in any org. **Used in the `orgs`/`org_members`/`org_invites` RLS policies and every org capability check.**
+  - `lorekit_get_limit(uuid,text)` / `lorekit_get_org_limit(uuid,text)` (`00004`/`00018` ~L60) / `lorekit_default_limit` — leak a user's/org's numeric limit (≈ plan tier). **Called by the `enforce_memory_cap` trigger on every memory insert** (it is `SECURITY DEFINER`, so the internal call survives a revoke, but confirm no invoker path).
 
-**Fix.** `revoke execute … from public`, granting only the roles that need them; **do not** touch
-`lorekit_org_role`/`_can` grants without an RLS-path assertion (they gate `memories`/`orgs` policies).
+**Fix.** `revoke execute … from public`, granting only the roles that need them — but **do not** touch
+`lorekit_org_role`/`_can` grants without an `migrations.test.sql` assertion that the org RLS read path
+still evaluates, and confirm nothing calls `get_limit` as an invoker before revoking `authenticated`.
 
-**Effort:** M (mostly for the RLS-embedded pair).
+**Effort:** M · low value, real regression risk — do carefully.
 
 ---
 
@@ -322,8 +294,12 @@ Not vulnerabilities — product/quality items the analysis raised. Listed so the
 
 ## Suggested triage order
 
-1. **SEC-1** (High, real token exfil, no user action) and **SEC-2** (High, anon installation hijack).
-2. The **[safe-sweep]** grant revokes: **SEC-2, SEC-4, SEC-3** (the three safe read fns), **SEC-13** (safe subset) — batchable into one small, well-tested migration.
-3. **SEC-5, SEC-6, SEC-10** (small, isolated code fixes).
-4. **SEC-3** (`member_org_ids`), **SEC-8, SEC-9, SEC-13** (`org_role`/`_can`) — the **[rls/hot-path]** grant changes, each with an RLS-path assertion in `migrations.test.sql`. **Do these carefully.**
-5. **SEC-7, SEC-11, SEC-12, SEC-14** and the **SEC-15** hardening batch.
+The clearly-safe grant sweep (former SEC-2/SEC-4 + the safe subsets of SEC-3/SEC-13) already shipped in
+`00047`. Remaining:
+
+1. **SEC-1** (High) — CLI token exfiltration. The only High left; behaviour-sensitive, needs tests.
+2. **SEC-5, SEC-6, SEC-10** — small, isolated code fixes (MCP error-leak, CLI store path escape, cursor-id).
+3. The **[rls/hot-path]** grant changes — **SEC-3** (`member_org_ids`), **SEC-8** (`check_rate_limit`),
+   **SEC-9** (`record_usage_event`), **SEC-13** (`org_role`/`_can`, `get_limit`/`_org_limit`) — each with an
+   RLS-path / hot-path assertion in `migrations.test.sql`. **Do these carefully; low value, real risk.**
+4. **SEC-7, SEC-11, SEC-12, SEC-14** and the **SEC-15** hardening batch.

--- a/supabase/migrations/00047_readfn_grant_hardening.sql
+++ b/supabase/migrations/00047_readfn_grant_hardening.sql
@@ -1,0 +1,159 @@
+-- ═════════════════════════════════════════════════════════════════════════
+-- Read-function grant hardening — the "clearly-safe" half of the deferred
+-- security-review sweep (docs/tasks/security-review-deferred-findings.md).
+--
+-- Same root cause as 00046: PostgreSQL grants EXECUTE to PUBLIC by default, and
+-- only 00041/00046 ever revoked it — so a set of SECURITY DEFINER functions
+-- that take a bare `p_user_id` (or are service-role-only) stayed anon-reachable
+-- over PostgREST, leaking other users' data or letting anon call service-only
+-- procedures. This migration closes the CLEARLY-SAFE subset:
+--
+--   * lorekit_memory_scopes / lorekit_memory_count — edge-called reads that
+--     trust p_user_id → get the 00046/00041 actor guard (honour p_user_id only
+--     under a verified service-role connection, else auth.uid()) AND lose the
+--     PUBLIC/anon grant, closing both the anon and the authenticated cross-user
+--     read.
+--   * lorekit_find_user_by_github_id + the three installation RPCs +
+--     lorekit_purge_old_usage_events + lorekit_purge_all_expired_memories —
+--     service-role / webhook / cron only → simply lose PUBLIC EXECUTE.
+--
+-- DELIBERATELY OUT OF SCOPE (left for a separate, carefully-tested pass):
+-- functions embedded in RLS policies or the insert/rate-limit hot path
+-- (lorekit_member_org_ids, lorekit_org_role/_can, lorekit_check_rate_limit,
+-- lorekit_purge_rate_limit_counters, lorekit_get_limit/_org_limit/default_limit,
+-- lorekit_record_usage_event) — a wrong grant/actor change there is a
+-- production-availability incident. See the findings doc, "[rls/hot-path]".
+-- ═════════════════════════════════════════════════════════════════════════
+
+-- ── 1. lorekit_memory_scopes — actor guard (preserves the CI escape hatch) ──
+create or replace function lorekit_memory_scopes(p_user_id uuid)
+returns table (scope text, count bigint)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  -- Honour a caller-supplied p_user_id only on a verified service-role
+  -- connection (the edge resolves the token owner and passes it); an
+  -- authenticated caller is pinned to its own auth.uid(), closing the
+  -- cross-user scope-name enumeration. A NULL actor under service-role is the
+  -- CI escape hatch, preserved by the first visibility branch below.
+  v_actor uuid := case
+    when auth.role() = 'service_role' then coalesce(p_user_id, auth.uid())
+    else auth.uid()
+  end;
+begin
+  return query
+    select m.scope, count(*) as count
+      from memories m
+     where (
+             (v_actor is null and auth.role() = 'service_role')
+             or m.user_id = v_actor
+             or m.org_id in (select lorekit_member_org_ids(v_actor))
+           )
+       and m.archived_at is null
+       and (m.expires_at is null or m.expires_at > now())
+     group by m.scope
+     order by m.scope asc;
+end;
+$$;
+
+revoke execute on function lorekit_memory_scopes(uuid) from public, anon;
+grant  execute on function lorekit_memory_scopes(uuid) to authenticated, service_role;
+
+comment on function lorekit_memory_scopes(uuid) is
+  'Per-scope active counts visible to the EFFECTIVE caller. Actor resolved by
+   the 00046/00041 service-role-gated rule: a caller-supplied p_user_id is
+   honoured only on a verified service-role connection, otherwise auth.uid()
+   wins — so an authenticated caller can never enumerate another user''s scope
+   names. p_user_id IS NULL under service-role is the CI escape hatch.';
+
+-- ── 2. lorekit_memory_count — actor guard ───────────────────────────────────
+create or replace function lorekit_memory_count(p_user_id uuid)
+returns jsonb
+language plpgsql
+security definer
+stable
+set search_path = public
+as $$
+declare
+  v_personal_count integer;
+  v_org_count      integer;
+  v_limit          integer;
+  v_plan_name      text;
+  v_org_ids        uuid[];
+  v_actor          uuid := case
+    when auth.role() = 'service_role' then coalesce(p_user_id, auth.uid())
+    else auth.uid()
+  end;
+begin
+  -- Resolve org memberships once (for the resolved actor).
+  select array_agg(org_id)
+    into v_org_ids
+    from org_members om
+    join orgs o on o.id = om.org_id
+   where om.user_id = v_actor
+     and o.deleted_at is null;
+
+  -- Personal active memories.
+  select count(*)
+    into v_personal_count
+    from memories
+   where user_id = v_actor
+     and archived_at is null;
+
+  -- Org-owned active memories across all orgs the actor belongs to.
+  if v_org_ids is not null and cardinality(v_org_ids) > 0 then
+    select count(*)
+      into v_org_count
+      from memories
+     where org_id = any(v_org_ids)
+       and archived_at is null;
+  else
+    v_org_count := 0;
+  end if;
+
+  -- Resolve effective personal limit and plan name.
+  v_limit := lorekit_get_limit(v_actor, 'max_memories');
+
+  select coalesce(up.plan_name, 'free')
+    into v_plan_name
+    from user_plans up
+   where up.user_id = v_actor;
+
+  if v_plan_name is null then
+    v_plan_name := 'free';
+  end if;
+
+  return jsonb_build_object(
+    'count',          coalesce(v_personal_count, 0) + coalesce(v_org_count, 0),
+    'personal_count', coalesce(v_personal_count, 0),
+    'org_count',      v_org_count,
+    'limit',          v_limit,
+    'plan',           v_plan_name
+  );
+end;
+$$;
+
+revoke execute on function lorekit_memory_count(uuid) from public, anon;
+grant  execute on function lorekit_memory_count(uuid) to authenticated, service_role;
+
+comment on function lorekit_memory_count(uuid) is
+  'Personal + org memory counts, limit and plan for the EFFECTIVE caller. Same
+   service-role-gated actor rule as lorekit_memory_scopes (00047) — an
+   authenticated caller cannot read another user''s counts or plan tier.';
+
+-- ── 3. Service-role / webhook / cron-only functions — drop PUBLIC EXECUTE ────
+-- These take no p_user_id (or are procedures the app never calls as a normal
+-- user), so no actor guard applies; they should simply not be anon-reachable.
+-- They were granted `to service_role` only, but the default PUBLIC grant was
+-- never revoked. `find_user_by_github_id` also loses authenticated (it maps a
+-- GitHub id to an internal user UUID — a deanonymisation oracle).
+revoke execute on function lorekit_find_user_by_github_id(text)                                   from public, anon, authenticated;
+revoke execute on function lorekit_installation_upsert(bigint, bigint, text, text, uuid, text, text[]) from public, anon, authenticated;
+revoke execute on function lorekit_installation_remove_repos(bigint, text[])                       from public, anon, authenticated;
+revoke execute on function lorekit_installation_remove(bigint)                                     from public, anon, authenticated;
+revoke execute on function lorekit_purge_old_usage_events(interval)                                from public, anon, authenticated;
+revoke execute on function lorekit_purge_all_expired_memories()                                    from public, anon, authenticated;

--- a/supabase/tests/migrations.test.sql
+++ b/supabase/tests/migrations.test.sql
@@ -2031,6 +2031,15 @@ declare
   v_scopes       text[];
   v_sorted       text[];
 begin
+  -- 00047 gave lorekit_memory_scopes the service-role-gated actor guard: a
+  -- caller-supplied p_user_id is honoured only on a verified service-role
+  -- connection, otherwise auth.uid() wins. Adopt that context — it is exactly
+  -- how the edge GET /memories/scopes path invokes it (a service-role client
+  -- naming the token owner). Without it the actor resolves to a NULL auth.uid()
+  -- and every assertion below reads an empty result set.
+  set local role service_role;
+  perform set_config('request.jwt.claims', '{"role":"service_role"}', true);
+
   -- AC-1 + AC-3 + AC-4: A's own scope is present, counting ONLY the two active
   -- rows — the archived and the expired sibling in the same scope are excluded.
   select count into v_count
@@ -2080,6 +2089,9 @@ begin
   select array_agg(s order by s) into v_sorted from unnest(v_scopes) as s;
   assert v_scopes = v_sorted,
     format('memory scopes AC-8: results must be sorted by scope asc, got %s', v_scopes);
+
+  reset role;
+  perform set_config('request.jwt.claims', '', true);
 end;
 $$;
 

--- a/supabase/tests/migrations.test.sql
+++ b/supabase/tests/migrations.test.sql
@@ -3217,7 +3217,19 @@ declare
   v_svc_null    int;
   v_b2_scopes   int;
   v_b2_count    jsonb;
+  v_b2_personal int;
+  v_a1_personal int;
 begin
+  -- Ground truth for the count assertion below, computed the way
+  -- lorekit_memory_count computes personal_count (active = not archived; the
+  -- personal branch deliberately does not filter on expires_at). b2 is NOT a
+  -- blank user in this fixture — earlier sections give it its own rows — so
+  -- the property is "b2 sees b2's own total", never a hardcoded zero.
+  select count(*) into v_b2_personal from memories
+   where user_id = '00000000-0000-0000-0000-0000000000b2' and archived_at is null;
+  select count(*) into v_a1_personal from memories
+   where user_id = '00000000-0000-0000-0000-0000000000a1' and archived_at is null;
+
   set local role service_role;
   perform set_config('request.jwt.claims', '{"role":"service_role"}', true);
   select count(*) into v_svc_scopes
@@ -3247,8 +3259,15 @@ begin
     format('readfn guard: service-role NULL p_user_id (CI escape hatch) must see a1''s scope, got %s', v_svc_null);
   assert v_b2_scopes = 0,
     format('readfn guard: authenticated b2 naming a1 must NOT enumerate a1''s scopes (IDOR closed), got %s', v_b2_scopes);
-  assert coalesce((v_b2_count->>'personal_count')::int, -1) = 0,
-    format('readfn guard: authenticated b2 memory_count(a1) must report b2''s own 0 personal, got %s', v_b2_count->>'personal_count');
+  -- Anti-vacuity: the two users' active personal totals must differ, otherwise
+  -- "b2 got b2's number" and "b2 got a1's number" would be indistinguishable
+  -- and the assertion below could not prove the actor was pinned.
+  assert v_a1_personal <> v_b2_personal,
+    format('readfn guard fixture: a1 and b2 must hold a different number of active personal rows for the count assertion to be meaningful (a1=%s, b2=%s)',
+           v_a1_personal, v_b2_personal);
+  assert coalesce((v_b2_count->>'personal_count')::int, -1) = v_b2_personal,
+    format('readfn guard: authenticated b2 memory_count(a1) must report b2''s OWN personal total (%s), not a1''s (%s), got %s',
+           v_b2_personal, v_a1_personal, v_b2_count->>'personal_count');
 end;
 $$;
 

--- a/supabase/tests/migrations.test.sql
+++ b/supabase/tests/migrations.test.sql
@@ -3142,6 +3142,95 @@ begin
 end;
 $$;
 
+-- ═══════════════════════════════════════════════════════════════════════════
+-- 61. Read-function grant hardening — 00047_readfn_grant_hardening.sql
+-- ═══════════════════════════════════════════════════════════════════════════
+-- The clearly-safe half of the deferred grant sweep: the caller-supplied-
+-- p_user_id read RPCs (lorekit_memory_scopes/_count) get the actor guard and
+-- lose anon EXECUTE; the service-role-only functions (find_user_by_github_id,
+-- the installation RPCs, the two purge procedures) lose PUBLIC EXECUTE.
+
+-- ── 61a. Grant surface ──────────────────────────────────────────────────────
+do $$
+declare
+  v_sig  text;
+  -- Reads: authenticated + service_role, never anon.
+  v_read text[] := array[
+    'lorekit_memory_scopes(uuid)',
+    'lorekit_memory_count(uuid)'
+  ];
+  -- Service-role-only: never anon, never authenticated.
+  v_svc  text[] := array[
+    'lorekit_find_user_by_github_id(text)',
+    'lorekit_installation_upsert(bigint, bigint, text, text, uuid, text, text[])',
+    'lorekit_installation_remove_repos(bigint, text[])',
+    'lorekit_installation_remove(bigint)',
+    'lorekit_purge_old_usage_events(interval)',
+    'lorekit_purge_all_expired_memories()'
+  ];
+begin
+  assert array_length(v_read, 1) = 2 and array_length(v_svc, 1) = 6,
+    'readfn grant guard: expected 2 read + 6 service-only signatures (anti-vacuity)';
+
+  foreach v_sig in array v_read loop
+    assert not has_function_privilege('anon', v_sig, 'EXECUTE'),
+      format('%s must NOT be executable by anon after 00047', v_sig);
+    assert has_function_privilege('authenticated', v_sig, 'EXECUTE'),
+      format('%s must stay executable by authenticated', v_sig);
+    assert has_function_privilege('service_role', v_sig, 'EXECUTE'),
+      format('%s must stay executable by service_role', v_sig);
+  end loop;
+
+  foreach v_sig in array v_svc loop
+    assert not has_function_privilege('anon', v_sig, 'EXECUTE'),
+      format('%s must NOT be executable by anon after 00047', v_sig);
+    assert not has_function_privilege('authenticated', v_sig, 'EXECUTE'),
+      format('%s must NOT be executable by authenticated after 00047 (service-role only)', v_sig);
+    assert has_function_privilege('service_role', v_sig, 'EXECUTE'),
+      format('%s must stay executable by service_role', v_sig);
+  end loop;
+end;
+$$;
+
+-- ── 61b. Actor guard: an authenticated caller cannot read another user ──────
+-- a1 owns a distinctively-named scope. An authenticated b2 naming a1 must see
+-- NONE of a1's scopes/counts (resolved to b2's own auth.uid()); a service-role
+-- caller naming a1 sees a1's, as the edge GET /memories/scopes path does.
+insert into memories (user_id, scope, key, value) values
+  ('00000000-0000-0000-0000-0000000000a1', 'project::readfn-guard-secret', 'k', 'v');
+
+do $$
+declare
+  v_svc_scopes  int;
+  v_b2_scopes   int;
+  v_b2_count    jsonb;
+begin
+  set local role service_role;
+  perform set_config('request.jwt.claims', '{"role":"service_role"}', true);
+  select count(*) into v_svc_scopes
+    from lorekit_memory_scopes('00000000-0000-0000-0000-0000000000a1')
+   where scope = 'project::readfn-guard-secret';
+  reset role;
+
+  set local role authenticated;
+  perform set_config('request.jwt.claims',
+    '{"sub":"00000000-0000-0000-0000-0000000000b2","role":"authenticated"}', true);
+  select count(*) into v_b2_scopes
+    from lorekit_memory_scopes('00000000-0000-0000-0000-0000000000a1')
+   where scope = 'project::readfn-guard-secret';
+  select lorekit_memory_count('00000000-0000-0000-0000-0000000000a1') into v_b2_count;
+  reset role;
+  perform set_config('request.jwt.claims', '', true);
+
+  assert v_svc_scopes = 1,
+    format('readfn guard: service-role naming a1 must see a1''s scope, got %s', v_svc_scopes);
+  assert v_b2_scopes = 0,
+    format('readfn guard: authenticated b2 naming a1 must NOT enumerate a1''s scopes (IDOR closed), got %s', v_b2_scopes);
+  assert coalesce((v_b2_count->>'personal_count')::int, -1) = 0,
+    format('readfn guard: authenticated b2 memory_count(a1) must report b2''s own 0 personal, got %s', v_b2_count->>'personal_count');
+end;
+$$;
+
 rollback;
 
 \echo 'migrations.test.sql: all assertions passed'

--- a/supabase/tests/migrations.test.sql
+++ b/supabase/tests/migrations.test.sql
@@ -3214,6 +3214,7 @@ insert into memories (user_id, scope, key, value) values
 do $$
 declare
   v_svc_scopes  int;
+  v_svc_null    int;
   v_b2_scopes   int;
   v_b2_count    jsonb;
 begin
@@ -3221,6 +3222,12 @@ begin
   perform set_config('request.jwt.claims', '{"role":"service_role"}', true);
   select count(*) into v_svc_scopes
     from lorekit_memory_scopes('00000000-0000-0000-0000-0000000000a1')
+   where scope = 'project::readfn-guard-secret';
+  -- CI escape hatch: a service-role caller with NULL p_user_id sees EVERY
+  -- scope (v_actor resolves NULL → the `v_actor is null and service_role`
+  -- branch), so a1's secret scope is visible without naming any user.
+  select count(*) into v_svc_null
+    from lorekit_memory_scopes(null)
    where scope = 'project::readfn-guard-secret';
   reset role;
 
@@ -3236,6 +3243,8 @@ begin
 
   assert v_svc_scopes = 1,
     format('readfn guard: service-role naming a1 must see a1''s scope, got %s', v_svc_scopes);
+  assert v_svc_null = 1,
+    format('readfn guard: service-role NULL p_user_id (CI escape hatch) must see a1''s scope, got %s', v_svc_null);
   assert v_b2_scopes = 0,
     format('readfn guard: authenticated b2 naming a1 must NOT enumerate a1''s scopes (IDOR closed), got %s', v_b2_scopes);
   assert coalesce((v_b2_count->>'personal_count')::int, -1) = 0,


### PR DESCRIPTION
## Why

Follow-up to #288/#293. The security review found a cluster of `SECURITY DEFINER` functions that kept Postgres's default `PUBLIC` `EXECUTE`, so `anon` (or any authenticated caller) could read another user's data or call service-only procedures over PostgREST. This PR closes the **clearly-safe half** of that sweep and captures the rest as a triage backlog.

## What changed

- **Migration `00047`:**
  - `lorekit_memory_scopes` / `lorekit_memory_count` trusted a bare `p_user_id` — anon/authenticated could enumerate another user's scope names, counts and plan tier. Both get the `00046`/`00041` **service-role-gated actor guard** (`p_user_id` honoured only under `service_role`, else `auth.uid()`) **and** lose the `public`/`anon` grant, closing the anon *and* authenticated cross-user read. The `memory_scopes` CI escape hatch is preserved.
  - `lorekit_find_user_by_github_id`, the 3 GitHub-App installation RPCs, `lorekit_purge_old_usage_events`, `lorekit_purge_all_expired_memories` were granted to `service_role` only but never had `PUBLIC` revoked (so anon could forge/hijack installations, deanonymise a GitHub id → user UUID, or wipe all usage analytics). Revoked to service-role only.
- **`migrations.test.sql` §41** (the pre-existing `memory_scopes` visibility test) is **retrofitted to run under a service-role context**. The new actor guard pins `memory_scopes` to `auth.uid()` unless the connection carries a `service_role` claim, and §41 called it for a1/b2/c3 in one block with no role/claims set — so its AC-1/AC-6 assertions now adopt the same service-role claim the edge `GET /memories/scopes` path connects with. Without this the actor resolved to a NULL `auth.uid()` and the block failed.
- **`migrations.test.sql` §61** asserts the grant surface, that an authenticated caller naming another user reads nothing of theirs (IDOR closed), that a `service_role` caller with a NULL `p_user_id` still sees everything (the claim-gated CI escape hatch), and that `memory_count` under an authenticated caller reports **that caller's own** total, never the named user's.
- **`docs/tasks/security-review-deferred-findings.md`** — the full deferred-findings backlog (SEC-1…SEC-15, Linear-ready), with the items this PR resolves struck through.

## Deliberately out of scope

The RLS-policy / insert-hot-path / rate-limit functions (`lorekit_member_org_ids`, `lorekit_org_role`/`_can`, `lorekit_check_rate_limit`, `lorekit_get_limit`/`_org_limit`, `record_usage_event`, …) are **not** touched here — a wrong grant there is a production-availability incident. They stay in the findings doc with a `[rls/hot-path]` tag and need their own tested pass.

## How to verify

- `migrations.test.sql` §41 + §61 in CI's integration job. Validated against real Postgres 16 (grants, the service-role-gated actor guard, the claim-gated CI escape hatch, and `memory_count`/`memory_scopes` actor-pinning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fxz6ooCnLR3SVaHkvqnzJJ)_