### PR TITLE
feat(cli): deep-links docs page + `tags` param + web↔CLI drift guard

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -320,6 +320,7 @@ lorekit link global                       # the Explorer filtered to global scop
 lorekit link repo::owner/repo prefer-guards   # open one lesson's detail sheet
 lorekit link global::prefer-guards --json     # { url, surface, base, params }
 lorekit url --q "flaky test" --owner personal # search + ownership filter
+lorekit link global --tags "perf,ci"          # Explorer filtered to labels
 ```
 
 With no arguments it links to the cwd's **most-specific scope** ("share what I'm
@@ -330,8 +331,9 @@ that lesson's detail sheet. It sets **both** the `lesson` param (which opens the
 sheet) and `scope` — not because scope is needed to find the lesson (the sidebar
 reads one unfiltered recent set), but so the Explorer list *behind* the sheet is
 filtered to the lesson's own scope. Filter flags mirror the Explorer: `--q`
-(search), `--owner <all|personal|orgId>`, `--range`/`--from`/`--to`, `--archived`,
-`--view <scope|time>`.
+(search), `--owner <all|personal|orgId>`, `--tags <a,b,c>` (label filter, AND
+across labels; comma-separated or a JSON array), `--range`/`--from`/`--to`,
+`--archived`, `--view <scope|time>`.
 
 Every param is `encodeURIComponent(JSON.stringify(value))` — the exact inverse of
 how the dashboard's `useUrlState` reads it back (`JSON.parse`, falling back to the

--- a/packages/cli/bin/lorekit.mjs
+++ b/packages/cli/bin/lorekit.mjs
@@ -85,8 +85,8 @@ ${c.bold('Commands')}
   link (url)  Print a shareable dashboard deep-link URL for the current context,
               a scope, or a specific lesson (opens its detail sheet). No args
               links to the cwd's most-specific scope. Filter flags mirror the
-              Explorer (--q / --owner / --range / --archived / --view); --base or
-              LOREKIT_APP_URL override the dashboard host. --json. Pipe it:
+              Explorer (--q / --owner / --tags / --range / --archived / --view);
+              --base or LOREKIT_APP_URL override the dashboard host. --json. Pipe it:
               lorekit link | pbcopy.
   bootstrap   Apply the BYOD schema to a user-supplied Supabase database.
               Only needed when using LOREKIT_STORAGE_URL / LOREKIT_STORAGE_ANON_KEY.
@@ -506,6 +506,7 @@ ${c.bold('Options')}
       --scope <scope>     Scope to link to (when no positional scope is given)
       --q <text>          Pre-fill the Explorer search box
       --owner <o>         Ownership filter: all | personal | <orgId>
+      --tags <a,b,c>      Label filter (AND across labels); comma-separated or a JSON array
       --range <json>      Date range as {"from":"YYYY-MM-DD","to":"YYYY-MM-DD"}
       --from <date>       Range start (shorthand for --range)
       --to <date>         Range end (shorthand for --range)
@@ -521,6 +522,7 @@ ${c.bold('Examples')}
   npx @lorekit/cli link repo::owner/repo prefer-guards   # open one lesson's detail sheet
   npx @lorekit/cli link global::prefer-guards --json     # { url, surface, base, params }
   npx @lorekit/cli url --q "flaky test" --owner personal # search + ownership filter
+  npx @lorekit/cli link global --tags "perf,ci"          # Explorer filtered to labels
 `,
   migrate: `${c.bold('lorekit migrate')} — relocate a LoreKit-format local store into the current layout
 

--- a/packages/cli/src/deeplink-pure.mjs
+++ b/packages/cli/src/deeplink-pure.mjs
@@ -29,14 +29,17 @@ export const LORE_PARAM_DEFAULTS = {
   q: '', // string search query
   range: null, // { from, to } | null (DateRange, "YYYY-MM-DD")
   owner: 'all', // 'all' | 'personal' | { orgId }
+  tags: [], // string[] — label filter (AND across labels); [] means "no filter"
   view: 'scope', // 'scope' | 'time'
   archived: false, // boolean
   lesson: null, // { scope, key } | null — opens the detail sheet
 };
 
 // A stable, readable param order (also makes URLs deterministic for tests).
-// `scope` precedes `lesson` so a lesson link reads `?scope=…&lesson=…`.
-const PARAM_ORDER = ['scope', 'q', 'range', 'owner', 'view', 'archived', 'lesson'];
+// Mirrors the `useUrlState` call order in `LoreExplorer.tsx` (+ the `lesson`
+// param last), so `tags` sits between `owner` and `view`. `scope` precedes
+// `lesson` so a lesson link reads `?scope=…&lesson=…`.
+const PARAM_ORDER = ['scope', 'q', 'range', 'owner', 'tags', 'view', 'archived', 'lesson'];
 
 // Strip trailing slashes from a base URL, falling back to the default when the
 // input is empty/absent. Pure.
@@ -152,6 +155,44 @@ export function parseOwnerArg(owner) {
 // else (incl. absent/invalid) → 'scope'. Pure.
 export function parseViewArg(view) {
   return view === 'time' ? 'time' : 'scope';
+}
+
+// Coerce the `--tags` flag to a normalized `string[]` label filter, mirroring the
+// web app's `normalizeTags` (`packages/web/src/lib/tag-filter.ts`): trim each
+// entry, drop empties, de-duplicate, preserve first-seen order. Accepts either a
+// JSON array string (`'["perf","ci"]'`) or the friendlier comma-separated form
+// (`'perf, ci'`); a malformed JSON array falls back to comma-splitting rather
+// than throwing. Returns `[]` for absent/empty input (the default → omitted from
+// the URL). Pure.
+export function parseTagsArg(tags) {
+  if (Array.isArray(tags)) return normalizeTagList(tags);
+  if (typeof tags !== 'string' || !tags.trim()) return [];
+  const s = tags.trim();
+  if (s.startsWith('[')) {
+    try {
+      const parsed = JSON.parse(s);
+      if (Array.isArray(parsed)) return normalizeTagList(parsed);
+    } catch {
+      /* malformed JSON array → fall through to comma-splitting */
+    }
+  }
+  return normalizeTagList(s.split(','));
+}
+
+// Trim, drop non-string/empty entries, and de-duplicate preserving order. The
+// CLI-side twin of the web's `normalizeTags`; kept inline to keep this module
+// zero-import. Pure.
+function normalizeTagList(list) {
+  const seen = new Set();
+  const out = [];
+  for (const item of list) {
+    if (typeof item !== 'string') continue;
+    const t = item.trim();
+    if (!t || seen.has(t)) continue;
+    seen.add(t);
+    out.push(t);
+  }
+  return out;
 }
 
 // Coerce the date-range flags to a `{ from, to }` DateRange or null. `--range`

--- a/packages/cli/src/link.mjs
+++ b/packages/cli/src/link.mjs
@@ -25,6 +25,7 @@ import {
   parseOwnerArg,
   parseViewArg,
   parseRangeArg,
+  parseTagsArg,
   resolveScopeArg,
   surfaceFor,
 } from './deeplink-pure.mjs';
@@ -66,6 +67,7 @@ export async function link(args) {
   const owner = parseOwnerArg(args.owner);
   const view = parseViewArg(args.view);
   const range = parseRangeArg(args);
+  const tags = parseTagsArg(args.tags);
   const archived = Boolean(args.archived);
 
   const gaveAnyInput =
@@ -75,6 +77,7 @@ export async function link(args) {
     owner !== 'all' ||
     view !== 'scope' ||
     range !== null ||
+    tags.length > 0 ||
     archived;
 
   // Bare `lorekit link` (no scope, no lesson, no filters) → the cwd's
@@ -90,6 +93,7 @@ export async function link(args) {
   if (key) params.lesson = { scope, key };
   if (q) params.q = q;
   if (owner !== 'all') params.owner = owner;
+  if (tags.length) params.tags = tags;
   if (view !== 'scope') params.view = view;
   if (range !== null) params.range = range;
   if (archived) params.archived = true;

--- a/packages/cli/test/deeplink.test.mjs
+++ b/packages/cli/test/deeplink.test.mjs
@@ -446,12 +446,20 @@ test('link --tags prints the label-filtered Explorer link', () => {
 // instead of silently producing a link the dashboard ignores. This is the guard
 // that would have caught the missing `tags` param.
 
+const WEB_PACKAGE_DIR = fileURLToPath(new URL('../../web', import.meta.url));
+
 const WEB_SOURCES = [
   '../../web/src/components/lore/LoreExplorer.tsx',
   '../../web/src/components/providers/MemorySidebarProvider.tsx',
 ].map((rel) => fileURLToPath(new URL(rel, import.meta.url)));
 
-const WEB_SOURCES_PRESENT = WEB_SOURCES.every((p) => fs.existsSync(p));
+// The skip is gated on the PACKAGE, not on the individual files. A CLI-only
+// checkout legitimately has no `packages/web` and must skip; but if the package
+// IS present and a listed source is missing, it was moved or renamed — that must
+// FAIL loudly. Keying the skip on the files themselves turned exactly that case
+// into a silent pass, disabling the guard without any signal.
+const WEB_PACKAGE_PRESENT = fs.existsSync(WEB_PACKAGE_DIR);
+const MISSING_WEB_SOURCES = WEB_PACKAGE_PRESENT ? WEB_SOURCES.filter((p) => !fs.existsSync(p)) : [];
 
 // Extract every URL-backed param from `use[Debounced]UrlState<…>('key', <default>, …)`
 // calls into a Map of key → raw default token (as written in source).
@@ -483,6 +491,13 @@ function parseDefaultToken(tok) {
 }
 
 function readWebParams() {
+  assert.deepEqual(
+    MISSING_WEB_SOURCES,
+    [],
+    `packages/web is present but these Explorer sources are missing — they were moved or ` +
+      `renamed. Update WEB_SOURCES so this drift guard keeps running:\n  ` +
+      `${MISSING_WEB_SOURCES.join('\n  ')}`,
+  );
   const params = new Map();
   for (const p of WEB_SOURCES) {
     for (const [k, v] of extractUrlStateParams(fs.readFileSync(p, 'utf8'))) {
@@ -494,7 +509,7 @@ function readWebParams() {
 
 test(
   'web ↔ CLI: LORE_PARAM_DEFAULTS covers exactly the Explorer useUrlState params',
-  { skip: WEB_SOURCES_PRESENT ? false : 'packages/web sources not present in this checkout' },
+  { skip: WEB_PACKAGE_PRESENT ? false : 'packages/web not present in this checkout' },
   () => {
     const webKeys = [...readWebParams().keys()].sort();
     const cliKeys = Object.keys(LORE_PARAM_DEFAULTS).sort();
@@ -509,7 +524,7 @@ test(
 
 test(
   'web ↔ CLI: scalar param defaults agree with the Explorer',
-  { skip: WEB_SOURCES_PRESENT ? false : 'packages/web sources not present in this checkout' },
+  { skip: WEB_PACKAGE_PRESENT ? false : 'packages/web not present in this checkout' },
   () => {
     for (const [key, token] of readWebParams()) {
       const parsed = parseDefaultToken(token);

--- a/packages/cli/test/deeplink.test.mjs
+++ b/packages/cli/test/deeplink.test.mjs
@@ -455,8 +455,12 @@ const WEB_SOURCES_PRESENT = WEB_SOURCES.every((p) => fs.existsSync(p));
 
 // Extract every URL-backed param from `use[Debounced]UrlState<…>('key', <default>, …)`
 // calls into a Map of key → raw default token (as written in source).
+// The type parameter is OPTIONAL in the pattern: the inference-only form
+// `useDebouncedUrlState('name', '', …)` (already used in `AuditLogFeed.tsx`) carries
+// no `<…>`, and requiring one would silently skip a future no-generic Explorer
+// filter — the guard would still pass while no longer guarding.
 function extractUrlStateParams(src) {
-  const re = /use(?:Debounced)?UrlState<[^>]*>\(\s*'([^']+)'\s*,\s*([^,)]+?)\s*[,)]/g;
+  const re = /use(?:Debounced)?UrlState(?:<[^>]*>)?\(\s*'([^']+)'\s*,\s*([^,)]+?)\s*[,)]/g;
   const found = new Map();
   let m;
   while ((m = re.exec(src)) !== null) {

--- a/packages/cli/test/deeplink.test.mjs
+++ b/packages/cli/test/deeplink.test.mjs
@@ -19,6 +19,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   DEFAULT_APP_BASE,
+  LORE_PARAM_DEFAULTS,
   resolveAppBase,
   encodeParam,
   buildLoreQuery,
@@ -28,6 +29,7 @@ import {
   parseOwnerArg,
   parseViewArg,
   parseRangeArg,
+  parseTagsArg,
   resolveScopeArg,
   mostSpecificScope,
   surfaceFor,
@@ -398,3 +400,148 @@ test('--link honours --json and --base on a read command', () => {
   assert.equal(out.surface, 'scope');
   assert.equal(out.url, 'https://acme.dev/lore?scope=%22global%22');
 });
+
+// ── unit: the `tags` label filter ─────────────────────────────────────────────
+
+test('parseTagsArg: comma form, JSON-array form, normalization, and empties', () => {
+  // Comma-separated is trimmed, de-duplicated, order-preserving.
+  assert.deepEqual(parseTagsArg('perf, ci, perf, '), ['perf', 'ci']);
+  // A JSON array string is accepted and normalized the same way.
+  assert.deepEqual(parseTagsArg('["perf"," ci ","perf"]'), ['perf', 'ci']);
+  // An already-array input is normalized too (drops non-strings/empties).
+  assert.deepEqual(parseTagsArg(['a', '', 'a', 2, 'b']), ['a', 'b']);
+  // A malformed JSON array falls back to comma-splitting rather than throwing.
+  assert.deepEqual(parseTagsArg('[perf'), ['[perf']);
+  // Absent / blank → [] (the default, so it is omitted from the URL).
+  assert.deepEqual(parseTagsArg(undefined), []);
+  assert.deepEqual(parseTagsArg('   '), []);
+});
+
+test('buildLoreUrl encodes tags as a JSON array and omits the empty default', () => {
+  assert.equal(
+    buildLoreUrl({ scope: 'global', tags: ['perf', 'ci'] }),
+    'https://lorekit.io/lore?scope=%22global%22&tags=%5B%22perf%22%2C%22ci%22%5D',
+  );
+  // An empty tags array equals the default → omitted, same as no tags at all.
+  assert.equal(buildLoreUrl({ scope: 'global', tags: [] }), 'https://lorekit.io/lore?scope=%22global%22');
+  // Round-trip: the app reads it back via JSON.parse.
+  const url = new URL(buildLoreUrl({ tags: ['perf', 'ci'] }));
+  assert.deepEqual(JSON.parse(url.searchParams.get('tags')), ['perf', 'ci']);
+});
+
+test('link --tags prints the label-filtered Explorer link', () => {
+  const root = tmp('lk-link-proj-');
+  const res = run(['link', 'global', '--tags', 'perf,ci'], { dir: root });
+  assert.equal(res.status, 0, res.stderr);
+  assert.equal(
+    res.stdout.trim(),
+    'https://lorekit.io/lore?scope=%22global%22&tags=%5B%22perf%22%2C%22ci%22%5D',
+  );
+});
+
+// ── web ↔ CLI drift guard ─────────────────────────────────────────────────────
+// `LORE_PARAM_DEFAULTS` mirrors the /lore Explorer's `useUrlState` params
+// (packages/web). This reads the ACTUAL param set from the web source — it never
+// hardcodes it — so a new Explorer filter (or a changed default) fails HERE
+// instead of silently producing a link the dashboard ignores. This is the guard
+// that would have caught the missing `tags` param.
+
+const WEB_SOURCES = [
+  '../../web/src/components/lore/LoreExplorer.tsx',
+  '../../web/src/components/providers/MemorySidebarProvider.tsx',
+].map((rel) => fileURLToPath(new URL(rel, import.meta.url)));
+
+const WEB_SOURCES_PRESENT = WEB_SOURCES.every((p) => fs.existsSync(p));
+
+// Extract every URL-backed param from `use[Debounced]UrlState<…>('key', <default>, …)`
+// calls into a Map of key → raw default token (as written in source).
+function extractUrlStateParams(src) {
+  const re = /use(?:Debounced)?UrlState<[^>]*>\(\s*'([^']+)'\s*,\s*([^,)]+?)\s*[,)]/g;
+  const found = new Map();
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    if (!found.has(m[1])) found.set(m[1], m[2].trim());
+  }
+  return found;
+}
+
+// Parse a simple literal default token to a value. `NO_TAGS` is the web
+// module-scoped `[]` alias. Complex tokens report `ok: false` so the value check
+// is skipped for them (the key-set check still covers presence).
+function parseDefaultToken(tok) {
+  if (tok === 'null') return { ok: true, value: null };
+  if (tok === 'true') return { ok: true, value: true };
+  if (tok === 'false') return { ok: true, value: false };
+  if (tok === 'NO_TAGS') return { ok: true, value: [] };
+  const str = /^'([^']*)'$/.exec(tok) || /^"([^"]*)"$/.exec(tok);
+  if (str) return { ok: true, value: str[1] };
+  return { ok: false };
+}
+
+function readWebParams() {
+  const params = new Map();
+  for (const p of WEB_SOURCES) {
+    for (const [k, v] of extractUrlStateParams(fs.readFileSync(p, 'utf8'))) {
+      if (!params.has(k)) params.set(k, v);
+    }
+  }
+  return params;
+}
+
+test(
+  'web ↔ CLI: LORE_PARAM_DEFAULTS covers exactly the Explorer useUrlState params',
+  { skip: WEB_SOURCES_PRESENT ? false : 'packages/web sources not present in this checkout' },
+  () => {
+    const webKeys = [...readWebParams().keys()].sort();
+    const cliKeys = Object.keys(LORE_PARAM_DEFAULTS).sort();
+    assert.deepEqual(
+      webKeys,
+      cliKeys,
+      `deeplink-pure.mjs LORE_PARAM_DEFAULTS must match the /lore Explorer useUrlState params.\n` +
+        `  web: ${webKeys.join(', ')}\n  cli: ${cliKeys.join(', ')}`,
+    );
+  },
+);
+
+test(
+  'web ↔ CLI: scalar param defaults agree with the Explorer',
+  { skip: WEB_SOURCES_PRESENT ? false : 'packages/web sources not present in this checkout' },
+  () => {
+    for (const [key, token] of readWebParams()) {
+      const parsed = parseDefaultToken(token);
+      if (!parsed.ok) continue; // complex default — presence is covered by the key test
+      assert.equal(
+        JSON.stringify(parsed.value),
+        JSON.stringify(LORE_PARAM_DEFAULTS[key]),
+        `default for '${key}' drifted: web ${JSON.stringify(parsed.value)} vs cli ${JSON.stringify(LORE_PARAM_DEFAULTS[key])}`,
+      );
+    }
+  },
+);
+
+// ── docs accuracy ─────────────────────────────────────────────────────────────
+// The example URLs printed in the deep-links docs page must be byte-for-byte
+// reproducible by the builder, so the docs can never drift from the encoding.
+
+const DOCS_PAGE = fileURLToPath(new URL('../../web/src/content/docs/deep-links.mdx', import.meta.url));
+const DOCS_PAGE_PRESENT = fs.existsSync(DOCS_PAGE);
+
+test(
+  'docs: every example URL in deep-links.mdx is reproducible by the builder',
+  { skip: DOCS_PAGE_PRESENT ? false : 'deep-links.mdx not present in this checkout' },
+  () => {
+    const page = fs.readFileSync(DOCS_PAGE, 'utf8');
+    const expected = [
+      loreScopeUrl('global'),
+      loreScopeUrl('repo::acme/widget'),
+      buildLessonUrl('global', 'prefer-guard-clauses'),
+      buildLoreUrl({ q: 'flaky test', owner: 'personal' }),
+      buildLoreUrl({ scope: 'global', tags: ['perf', 'ci'] }),
+      buildLoreUrl({ scope: 'global', view: 'time', archived: true }),
+      buildLoreUrl({ scope: 'global' }, { base: 'https://lore.acme.dev' }),
+    ];
+    for (const url of expected) {
+      assert.ok(page.includes(url), `deep-links.mdx is missing (or misencodes) the documented URL: ${url}`);
+    }
+  },
+);

--- a/packages/web/src/content/docs/deep-links.mdx
+++ b/packages/web/src/content/docs/deep-links.mdx
@@ -1,0 +1,132 @@
+---
+title: "Deep links"
+description: "Every view in the LoreKit dashboard is a shareable URL. Link straight to a scope in the Explorer, open one memory's detail sheet, or share a filtered search — from the terminal, a PR, or a chat message. Generate them by hand or with the CLI's link command and --link flag."
+order: 9
+keywords: ["deep link", "deeplink", "share link", "shareable url", "explorer", "scope link", "memory link", "lesson link", "lorekit link", "--link flag", "url command", "LOREKIT_APP_URL", "--base", "self-hosting", "useUrlState", "query params", "tags filter"]
+---
+
+The LoreKit dashboard keeps its entire view state in the URL. Every scope filter, search query, label selection, date range, and open memory is a query parameter — so any view you are looking at is a link you can copy, paste, and share, and it opens on exactly that view.
+
+**Where deep links go**
+
+| Destination | Path |
+| --- | --- |
+| The memory Explorer | `/lore` |
+| One memory's detail sheet | `/lore?lesson=…` |
+| A scope-filtered Explorer | `/lore?scope=…` |
+
+## How dashboard URLs are encoded
+
+The Explorer reads each parameter with `useUrlState`, which does `JSON.parse(searchParams.get(key))` and falls back to the parameter's **default** when the value is absent or fails to parse. Two rules follow from that, and every LoreKit-generated link obeys both:
+
+1. **Each value is JSON-encoded, then URL-encoded** — `encodeURIComponent(JSON.stringify(value))`. A string scope is therefore double-quoted: `?scope=%22global%22`, not `?scope=global`. A raw `?scope=global` fails `JSON.parse` and silently means "all scopes".
+2. **A value equal to its default is omitted.** A present-but-default parameter is noise, so clean links carry only the parameters that actually change the view.
+
+**The Explorer parameters**
+
+| Param | Default | Meaning |
+| --- | --- | --- |
+| `scope` | `null` | Filter to one scope. `null` means all scopes. |
+| `q` | `""` | Search query (pre-fills the search box). |
+| `range` | `null` | Date range `{ "from": "YYYY-MM-DD", "to": "YYYY-MM-DD" }`. |
+| `owner` | `"all"` | Ownership filter: `"all"`, `"personal"`, or `{ "orgId": "…" }`. |
+| `tags` | `[]` | Label filter, AND across labels (e.g. `["perf","ci"]`). |
+| `view` | `"scope"` | Explorer view: `"scope"` or `"time"`. |
+| `archived` | `false` | Include archived memories. |
+| `lesson` | `null` | `{ "scope", "key" }` — opens that memory's detail sheet. |
+
+> The CLI mirrors this exact table in `deeplink-pure.mjs` (`LORE_PARAM_DEFAULTS`), and a cross-package test reads the real `useUrlState` parameters from the web source so the two can never drift.
+
+## Link to a scope
+
+Filter the Explorer to a single scope. `global` is a real scope — only the actual default (`null`, no filter) is omitted.
+
+```text
+# global scope
+https://lorekit.io/lore?scope=%22global%22
+
+# a repo scope (repo::acme/widget)
+https://lorekit.io/lore?scope=%22repo%3A%3Aacme%2Fwidget%22
+```
+
+## Link to a specific memory
+
+Open a memory's detail sheet directly. The link sets `lesson` (which opens the sheet) plus `scope`, so the list behind the sheet is filtered to the memory's own scope:
+
+```text
+# opens the "prefer-guard-clauses" memory in the global scope
+https://lorekit.io/lore?scope=%22global%22&lesson=%7B%22scope%22%3A%22global%22%2C%22key%22%3A%22prefer-guard-clauses%22%7D
+```
+
+The detail sheet reads from a recent, unfiltered set, so a memory older than that window or an archived one can still open blank — a dashboard limitation the link itself cannot fix.
+
+## Link to a search or a filtered view
+
+Combine any of the Explorer parameters. Each is JSON-encoded and default-omitted:
+
+```text
+# search "flaky test", personal memories only
+https://lorekit.io/lore?q=%22flaky%20test%22&owner=%22personal%22
+
+# global scope, filtered to the "perf" and "ci" labels
+https://lorekit.io/lore?scope=%22global%22&tags=%5B%22perf%22%2C%22ci%22%5D
+
+# global scope, time view, including archived
+https://lorekit.io/lore?scope=%22global%22&view=%22time%22&archived=true
+```
+
+## Generate links from the CLI
+
+You rarely need to hand-encode these. The CLI builds them for you and prints the URL alone to stdout, so it pipes straight to your clipboard or a message.
+
+**The `link` command** (alias `url`):
+
+```bash
+lorekit link                              # the current repo/branch context
+lorekit link | pbcopy                     # copy it straight to the clipboard
+lorekit link global                       # the Explorer filtered to global scope
+lorekit link repo::acme/widget prefer-guards   # open one memory's detail sheet
+lorekit link global --tags "perf,ci"      # a label-filtered Explorer link
+lorekit url --q "flaky test" --owner personal  # search + ownership filter
+lorekit link global::prefer-guards --json      # { url, surface, base, params }
+```
+
+With no arguments it links to the current directory's most-specific scope — "share what I'm looking at". A single argument is treated as a scope (a valid `repo::…` / `branch::…::…` scope is a scope, not a memory key); a scope **and** a key (or the `scope::key` shorthand) links to that memory's detail sheet. The filter flags mirror the Explorer: `--q`, `--owner`, `--tags`, `--range` (or `--from` / `--to`), `--view`, `--archived`.
+
+**The `--link` flag** short-circuits a read command to the deep link for the view you just ran — same builder, no query:
+
+```bash
+lorekit show global prefer-guard-clauses --link   # link to that memory
+lorekit search "flaky test" --scope global --link # link to that search
+lorekit list --scope global --link                # link to that scope's Explorer
+lorekit tree --scope global --link                # same, from the scope tree
+```
+
+`show` and `search` map exactly; `list` and `tree` map their multi-scope view to the most-specific applicable scope, because the dashboard filters one scope at a time.
+
+## Self-hosting
+
+Deep links default to the hosted dashboard at `https://lorekit.io`. Point them at your own deployment with the `--base` flag or the `LOREKIT_APP_URL` environment variable (the flag wins):
+
+```bash
+lorekit link global --base https://lore.acme.dev
+# → https://lore.acme.dev/lore?scope=%22global%22
+
+export LOREKIT_APP_URL=https://lore.acme.dev
+lorekit link global   # picks up the env var
+```
+
+## Other useful links
+
+These dashboard pages are plain routes — no encoding needed:
+
+| Page | Path |
+| --- | --- |
+| Memory Explorer | `/lore` |
+| Dashboard overview | `/dashboard` |
+| API keys & tokens | `/settings/api-keys` |
+| Audit log | `/settings/audit` |
+| Organization | `/settings/organization` |
+| Integrations | `/settings/integrations` |
+| Documentation | `/docs` |
+| REST API reference | `/api-docs` |

--- a/packages/web/src/lib/docs/sections.ts
+++ b/packages/web/src/lib/docs/sections.ts
@@ -7,6 +7,7 @@ import {
   Tag,
   FileCog,
   Zap,
+  Link2,
   FileCode,
   type LucideIcon,
 } from 'lucide-react';
@@ -40,6 +41,7 @@ export const DOCS_SECTIONS: readonly DocsSection[] = [
   { id: 'tags', label: 'Tags & scopes', icon: Tag, summary: 'Organise lessons by scope and tag' },
   { id: 'config', label: 'Configuration', icon: FileCog, summary: 'All .lorekit.json / config.json options' },
   { id: 'use-cases', label: 'Use cases', icon: Zap, summary: 'Common patterns and workflows' },
+  { id: 'deep-links', label: 'Deep links', icon: Link2, summary: 'Shareable dashboard URLs for scopes, memories, and filters' },
 ];
 
 /** URL slugs / MDX filename stems, in reading order. */


### PR DESCRIPTION
## What & why

Follow-up to #296 (which shipped `lorekit link` / `--link`). Three things, all rooted in the same idea — the dashboard's URL state is the source of truth, so read it:

1. **Docs** — a user-facing docs-site page for deep links (there wasn't one; only CLI `--help` / README / `docs/otel.md`).
2. **Close a real gap** — the `/lore` Explorer exposes a `tags` label filter that the CLI builder's `LORE_PARAM_DEFAULTS` didn't cover, so the CLI couldn't build a label-filtered link. Reading the actual `useUrlState` params from `packages/web` surfaces it.
3. **Guard against drift** — the exact deferred follow-up from #296: a test that reads the real Explorer params and asserts the CLI mirror matches.

## What shipped

**CLI (`packages/cli`)**
- `deeplink-pure.mjs`: add `tags` (`[]` default) to `LORE_PARAM_DEFAULTS` + `PARAM_ORDER`, positioned between `owner` and `view` to mirror the `LoreExplorer.tsx` call order. New pure `parseTagsArg` — accepts comma-separated (`perf,ci`) or a JSON array (`["perf","ci"]`) and normalizes like the web `normalizeTags` (trim, drop empties, de-dupe, order-preserving).
- `link.mjs`: wire `--tags` into the `link` command.
- `bin/lorekit.mjs` + `README.md`: document `--tags` on `link`.

**Docs (`packages/web`)**
- New `src/content/docs/deep-links.mdx`, registered in `sections.ts` (order 9). Covers the `encodeURIComponent(JSON.stringify(value))` contract and default-omission, Explorer-by-scope, specific-memory (`lesson`) links, search/filter/`tags` links, the CLI `link`/`url` command and `--link` flag, self-hosting via `--base` / `LOREKIT_APP_URL`, and other useful dashboard routes.

## The drift guard (reads the web value)

`test/deeplink.test.mjs` now reads the real `use[Debounced]UrlState<…>('key', <default>)` param set from `LoreExplorer.tsx` + `MemorySidebarProvider.tsx` and asserts `LORE_PARAM_DEFAULTS` matches — **keys and scalar defaults**. This is the guard that would have caught the missing `tags`. A new Explorer filter, or a changed default, now fails here instead of silently producing a link the dashboard ignores. It skips cleanly if `packages/web` isn't in the checkout.

## Docs stay honest

A docs-accuracy test asserts every example URL printed in `deep-links.mdx` is byte-for-byte reproducible by the builder, so the page can't drift from the encoding.

## Tests

- `test/deeplink.test.mjs`: **40 pass** (34 prior + 6 new — `tags` unit/integration, the two drift-guard tests, docs-accuracy).
- `packages/web` `sections.spec.ts` (6) + `mdx-render.spec.ts` (3): pass — the new page is registered and compiles.
- `cli.test.mjs` / `source-hygiene.test.mjs` / `hooks.test.mjs`: 54 pass (no help/hygiene regression).

## Deferred (unchanged from #296)

- `lorekit open <url>` (reverse direction).
- `show`'s two-positional `::`-scope split (pre-existing, off-diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRtKboZBFfq3mrKWymgYbm)_