### PR TITLE
fix(deploy): parse the real backticked migration-list format in the drift classifier

### DIFF
--- a/scripts/check-remote-migration-drift.mjs
+++ b/scripts/check-remote-migration-drift.mjs
@@ -46,17 +46,26 @@
 const ANSI = /\u001B\[[0-9;]*m/g;
 
 /**
- * Parse the two-column version table `supabase migration list` prints:
+ * Parse the version table `supabase migration list --linked` prints. The CLI
+ * wraps each version in BACKTICKS and prints THREE columns (Local | Remote |
+ * Time), e.g.
  *
- *         Local      | Remote     | Time (UTC)
- *     ---------------|------------|---------------------
- *      00048         | 00048      |
- *                    | 00049      |
+ *      Local   | Remote  | Time (UTC)
+ *      --------|---------|--------------------
+ *      `00048` | `00048` | `00048`
+ *      ` `     | `00049` | `00049`
  *
- * Only cells that are entirely digits count as versions, so the header row, the
- * dashed separator, and the CLI's chatter ("Connecting to remote database...")
- * are all ignored without needing to be recognised. Returns
- * `{ local: string[], remote: string[] }` preserving on-screen order.
+ * (older CLI builds printed bare digits in two columns — both are handled). Each
+ * cell is stripped of backticks and whitespace, then only cells that are
+ * ENTIRELY digits count as versions, so the header row, the separator, the third
+ * column, and the CLI's chatter ("Connecting to remote database...") are all
+ * ignored without needing to be recognised. Only cells[0] (Local) and cells[1]
+ * (Remote) are read. Returns `{ local: string[], remote: string[] }` preserving
+ * on-screen order.
+ *
+ * NOTE: this backtick handling is why the deploy that first shipped the
+ * classifier still failed — the real listing is backticked, the original parser
+ * matched only bare digits, so it saw an EMPTY table and mis-chose `push`.
  */
 export function parseMigrationList(stdout) {
   const local = [];
@@ -64,7 +73,7 @@ export function parseMigrationList(stdout) {
   for (const rawLine of String(stdout ?? '').split('\n')) {
     const line = rawLine.replace(ANSI, '');
     if (!line.includes('|')) continue;
-    const cells = line.split('|').map((c) => c.trim());
+    const cells = line.split('|').map((c) => c.replace(/`/g, '').trim());
     if (/^\d+$/.test(cells[0])) local.push(cells[0]);
     if (cells.length > 1 && /^\d+$/.test(cells[1])) remote.push(cells[1]);
   }

--- a/scripts/check-remote-migration-drift.test.mjs
+++ b/scripts/check-remote-migration-drift.test.mjs
@@ -14,7 +14,26 @@ import { parseMigrationList, classifyDrift, annotate } from './check-remote-migr
 // an open PR has pushed 00049–00051 to the shared preview project and `main`
 // (00001–00048, abbreviated here) has nothing pending. This is the exact state
 // that wedged the Deploy workflow.
+// The REAL `supabase migration list --linked` output that wedged the deploy:
+// versions are BACKTICK-wrapped and there are THREE columns (Local | Remote |
+// Time). This is a verbatim capture from the failing run's log — the original
+// fixture used bare digits in two columns, which is why the buggy parser passed
+// its tests yet saw an empty table in production.
 const PREVIEW_AHEAD = `
+Connecting to remote database...
+
+    Local   | Remote  | Time (UTC)
+   ---------|---------|--------------------
+    \`00046\` | \`00046\` | \`00046\`
+    \`00047\` | \`00047\` | \`00047\`
+    \`00048\` | \`00048\` | \`00048\`
+    \` \`     | \`00049\` | \`00049\`
+    \` \`     | \`00050\` | \`00050\`
+    \` \`     | \`00051\` | \`00051\`
+`;
+
+// Older CLI builds printed bare digits in two columns — still supported.
+const PREVIEW_AHEAD_BARE = `
 Connecting to remote database...
 
         Local      | Remote     | Time (UTC)
@@ -27,8 +46,14 @@ Connecting to remote database...
                    | 00051      |
 `;
 
-test('parseMigrationList — reads both columns and ignores chatter, header, separator', () => {
+test('parseMigrationList — reads the real backticked 3-column table, ignores chatter/header/separator/3rd column', () => {
   const { local, remote } = parseMigrationList(PREVIEW_AHEAD);
+  assert.deepEqual(local, ['00046', '00047', '00048']);
+  assert.deepEqual(remote, ['00046', '00047', '00048', '00049', '00050', '00051']);
+});
+
+test('parseMigrationList — still reads the older bare-digit two-column format', () => {
+  const { local, remote } = parseMigrationList(PREVIEW_AHEAD_BARE);
   assert.deepEqual(local, ['00046', '00047', '00048']);
   assert.deepEqual(remote, ['00046', '00047', '00048', '00049', '00050', '00051']);
 });


### PR DESCRIPTION
## Why

The drift classifier merged in #320 **still failed the first `main` deploy** ([run 30736081792](https://github.com/mthines/lorekit/actions/runs/30736081792)) — reproducing the exact `00049`–`00051` wedge it was meant to fix. The classifier misparsed the migration table and chose `push`:

```
`00047` | `00047` | `00047`
` `     | `00049` | `00049`
migration-drift: no unknown versions on the remote — pushing 0 pending migration(s).
```

`supabase migration list --linked` wraps every version in **backticks** and prints **three columns** (Local | Remote | Time). The parser matched only bare digits in two columns, so it saw an *empty* table → no remote-only versions → `push` → `db push` hit the drift and died. The bug shipped because the test fixture was fictional (bare digits) and passed while the parser was wrong.

## What changed

- `parseMigrationList`: strip backticks from each cell before the digit test; only Local/Remote columns are read, so the third is ignored
- Replace the invented fixture with the verbatim backticked 3-column capture from the failing run; add a back-compat case for the older bare-digit format

## How to verify

- `node --test scripts/check-remote-migration-drift.test.mjs` — 12/12; the `00049`–`00051` state now classifies as `skip`

## Notes for reviewers

Once merged, the deploy this triggers will `skip` the benign preview drift and reach `deploy-production` — this is the change that actually unblocks the pipeline. Non-destructive: preview keeps `00049`–`00051`, which reconcile when their PR merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MhhQHNsznuUEmVWDFi6QHi)_