### PR TITLE
fix(edge): accept www + apex origin siblings in REST CORS allowlist

### DIFF
--- a/supabase/functions/_shared/api/CLAUDE.md
+++ b/supabase/functions/_shared/api/CLAUDE.md
@@ -104,7 +104,11 @@ Rules:
   split stays in the router — the decision itself is not inline here any more.
 
 ### cors.ts
-- `corsHeaders(req)` — returns CORS headers; respects `ALLOWED_ORIGINS` env var.
+- `corsHeaders(req)` — returns CORS headers; respects `ALLOWED_ORIGINS` env var. Every
+  configured origin is expanded to BOTH its apex and its `www.` host (`expandOriginSiblings`),
+  so an allowlist naming only `https://lorekit.io` still admits the canonical
+  `https://www.lorekit.io` the dashboard is served from (the apex 308-redirects to www). `*`
+  passes through unchanged.
 - `handlePreflight(req)` — returns 204 with CORS headers for OPTIONS requests.
 - Emits `Access-Control-Expose-Headers: traceparent`. Every response produced under
   `traceRequest` (`_shared/otel.ts`) carries a `traceparent` header built from the root

--- a/supabase/functions/_shared/api/cors.ts
+++ b/supabase/functions/_shared/api/cors.ts
@@ -1,6 +1,29 @@
 const RAW = Deno.env.get('ALLOWED_ORIGINS') ?? '';
 const IS_PROD = Deno.env.get('VERCEL_ENV') === 'production';
-const ALLOWED: string[] = RAW ? RAW.split(',').map((o) => o.trim()).filter(Boolean) : IS_PROD ? ['https://lorekit.io'] : ['*'];
+const CONFIGURED: string[] = RAW ? RAW.split(',').map((o) => o.trim()).filter(Boolean) : IS_PROD ? ['https://lorekit.io'] : ['*'];
+
+// Expand every configured origin to BOTH its apex and its `www.` host. The
+// dashboard's canonical Vercel domain is https://www.lorekit.io (the apex
+// https://lorekit.io 308-redirects to it), but the allowlist is commonly set to
+// the apex alone — so a browser preflight from the www host was blocked, with no
+// Access-Control-Allow-Origin on the 204. The PostgREST gateway the dashboard
+// used before the REST-client migration applied permissive CORS, which masked
+// this mismatch until the dashboard started calling the edge functions directly.
+// Accepting the sibling host makes the allowlist robust to which of the two is
+// configured. `*` is passed through unchanged.
+function expandOriginSiblings(origin: string): string[] {
+  if (origin === '*') return ['*'];
+  try {
+    const url = new URL(origin);
+    const apexHost = url.host.startsWith('www.') ? url.host.slice(4) : url.host;
+    return [`${url.protocol}//${apexHost}`, `${url.protocol}//www.${apexHost}`];
+  } catch {
+    // Not a parseable origin (e.g. a bare wildcard variant) — keep it verbatim.
+    return [origin];
+  }
+}
+
+const ALLOWED: string[] = Array.from(new Set(CONFIGURED.flatMap(expandOriginSiblings)));
 
 export function corsHeaders(req: Request): Record<string, string> {
   const origin = req.headers.get('Origin') ?? '';


### PR DESCRIPTION
## Problem

After #311 moved the dashboard off PostgREST onto the REST edge functions, the Lore Explorer fails to load with **CORS errors** on every `/memories`, `/memories/scopes` and `/memories/activity` call ("Failed to load lore data. Please refresh the page.").

**Root cause:** the dashboard's canonical Vercel domain is `https://www.lorekit.io` — the apex `https://lorekit.io` **308-redirects to www**. But the edge functions' `ALLOWED_ORIGINS` allowlist names only the apex `https://lorekit.io`. So the browser preflight from the www origin comes back with **no `Access-Control-Allow-Origin`** and is blocked.

Confirmed against the live function:

```
OPTIONS /functions/v1/memories/scopes
  Origin: https://lorekit.io       → 204 + access-control-allow-origin: https://lorekit.io  ✅
  Origin: https://www.lorekit.io   → 204, NO access-control-allow-origin                    ❌
```

Before #311 the browser hit PostgREST, whose Supabase gateway applies permissive CORS — which masked the www/apex mismatch. The strict edge-function allowlist exposed it.

> Note: on Supabase, `VERCEL_ENV` is never set, so `IS_PROD` is always `false` and the code default is dead in prod — the live `ALLOWED_ORIGINS` secret is the only control. The fix therefore broadens the **match**, not the default, so it works regardless of the secret value and deploys through the normal function-deploy pipeline.

## Fix

`corsHeaders` now expands every configured origin to **both** its apex and its `www.` host (`expandOriginSiblings`). An allowlist naming only `https://lorekit.io` admits `https://www.lorekit.io` and vice-versa. `*` is passed through unchanged; unrelated origins (`https://evil.com`) are still rejected.

Shared by all three REST functions (`memories`, `orgs`, `openapi`) via `_shared/api/cors.ts`.

## Testing

- Verified the sibling-matching predicate: apex-config admits www, www-config admits apex, `*` allows all, `evil.com` rejected.
- Follow-up PR will add CI-run unit tests for the origin matcher (edge functions have no Deno test harness today; the pure matcher will be mirrored into `mcp-core` per the repo's `limits.ts` pattern and vitest-tested).

## User-facing docs

None — CORS allowlist matching is internal infra, not a user-configurable surface. Contributor doc (`_shared/api/CLAUDE.md`) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)