### PR TITLE
fix(web): memory badge loading gate + invalidate total on archive/restore

### DIFF
--- a/packages/web/src/components/lore/MemoryExpandButton.tsx
+++ b/packages/web/src/components/lore/MemoryExpandButton.tsx
@@ -83,7 +83,9 @@ export function MemoryExpandButton({
     return memoryTotal;
   }, [data, scope, memoryTotal]);
 
-  if (isLoading || isTotalLoading) {
+  // `total` above reads `memoryTotal` only on the unscoped branch, so a scoped
+  // instance must not block its skeleton on the account-wide count query.
+  if (isLoading || (!scope && isTotalLoading)) {
     return (
       <div
         className={`flex items-center gap-1.5 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-raised)] px-3 py-1.5 ${className}`}

--- a/packages/web/src/components/lore/MemoryExpandButton.tsx
+++ b/packages/web/src/components/lore/MemoryExpandButton.tsx
@@ -37,7 +37,7 @@ export function MemoryExpandButton({
   className = '',
 }: MemoryExpandButtonProps) {
   const { data, isLoading } = useLoreData();
-  const { data: memoryTotal = 0 } = useMemoryTotal();
+  const { data: memoryTotal = 0, isLoading: isTotalLoading } = useMemoryTotal();
   const { openLesson, openLessonById, closeLesson } = useMemorySidebar();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -83,7 +83,7 @@ export function MemoryExpandButton({
     return memoryTotal;
   }, [data, scope, memoryTotal]);
 
-  if (isLoading) {
+  if (isLoading || isTotalLoading) {
     return (
       <div
         className={`flex items-center gap-1.5 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-raised)] px-3 py-1.5 ${className}`}

--- a/packages/web/src/lib/queries/lore.ts
+++ b/packages/web/src/lib/queries/lore.ts
@@ -338,6 +338,7 @@ export function useArchiveLesson() {
       void queryClient.invalidateQueries({ queryKey: ['lore-scopes'] });
       void queryClient.invalidateQueries({ queryKey: ['lore-tags'] });
       void queryClient.invalidateQueries({ queryKey: ['lore'] });
+      void queryClient.invalidateQueries({ queryKey: ['memory-total'] });
       // Invalidate archived list so it picks up the newly archived row.
       void queryClient.invalidateQueries({
         predicate: (q) => q.queryKey[0] === 'memories' && q.queryKey[4] === true,
@@ -375,6 +376,7 @@ export function useRestoreLesson() {
       void queryClient.invalidateQueries({ queryKey: ['lore-scopes'] });
       void queryClient.invalidateQueries({ queryKey: ['lore-tags'] });
       void queryClient.invalidateQueries({ queryKey: ['lore'] });
+      void queryClient.invalidateQueries({ queryKey: ['memory-total'] });
       // Invalidate active list so the restored memory reappears.
       void queryClient.invalidateQueries({
         predicate: (q) => q.queryKey[0] === 'memories' && q.queryKey[4] === false,

--- a/packages/web/src/lib/queries/plan.ts
+++ b/packages/web/src/lib/queries/plan.ts
@@ -5,11 +5,15 @@ import { getPlanUsage } from '@/lib/plan';
 
 /**
  * The caller's total memory count — the SAME figure the /settings/plan page
- * shows, so the two never disagree. It comes from `lorekit_memory_count`
- * (personal active + org-owned active across the caller's orgs), NOT from a
- * paginated list length: the header badge used to count `useLoreData().lessons`,
- * which is only the first page (capped at the API's 100-row maximum), so it
- * stuck at "100 memories" for any larger account.
+ * shows, because both read the shared `lorekit_memory_count` RPC (personal
+ * active + org-owned active across the caller's orgs). NOT a paginated list
+ * length: the header badge used to count `useLoreData().lessons`, which is only
+ * the first page (capped at the API's 100-row maximum), so it stuck at
+ * "100 memories" for any larger account.
+ *
+ * Caveat: `lorekit_memory_count` has no `expires_at` filter, so it can over-count
+ * TTL-expired rows relative to the expiry-aware `lorekit_memory_scopes` /
+ * `lorekit_memory_activity` views the Explorer and heatmap use.
  *
  * `getPlanUsage` returns count + limit + plan in one round-trip; the badge needs
  * only the count. Degrades to 0 when there is no session / the RPC fails, matching


### PR DESCRIPTION
## Why

Three small Overview follow-ups were validated by the review loop on #333 but **dropped from main** — #333 was squash-merged at its pre-loop head, so the loop's later commits never landed. This restores them (base for the stacked Overview-stats redesign).

## What changed

- Header memory badge's loading skeleton now gates on the total query too (`useMemoryTotal`), so it no longer flashes a stale/0 count before the total resolves.
- `useArchiveLesson` / `useRestoreLesson` invalidate `['memory-total']` on settle, so the badge count stays accurate after archiving or restoring a memory.
- Corrected the `useMemoryTotal` docblock: `lorekit_memory_count` has no `expires_at` filter, so it can over-count TTL-expired rows vs the expiry-aware scopes/activity views.

## How to verify

- `pnpm nx typecheck web && pnpm nx test web` (green); badge shows a skeleton until the count loads and updates immediately after archive/restore.

## Notes for reviewers

No `llms.txt`/docs change — internal dashboard behaviour, no route/tool/flag. Touches no visual story (MemoryExpandButton isn't storied), so no baseline regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)