### PR TITLE
fix: address #337 review — restore llms docs, dead doctor branch, CORS Vary

### DIFF
--- a/packages/cli/src/doctor.mjs
+++ b/packages/cli/src/doctor.mjs
@@ -268,11 +268,11 @@ async function checkRemote(control, root, args, record) {
     if (res.networkError) {
       record('fail', 'connectivity', res.networkError);
     } else if (res.ok) {
-      const tools = res.result && Array.isArray(res.result.tools) ? res.result.tools.length : null;
-      // Say what the probe actually proved. `/health` is public, so "reachable"
-      // is a statement about the network path only — the token is judged by the
-      // `authentication` check below.
-      record('pass', 'connectivity', tools !== null ? `reachable, ${tools} tools` : 'reachable (public health probe — token not checked)');
+      // Say what the probe actually proved. `ping()` hits the PUBLIC `/health`
+      // function and returns only `{ ok, httpStatus }` — never a tool list — so
+      // "reachable" is a statement about the network path alone. The token itself
+      // is judged by the `authentication` check below.
+      record('pass', 'connectivity', 'reachable (public health probe — token not checked)');
     } else if (res.error && AUTH_CODES.has(res.error.code)) {
       record('fail', 'connectivity', `auth rejected (${res.error.code}) — check your token`);
     } else if (res.error) {

--- a/packages/mcp-core/src/cors-origins.spec.ts
+++ b/packages/mcp-core/src/cors-origins.spec.ts
@@ -135,6 +135,10 @@ describe('corsResponseHeaders', () => {
       // is what links client-side RUM to the server trace.
       expect(headers['Access-Control-Expose-Headers']).toBe('traceparent, X-LoreKit-Dry-Run');
       expect(headers['Access-Control-Max-Age']).toBe('86400');
+      // Access-Control-Allow-Origin is origin-dependent, so the response MUST
+      // declare it varies by Origin — otherwise a shared cache can serve one
+      // origin's response to another. Present even for a disallowed origin.
+      expect(headers['Vary']).toBe('Origin');
     }
   });
 

--- a/packages/mcp-core/src/cors-origins.ts
+++ b/packages/mcp-core/src/cors-origins.ts
@@ -69,11 +69,19 @@ function isLoopbackOrigin(origin: string): boolean {
 // is what lets a browser read the server span's `traceparent` off the response
 // (traceRequest sets it) so client-side RUM can link to the server trace, plus the
 // dry-run acknowledgement so a client can confirm no-op execution.
+//
+// `Vary: Origin` is mandatory here BECAUSE `Access-Control-Allow-Origin` is
+// origin-dependent (echoed for an allowed origin, absent otherwise). Without it a
+// shared/CDN cache keyed only on the URL could serve one origin's CORS response —
+// including its `Access-Control-Allow-Origin` — to a different origin. It is emitted
+// unconditionally, since the presence/absence of the ACAO header is itself a function
+// of the request Origin even when the origin is disallowed.
 const STATIC_CORS_HEADERS: Readonly<Record<string, string>> = {
   'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type, traceparent, tracestate, X-LoreKit-Dry-Run',
   'Access-Control-Expose-Headers': 'traceparent, X-LoreKit-Dry-Run',
   'Access-Control-Max-Age': '86400',
+  'Vary': 'Origin',
 };
 
 // Build the CORS response headers for one request Origin against an

--- a/packages/schemas/src/llms/template.md
+++ b/packages/schemas/src/llms/template.md
@@ -17,6 +17,26 @@ npx @lorekit/cli install \
 
 5. Verify: `npx @lorekit/cli doctor`
 
+`install` asks whether to wire the Claude Code lifecycle hooks. They inject
+context into the agent — none of them writes memory (the write is still the
+model calling `memory.write`). Three modes, selectable non-interactively with
+`--hooks <mode>`:
+
+- `all` — `SessionStart` (inject lessons) + `PostToolUseFailure` and `Stop`
+  (nudge to record one). Preselected on a fresh install.
+- `read-only` — `SessionStart` only: lessons are injected, nothing ever nudges.
+- `none` — skills + MCP only; memory stays model-invoked.
+
+An interactive re-run preselects whatever is already wired, so it never
+resurrects hooks you declined. `--yes` / a non-TTY run takes that same
+preselected value without asking — `all` on a fresh install, otherwise whatever
+is already wired, and a hand-wired set matching no preset keeps exactly that set
+(no event is added or removed; a stale hook command is still refreshed) — so
+pass `--hooks <mode>` when you need a specific wiring.
+`--hooks none` removes hooks that are already there; the older `--no-hooks` flag
+only skips wiring new ones. `npx @lorekit/cli doctor` reports which events are
+wired and in which scope.
+
 Full self-hosting guide (your own Supabase + Vercel): https://github.com/mthines/lorekit/blob/main/docs/install.md
 
 ## Local mode (offline, no account)
@@ -52,6 +72,13 @@ lk_wo_<32 chars>   # write only
 
 Tokens never expire unless revoked. Stored as SHA-256 hashes — shown once on creation.
 Maximum 20 tokens per account. Generate and revoke at lorekit.io.
+
+A revoked token is rejected with HTTP 401 (`{"error":"Authentication required","code":"unauthorized"}`)
+on REST and `-32001` on MCP. `npx @lorekit/cli doctor` verifies this directly: its
+`connectivity` check probes the public `/health` function (network path only) and its
+`authentication` check makes one authenticated request — `PASS` when the token is accepted
+(including a `lk_wo_*` token answered 403 on a read), `FAIL` on 401. Replace a revoked token
+with `npx @lorekit/cli install --force`, which offers to keep, replace, or remove the stored one.
 
 ### Permission matrix
 

--- a/packages/web/public/llms.txt
+++ b/packages/web/public/llms.txt
@@ -28,6 +28,26 @@ npx @lorekit/cli install \
 
 5. Verify: `npx @lorekit/cli doctor`
 
+`install` asks whether to wire the Claude Code lifecycle hooks. They inject
+context into the agent — none of them writes memory (the write is still the
+model calling `memory.write`). Three modes, selectable non-interactively with
+`--hooks <mode>`:
+
+- `all` — `SessionStart` (inject lessons) + `PostToolUseFailure` and `Stop`
+  (nudge to record one). Preselected on a fresh install.
+- `read-only` — `SessionStart` only: lessons are injected, nothing ever nudges.
+- `none` — skills + MCP only; memory stays model-invoked.
+
+An interactive re-run preselects whatever is already wired, so it never
+resurrects hooks you declined. `--yes` / a non-TTY run takes that same
+preselected value without asking — `all` on a fresh install, otherwise whatever
+is already wired, and a hand-wired set matching no preset keeps exactly that set
+(no event is added or removed; a stale hook command is still refreshed) — so
+pass `--hooks <mode>` when you need a specific wiring.
+`--hooks none` removes hooks that are already there; the older `--no-hooks` flag
+only skips wiring new ones. `npx @lorekit/cli doctor` reports which events are
+wired and in which scope.
+
 Full self-hosting guide (your own Supabase + Vercel): https://github.com/mthines/lorekit/blob/main/docs/install.md
 
 ## Local mode (offline, no account)
@@ -63,6 +83,13 @@ lk_wo_<32 chars>   # write only
 
 Tokens never expire unless revoked. Stored as SHA-256 hashes — shown once on creation.
 Maximum 20 tokens per account. Generate and revoke at lorekit.io.
+
+A revoked token is rejected with HTTP 401 (`{"error":"Authentication required","code":"unauthorized"}`)
+on REST and `-32001` on MCP. `npx @lorekit/cli doctor` verifies this directly: its
+`connectivity` check probes the public `/health` function (network path only) and its
+`authentication` check makes one authenticated request — `PASS` when the token is accepted
+(including a `lk_wo_*` token answered 403 on a read), `FAIL` on 401. Replace a revoked token
+with `npx @lorekit/cli install --force`, which offers to keep, replace, or remove the stored one.
 
 ### Permission matrix
 

--- a/supabase/functions/_shared/api/cors-origins.ts
+++ b/supabase/functions/_shared/api/cors-origins.ts
@@ -54,11 +54,19 @@ function isLoopbackOrigin(origin: string): boolean {
 // is what lets a browser read the server span's `traceparent` off the response
 // (traceRequest sets it) so client-side RUM can link to the server trace, plus the
 // dry-run acknowledgement so a client can confirm no-op execution.
+//
+// `Vary: Origin` is mandatory here BECAUSE `Access-Control-Allow-Origin` is
+// origin-dependent (echoed for an allowed origin, absent otherwise). Without it a
+// shared/CDN cache keyed only on the URL could serve one origin's CORS response —
+// including its `Access-Control-Allow-Origin` — to a different origin. It is emitted
+// unconditionally, since the presence/absence of the ACAO header is itself a function
+// of the request Origin even when the origin is disallowed.
 const STATIC_CORS_HEADERS: Readonly<Record<string, string>> = {
   'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
   'Access-Control-Allow-Headers': 'Authorization, Content-Type, traceparent, tracestate, X-LoreKit-Dry-Run',
   'Access-Control-Expose-Headers': 'traceparent, X-LoreKit-Dry-Run',
   'Access-Control-Max-Age': '86400',
+  'Vary': 'Origin',
 };
 
 // Build the CORS response headers for one request Origin against an


### PR DESCRIPTION
## Why

Follow-up to the three review findings on #337 (now merged). One was a real regression that PR shipped.

## What changed

- **Docs regression (blocking):** #337's `llms.txt` regeneration dropped main's `--hooks` section and #336's doctor `authentication` paragraph — that prose lived only in the committed `llms.txt`, never in `template.md`, so `render.spec` had been silently failing on main and I'd "fixed" it by stripping the content. Moved both blocks into `template.md` and regenerated, so the generator emits them and `committed == generated` holds with the docs intact.
- **`doctor.mjs` dead branch:** `ping()` returns only `{ ok, httpStatus }`, never `result`, so the `reachable, N tools` arm was unreachable — report the network-path-only message unconditionally.
- **CORS `Vary: Origin`:** `corsResponseHeaders` echoes the Origin but carried no `Vary`, so a shared cache could serve one origin's response to another. Added it to both the mcp-core source and its edge mirror, asserted in the shared spec.

## How to verify

- `npx vitest run packages/schemas/src/llms/render.spec.ts packages/mcp-core/src/cors-origins.spec.ts packages/mcp-core/src/edge-parity.spec.ts` and `node --test packages/cli/test/doctor.test.mjs`

## Notes for reviewers

The `render.spec` failure on main predates this PR — it landed via direct-to-main merges that bypass PR CI. This makes the invariant hold going forward.