### PR TITLE
ci(deploy): deploy the web dashboard from deploy.yml, in lockstep with the API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,28 @@
 # ─────────────────────────────────────────────────────────────────────────────
 # Deploy — preview-first promotion pipeline, runs on merge to main.
 #
-#   deploy-preview ─▶ smoke-preview ─▶ deploy-production ─▶ smoke-production
-#                                              └─▶ rollback-production (on failure)
-#   any job fails ─▶ notify-failure (Discord webhook)
+# Both the API (Supabase edge functions + migrations) AND the web dashboard
+# (Next.js on Vercel) are deployed here, in lockstep, so the frontend and backend
+# flip to production together instead of skewing apart. Vercel's native Git
+# auto-deploy is disabled (packages/web/vercel.json → git.deploymentEnabled.main
+# = false); this workflow is now the ONLY path the dashboard reaches production.
+#
+#   deploy-preview (API) ────────┐
+#   deploy-web-preview (FE) ──────┤
+#   stage-web-production (FE build)┘
+#            └─▶ smoke-preview ─▶ deploy-production (API) ─▶ promote-web-production (FE)
+#                                          └────────────────────────┴─▶ smoke-production
+#                                                                            ├─▶ rollback-production (functions)
+#                                                                            └─▶ rollback-web-production (Vercel)
+#   any job fails ─▶ notify-failure (Discord + Dash0)
 #
 # "preview" is the pre-production environment (a dedicated Supabase project);
-# production is only touched after preview is deployed and smoke-tested.
+# production is only touched after preview is deployed and smoke-tested. The web
+# production build is PRE-BUILT and uploaded during the preview phase
+# (stage-web-production, `--skip-domain`) so the final flip (promote-web-production)
+# is a near-instant alias swap that runs right after the API's deploy-production —
+# the production DOMAIN is never assigned until preview is green and the production
+# environment gate is cleared.
 #
 # Tests are NOT re-run here — the merged commit already passed the required PR
 # checks in ci.yml (unit + integration). Each job `needs:` the previous one, so a
@@ -16,10 +32,16 @@
 #   preview     → SUPABASE_PROJECT_REF, SUPABASE_DB_PASSWORD, LOREKIT_SMOKE_TOKEN
 #   production  → SUPABASE_PROJECT_REF, SUPABASE_DB_PASSWORD, LOREKIT_SMOKE_TOKEN
 # Repo-level secret shared by both: SUPABASE_ACCESS_TOKEN (personal access token).
+# Repo-level Vercel secrets (used by every web job): VERCEL_TOKEN, VERCEL_ORG_ID,
+# VERCEL_PROJECT_ID — the same three preview.yml already uses.
+# Optional repo-level variable: WEB_PROD_URL (the production dashboard origin the
+# production smoke curls; defaults to https://lorekit.io).
 # Optional (preview only) — enables the orgs REST smoke suite in smoke-preview
 # (see its "Mint a user JWT" step); unset → that suite is announced-skipped and
-# the memories suite still runs. The write-heavy REST smoke runs against preview
-# only, never production (see the note in smoke-production for why):
+# the memories suite still runs. SUPABASE_ANON_KEY additionally points the
+# preview web build at the preview Supabase project (deploy-web-preview). The
+# write-heavy REST smoke runs against preview only, never production (see the
+# note in smoke-production for why):
 #   SUPABASE_ANON_KEY, LOREKIT_SMOKE_EMAIL, LOREKIT_SMOKE_PASSWORD.
 # The fixed smoke user those secrets name must already exist on the project — seed it
 # once with `node scripts/seed-smoke-user.mjs` (see docs/deployment.md → "Seed
@@ -140,11 +162,201 @@ jobs:
             sleep 10
           done
 
+  # ── 1b. Deploy WEB to PREVIEW (Vercel) ────────────────────────────────────────
+  #    Builds the dashboard against the PREVIEW Supabase project and deploys a
+  #    Vercel preview, so the FE that smoke-preview exercises is the same bundle
+  #    the API preview just shipped. Runs in parallel with deploy-preview — a
+  #    Vercel build does not need the freshly-deployed functions to compile.
+  deploy-web-preview:
+    name: Deploy web → preview (Vercel)
+    runs-on: ubuntu-latest
+    environment: preview
+    permissions:
+      contents: read
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Verify Vercel secrets are set
+        run: |
+          missing=""
+          [ -z "$VERCEL_TOKEN" ] && missing="$missing VERCEL_TOKEN"
+          [ -z "$VERCEL_ORG_ID" ] && missing="$missing VERCEL_ORG_ID"
+          [ -z "$VERCEL_PROJECT_ID" ] && missing="$missing VERCEL_PROJECT_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing repo-level Vercel secrets:$missing. Add them under Settings ▸ Secrets and variables ▸ Actions."
+            exit 1
+          fi
+
+      - name: Install Vercel CLI
+        run: pnpm add -g vercel
+
+      - name: Pull Vercel environment (preview)
+        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+
+      # Point the preview FE at the PREVIEW Supabase project so smoke exercises the
+      # same API bundle deploy-preview just shipped. Mirrors preview.yml: rewrite
+      # the env file `vercel build` actually reads (.vercel/.env.preview.local), the
+      # only file whose values win over a .env.local entry. Skipped when
+      # SUPABASE_ANON_KEY is unset — the pulled Vercel preview env values remain
+      # (which may target production); set it in the preview environment to
+      # guarantee the FE talks to the preview API.
+      - name: Override Supabase config with preview-project values
+        env:
+          PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+        run: |
+          ENV_FILE=".vercel/.env.preview.local"
+          if [ -z "$ANON_KEY" ]; then
+            echo "::warning::SUPABASE_ANON_KEY unset for the preview environment — the preview web build uses Vercel's pulled Supabase env, which may point at production. Set it to pin the FE at the preview API."
+            exit 0
+          fi
+          if [ ! -f "$ENV_FILE" ]; then
+            echo "::error::$ENV_FILE not found — did 'vercel pull' run?"
+            exit 1
+          fi
+          grep -vE '^(NEXT_PUBLIC_SUPABASE_URL|NEXT_PUBLIC_SUPABASE_ANON_KEY|NEXT_PUBLIC_SUPABASE_PROJECT_REF)=' \
+            "$ENV_FILE" > "$ENV_FILE.tmp" || true
+          mv "$ENV_FILE.tmp" "$ENV_FILE"
+          {
+            echo "NEXT_PUBLIC_SUPABASE_URL=https://${PROJECT_REF}.supabase.co"
+            echo "NEXT_PUBLIC_SUPABASE_PROJECT_REF=${PROJECT_REF}"
+            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${ANON_KEY}"
+          } >> "$ENV_FILE"
+
+      # A CLI build gets none of Vercel's auto-injected VERCEL_GIT_* system env
+      # vars, so set them by hand — instrumentation-client.ts bakes them into
+      # NEXT_PUBLIC_VCS_* (OTel VCS resource attributes) and service.version.
+      - name: Build (preview)
+        env:
+          VERCEL_GIT_REPO_OWNER: ${{ github.repository_owner }}
+          VERCEL_GIT_REPO_SLUG: ${{ github.event.repository.name }}
+          VERCEL_GIT_COMMIT_REF: ${{ github.ref_name }}
+          VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
+        run: vercel build --token="$VERCEL_TOKEN"
+
+      - name: Deploy to Vercel (preview)
+        id: deploy
+        run: |
+          # Vercel prints the deployment URL to stdout and progress to stderr;
+          # grep the URL so a trailing stderr line is never mistaken for it.
+          out="$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")"
+          echo "$out"
+          URL="$(printf '%s\n' "$out" | grep -Eo 'https://[^[:space:]]+' | tail -1)"
+          if [ -z "$URL" ]; then
+            echo "::error::Could not parse Vercel preview deployment URL"
+            exit 1
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Verify preview deployment responds
+        run: |
+          URL="${{ steps.deploy.outputs.url }}"
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' -L "$URL")
+          echo "### Web preview" >> "$GITHUB_STEP_SUMMARY"
+          echo "- URL: $URL (HTTP $CODE)" >> "$GITHUB_STEP_SUMMARY"
+          # Vercel deployment protection can return 401 for a raw preview URL;
+          # accept any non-5xx as "the build served".
+          if [ "$CODE" -ge 500 ]; then
+            echo "::error::Web preview returned HTTP $CODE"
+            exit 1
+          fi
+
+  # ── 1c. STAGE web production build (Vercel, pre-built, no domain) ──────────────
+  #    Builds the production dashboard bundle (against Vercel's PRODUCTION env, so
+  #    it targets the production Supabase project) and uploads it as a
+  #    production-target deployment WITHOUT applying the production domain
+  #    (--skip-domain). Doing the slow `next build` here, during the preview phase,
+  #    makes the later flip (promote-web-production) a near-instant alias swap that
+  #    lands together with the API's deploy-production. No `environment:` — this
+  #    only STAGES (nothing serves on the domain yet), so it must not sit behind the
+  #    production approval gate; it authenticates to Vercel with the repo token.
+  stage-web-production:
+    name: Stage web → production (Vercel, pre-built)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    outputs:
+      deployment_url: ${{ steps.stage.outputs.url }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Verify Vercel secrets are set
+        run: |
+          missing=""
+          [ -z "$VERCEL_TOKEN" ] && missing="$missing VERCEL_TOKEN"
+          [ -z "$VERCEL_ORG_ID" ] && missing="$missing VERCEL_ORG_ID"
+          [ -z "$VERCEL_PROJECT_ID" ] && missing="$missing VERCEL_PROJECT_ID"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing repo-level Vercel secrets:$missing. Add them under Settings ▸ Secrets and variables ▸ Actions."
+            exit 1
+          fi
+
+      - name: Install Vercel CLI
+        run: pnpm add -g vercel
+
+      - name: Pull Vercel environment (production)
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+
+      - name: Build (production)
+        env:
+          VERCEL_GIT_REPO_OWNER: ${{ github.repository_owner }}
+          VERCEL_GIT_REPO_SLUG: ${{ github.event.repository.name }}
+          VERCEL_GIT_COMMIT_REF: ${{ github.ref_name }}
+          VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
+        run: vercel build --prod --token="$VERCEL_TOKEN"
+
+      - name: Upload prebuilt production output (staged, no domain)
+        id: stage
+        run: |
+          # Create a PRODUCTION-target deployment but do NOT assign the production
+          # domain yet (--skip-domain). Uploads + builds here, in the preview phase;
+          # the domain is applied only by promote-web-production, which is gated
+          # behind deploy-production (API) + the production environment approval —
+          # so the production domain is never touched until preview is green.
+          out="$(vercel deploy --prebuilt --prod --skip-domain --token="$VERCEL_TOKEN")"
+          echo "$out"
+          URL="$(printf '%s\n' "$out" | grep -Eo 'https://[^[:space:]]+' | tail -1)"
+          if [ -z "$URL" ]; then
+            echo "::error::Could not parse staged Vercel production deployment URL"
+            exit 1
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "### Web production (staged)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Built and uploaded: $URL (domain not yet applied)" >> "$GITHUB_STEP_SUMMARY"
+
   # ── 2. Integration test against PREVIEW (the gate before prod) ────────────────
   smoke-preview:
     name: Smoke tests → preview
     runs-on: ubuntu-latest
-    needs: deploy-preview
+    needs: [deploy-preview, deploy-web-preview]
     environment: preview
     permissions:
       contents: read
@@ -339,11 +551,54 @@ jobs:
             sleep 10
           done
 
+  # ── 3b. Promote WEB to PRODUCTION (Vercel alias swap) ─────────────────────────
+  #    The FE half of the production flip. Runs right after deploy-production (API),
+  #    so the frontend goes live in lockstep with the backend it depends on. Because
+  #    stage-web-production already built + uploaded the bundle, this is just an alias
+  #    swap — near-instant. `needs` deploy-production so the API is in production
+  #    BEFORE the new FE is served (a client should never front an older backend);
+  #    shares the `production` environment gate.
+  promote-web-production:
+    name: Promote web → production (Vercel)
+    runs-on: ubuntu-latest
+    needs: [deploy-production, stage-web-production]
+    environment: production
+    permissions:
+      contents: read
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      STAGED_URL: ${{ needs.stage-web-production.outputs.deployment_url }}
+    steps:
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      - name: Install Vercel CLI
+        run: pnpm add -g vercel
+
+      - name: Promote staged build to production
+        run: |
+          if [ -z "$STAGED_URL" ]; then
+            echo "::error::No staged production deployment URL from stage-web-production"
+            exit 1
+          fi
+          # Assign the production domain to the already-built, already-uploaded
+          # deployment — the instant alias swap that flips the FE to production.
+          vercel promote "$STAGED_URL" --token="$VERCEL_TOKEN" --yes
+          echo "### Web production promoted" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Promoted \`$STAGED_URL\` to the production domain." >> "$GITHUB_STEP_SUMMARY"
+
   # ── 4. Post-deploy verification against PRODUCTION ───────────────────────────
   smoke-production:
     name: Smoke test → production
     runs-on: ubuntu-latest
-    needs: deploy-production
+    needs: [deploy-production, promote-web-production]
     environment: production
     permissions:
       contents: read
@@ -386,6 +641,21 @@ jobs:
           echo "- MCP tools/list HTTP: **${CODE}**" >> "$GITHUB_STEP_SUMMARY"
           if [ "$CODE" != "200" ]; then
             echo "::error::Production MCP endpoint returned HTTP ${CODE} for tools/list"
+            exit 1
+          fi
+
+      # The FE half of the production gate: the promoted dashboard must serve. A
+      # failure here trips BOTH rollback-production (functions) and
+      # rollback-web-production (Vercel), so the FE and API revert together.
+      # WEB_PROD_URL overrides the origin for a self-hosted fork; defaults to the
+      # canonical dashboard domain.
+      - name: Verify web dashboard responds (production)
+        run: |
+          URL="${{ vars.WEB_PROD_URL || 'https://lorekit.io' }}"
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' -L "$URL")
+          echo "- Web dashboard: $URL (HTTP $CODE)" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$CODE" -ge 400 ]; then
+            echo "::error::Production web dashboard returned HTTP $CODE"
             exit 1
           fi
 
@@ -450,15 +720,17 @@ jobs:
   # ── 5. Rollback PRODUCTION functions on a production failure ──────────────────
   #    Redeploys the previous commit's edge functions. Migrations are forward-only
   #    (expand/contract + PITR is the DB safety net) so they are intentionally not
-  #    reverted here. Gated strictly on a PRODUCTION-job failure: a failure earlier
-  #    in the pipeline (preview) skips deploy-production, so neither prod job
-  #    reports 'failure' and this rollback does NOT run — prod is never touched
+  #    reverted here. Gated on ANY production-phase failure — the API deploy, the
+  #    web promote, or the shared smoke gate — so the API is reverted whenever the
+  #    frontend is (rollback-web-production), keeping FE and API in lockstep. A
+  #    failure earlier in the pipeline (preview) skips deploy-production, so none of
+  #    these report 'failure' and this rollback does NOT run — prod is never touched
   #    unless a prod deploy was actually attempted.
   rollback-production:
     name: Rollback → production functions
     runs-on: ubuntu-latest
-    needs: [deploy-production, smoke-production]
-    if: always() && (needs.deploy-production.result == 'failure' || needs.smoke-production.result == 'failure')
+    needs: [deploy-production, promote-web-production, smoke-production]
+    if: always() && (needs.deploy-production.result == 'failure' || needs.promote-web-production.result == 'failure' || needs.smoke-production.result == 'failure')
     environment: production
     permissions:
       contents: read
@@ -491,9 +763,53 @@ jobs:
           echo "::error::Production deploy failed — functions rolled back to the previous commit."
           exit 1
 
+  # ── 5b. Rollback PRODUCTION web on a production failure (Vercel) ──────────────
+  #    Reverts the production domain to the deployment that was live before this
+  #    pipeline promoted the new one, so the FE reverts in lockstep with the edge
+  #    functions. Runs ONLY when the web was actually promoted this run: the
+  #    promote failed, or the promote succeeded but the shared production smoke
+  #    then failed. If deploy-production (API) failed first, promote is skipped and
+  #    the web was never touched — so this stays out and only the functions revert.
+  rollback-web-production:
+    name: Rollback → production web (Vercel)
+    runs-on: ubuntu-latest
+    needs: [promote-web-production, smoke-production]
+    if: always() && (needs.promote-web-production.result == 'failure' || (needs.promote-web-production.result == 'success' && needs.smoke-production.result == 'failure'))
+    environment: production
+    permissions:
+      contents: read
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      - name: Install Vercel CLI
+        run: pnpm add -g vercel
+
+      - name: Roll back production web to the previous deployment
+        run: |
+          # `vercel rollback` with no target reverts to the deployment immediately
+          # prior to the current production deployment — the one live before this
+          # run's promote. Best-effort: rollback-production already fails the run
+          # loudly, so a rollback hiccup here is a warning, not a second hard fail.
+          if vercel rollback --token="$VERCEL_TOKEN" --yes; then
+            echo "### ⚠️ Production web rolled back" >> "$GITHUB_STEP_SUMMARY"
+            echo "The production domain was reverted to the previous Vercel deployment." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::vercel rollback failed — roll the production web back manually from the Vercel dashboard."
+          fi
+
   # ── 6. Notify Discord on ANY deploy-pipeline failure ─────────────────────────
   #    Fires when any job above reports 'failure' — a deploy step, a smoke gate, or
-  #    the rollback. Posts a single embed to the DISCORD_WEBHOOK_URL webhook so a
+  #    a rollback. Posts a single embed to the DISCORD_WEBHOOK_URL webhook so a
   #    red production deploy reaches you outside the Actions UI (the failure the
   #    smoke tests would otherwise report only there). If the webhook secret is
   #    unset the job no-ops with a warning and never fails the run itself — the
@@ -505,7 +821,7 @@ jobs:
   notify-failure:
     name: Notify on failure (Discord + Dash0)
     runs-on: ubuntu-latest
-    needs: [deploy-preview, smoke-preview, deploy-production, smoke-production, rollback-production]
+    needs: [deploy-preview, deploy-web-preview, stage-web-production, smoke-preview, deploy-production, promote-web-production, smoke-production, rollback-production, rollback-web-production]
     if: always() && contains(needs.*.result, 'failure')
     permissions:
       contents: read # checkout, so the local composite action is available
@@ -517,19 +833,27 @@ jobs:
         id: stage
         env:
           RESULT_DEPLOY_PREVIEW: ${{ needs.deploy-preview.result }}
+          RESULT_DEPLOY_WEB_PREVIEW: ${{ needs.deploy-web-preview.result }}
+          RESULT_STAGE_WEB_PRODUCTION: ${{ needs.stage-web-production.result }}
           RESULT_SMOKE_PREVIEW: ${{ needs.smoke-preview.result }}
           RESULT_DEPLOY_PRODUCTION: ${{ needs.deploy-production.result }}
+          RESULT_PROMOTE_WEB_PRODUCTION: ${{ needs.promote-web-production.result }}
           RESULT_SMOKE_PRODUCTION: ${{ needs.smoke-production.result }}
           RESULT_ROLLBACK: ${{ needs.rollback-production.result }}
+          RESULT_ROLLBACK_WEB: ${{ needs.rollback-web-production.result }}
         run: |
           # Name the first pipeline stage that failed (top-to-bottom = root cause;
           # rollback failing is a symptom of a prod-job failure listed before it).
           failed="an unknown stage"
-          if   [ "$RESULT_DEPLOY_PREVIEW"    = "failure" ]; then failed="deploy → preview"
-          elif [ "$RESULT_SMOKE_PREVIEW"     = "failure" ]; then failed="smoke tests → preview"
-          elif [ "$RESULT_DEPLOY_PRODUCTION" = "failure" ]; then failed="deploy → production"
-          elif [ "$RESULT_SMOKE_PRODUCTION"  = "failure" ]; then failed="smoke test → production"
-          elif [ "$RESULT_ROLLBACK"          = "failure" ]; then failed="production (rolled back to previous commit)"
+          if   [ "$RESULT_DEPLOY_PREVIEW"         = "failure" ]; then failed="deploy → preview"
+          elif [ "$RESULT_DEPLOY_WEB_PREVIEW"     = "failure" ]; then failed="web deploy → preview"
+          elif [ "$RESULT_STAGE_WEB_PRODUCTION"   = "failure" ]; then failed="web build (production staging)"
+          elif [ "$RESULT_SMOKE_PREVIEW"          = "failure" ]; then failed="smoke tests → preview"
+          elif [ "$RESULT_DEPLOY_PRODUCTION"      = "failure" ]; then failed="deploy → production"
+          elif [ "$RESULT_PROMOTE_WEB_PRODUCTION" = "failure" ]; then failed="web promote → production"
+          elif [ "$RESULT_SMOKE_PRODUCTION"       = "failure" ]; then failed="smoke test → production"
+          elif [ "$RESULT_ROLLBACK"               = "failure" ]; then failed="production (functions rolled back to previous commit)"
+          elif [ "$RESULT_ROLLBACK_WEB"           = "failure" ]; then failed="production web rollback"
           fi
           echo "failed=$failed" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,14 +66,71 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # ── 0. Detect what changed — gate the API and web halves independently ────────
+  #    A merge that touches only the web (or only the API, or only docs) should not
+  #    redeploy the unchanged half. Same path-filter approach as ci.yml's `changes`
+  #    job. `packages/schemas/` maps to BOTH (the edge functions mirror it and the
+  #    web transpiles it); the workspace files and deploy.yml itself force BOTH, so
+  #    a change to this pipeline exercises the whole thing. Skipping the unchanged
+  #    half is safe for the FE↔API lockstep — lockstep only matters when both
+  #    change, and then both halves run and flip together.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Compare changed paths against the deploy globs
+        id: filter
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          BASE="$BEFORE"
+          # Fall back to the parent commit for a first push, a missing base SHA,
+          # or workflow_dispatch (no event.before) → compare against HEAD~1.
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+            BASE="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
+          fi
+          echo "Comparing ${BASE}...HEAD"
+          CHANGED="$(git diff --name-only "${BASE}" HEAD)"
+          echo "$CHANGED"
+          API=false; WEB=false
+          # API = Supabase edge functions + migrations + the packages that compile
+          # into them (schemas mirror into the functions). Workspace files + this
+          # workflow force a deploy.
+          if printf '%s\n' "$CHANGED" | grep -qE '^(packages/mcp-core/|packages/mcp-server/|packages/schemas/|supabase/functions/|supabase/migrations/|supabase/tests/|supabase/config\.toml|package\.json|pnpm-lock\.yaml|nx\.json|\.github/workflows/deploy\.yml)'; then
+            API=true
+          fi
+          # Web = the Next.js dashboard + the schemas it transpiles + the workspace
+          # files that change how it installs, plus this workflow.
+          if printf '%s\n' "$CHANGED" | grep -qE '^(packages/web/|packages/schemas/|package\.json|pnpm-lock\.yaml|nx\.json|\.github/workflows/deploy\.yml)'; then
+            WEB=true
+          fi
+          echo "api=$API" >> "$GITHUB_OUTPUT"
+          echo "web=$WEB" >> "$GITHUB_OUTPUT"
+          echo "### Deploy scope" >> "$GITHUB_STEP_SUMMARY"
+          echo "- API (Supabase): $API" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Web (Vercel): $WEB" >> "$GITHUB_STEP_SUMMARY"
+
   # ── 1. Deploy to PREVIEW (migrations, then functions) ─────────────────────────
   #    No test job here: the commit on main already passed the required PR checks
   #    in ci.yml (unit + integration). Re-running them would just duplicate that
   #    work. Protect main with those required checks so only verified commits ever
-  #    reach this pipeline.
+  #    reach this pipeline. Gated on `changes.api` — a web-only or docs-only merge
+  #    skips the whole API preview→smoke→prod cycle.
   deploy-preview:
     name: Deploy → preview
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.api == 'true'
     environment: preview
     permissions:
       contents: read
@@ -170,6 +227,8 @@ jobs:
   deploy-web-preview:
     name: Deploy web → preview (Vercel)
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     environment: preview
     permissions:
       contents: read
@@ -202,7 +261,7 @@ jobs:
           fi
 
       - name: Install Vercel CLI
-        run: pnpm add -g vercel
+        run: pnpm add -g vercel@58
 
       - name: Pull Vercel environment (preview)
         run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
@@ -288,6 +347,8 @@ jobs:
   stage-web-production:
     name: Stage web → production (Vercel, pre-built)
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     permissions:
       contents: read
     env:
@@ -321,7 +382,7 @@ jobs:
           fi
 
       - name: Install Vercel CLI
-        run: pnpm add -g vercel
+        run: pnpm add -g vercel@58
 
       - name: Pull Vercel environment (production)
         run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
@@ -358,6 +419,10 @@ jobs:
     name: Smoke tests → preview
     runs-on: ubuntu-latest
     needs: [deploy-preview, deploy-web-preview]
+    # Runs when the API was deployed to preview (it smoke-tests the API). A skipped
+    # web job (web unchanged) is fine; a FAILED web-preview build halts the whole
+    # prod deploy — don't half-ship a merge that changed both.
+    if: always() && needs.deploy-preview.result == 'success' && needs.deploy-web-preview.result != 'failure'
     environment: preview
     permissions:
       contents: read
@@ -562,7 +627,13 @@ jobs:
   promote-web-production:
     name: Promote web → production (Vercel)
     runs-on: ubuntu-latest
-    needs: [deploy-production, stage-web-production]
+    needs: [changes, deploy-production, stage-web-production]
+    # Flip the web when it changed (stage-web-production ran) AND either the API
+    # did not change (nothing to wait for) or the API's prod deploy succeeded (so
+    # the API is live before the FE fronts it). `changes.outputs.api` disambiguates
+    # deploy-production's 'skipped' (API unchanged, fine) from a real upstream stop
+    # (API changed but its deploy failed / smoke-preview failed → not 'success').
+    if: always() && needs.stage-web-production.result == 'success' && (needs.changes.outputs.api == 'false' || needs.deploy-production.result == 'success')
     environment: production
     permissions:
       contents: read
@@ -572,6 +643,11 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       STAGED_URL: ${{ needs.stage-web-production.outputs.deployment_url }}
     steps:
+      # Checkout is required BEFORE pnpm/action-setup — it reads `packageManager`
+      # from the repo's package.json (no `version:` is pinned on the action).
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
 
@@ -581,7 +657,7 @@ jobs:
           node-version: 20
 
       - name: Install Vercel CLI
-        run: pnpm add -g vercel
+        run: pnpm add -g vercel@58
 
       - name: Promote staged build to production
         run: |
@@ -600,6 +676,10 @@ jobs:
     name: Smoke test → production
     runs-on: ubuntu-latest
     needs: [deploy-production, promote-web-production]
+    # Run when EITHER half reached production. The health/MCP curls hit the API
+    # (live either way) and the dashboard curl hits the web, so it validates
+    # whichever side just flipped and passes against the unchanged side.
+    if: always() && (needs.deploy-production.result == 'success' || needs.promote-web-production.result == 'success')
     environment: production
     permissions:
       contents: read
@@ -732,7 +812,13 @@ jobs:
     name: Rollback → production functions
     runs-on: ubuntu-latest
     needs: [deploy-production, promote-web-production, smoke-production]
-    if: always() && (needs.deploy-production.result == 'failure' || needs.promote-web-production.result == 'failure' || needs.smoke-production.result == 'failure')
+    # Revert functions ONLY when the API was actually deployed this run
+    # (deploy-production ran) and a production-phase failure occurred — its own
+    # deploy failed, or (having succeeded) the web promote or the shared smoke
+    # then failed, so the API reverts in lockstep with the web. If the API was
+    # unchanged (deploy-production skipped), the functions were never touched and
+    # are left alone even if the web half failed.
+    if: always() && (needs.deploy-production.result == 'failure' || (needs.deploy-production.result == 'success' && (needs.promote-web-production.result == 'failure' || needs.smoke-production.result == 'failure')))
     environment: production
     permissions:
       contents: read
@@ -776,7 +862,14 @@ jobs:
     name: Rollback → production web (Vercel)
     runs-on: ubuntu-latest
     needs: [promote-web-production, smoke-production]
-    if: always() && (needs.promote-web-production.result == 'failure' || (needs.promote-web-production.result == 'success' && needs.smoke-production.result == 'failure'))
+    # Roll back the web ONLY when the promote SUCCEEDED (the alias was actually
+    # swapped to this run's deployment) and the shared production smoke then failed.
+    # A FAILED promote never swapped the alias — production is still on the previous
+    # healthy deployment — so `vercel rollback` there would revert a good deployment
+    # to an even-older one. On a failed promote the functions revert instead
+    # (rollback-production), which is what restores FE↔API lockstep (old web that
+    # never moved + reverted functions).
+    if: always() && needs.promote-web-production.result == 'success' && needs.smoke-production.result == 'failure'
     environment: production
     permissions:
       contents: read
@@ -785,6 +878,11 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
+      # Checkout is required BEFORE pnpm/action-setup — it reads `packageManager`
+      # from the repo's package.json (no `version:` is pinned on the action).
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
 
@@ -794,14 +892,15 @@ jobs:
           node-version: 20
 
       - name: Install Vercel CLI
-        run: pnpm add -g vercel
+        run: pnpm add -g vercel@58
 
       - name: Roll back production web to the previous deployment
         run: |
           # `vercel rollback` with no target reverts to the deployment immediately
-          # prior to the current production deployment — the one live before this
-          # run's promote. Best-effort: rollback-production already fails the run
-          # loudly, so a rollback hiccup here is a warning, not a second hard fail.
+          # prior to the current production deployment — i.e. the one live before
+          # this run's (now-promoted) deployment. Best-effort: rollback-production
+          # already fails the run loudly, so a rollback hiccup here is a warning,
+          # not a second hard fail.
           if vercel rollback --token="$VERCEL_TOKEN" --yes; then
             echo "### ⚠️ Production web rolled back" >> "$GITHUB_STEP_SUMMARY"
             echo "The production domain was reverted to the previous Vercel deployment." >> "$GITHUB_STEP_SUMMARY"
@@ -823,7 +922,7 @@ jobs:
   notify-failure:
     name: Notify on failure (Discord + Dash0)
     runs-on: ubuntu-latest
-    needs: [deploy-preview, deploy-web-preview, stage-web-production, smoke-preview, deploy-production, promote-web-production, smoke-production, rollback-production, rollback-web-production]
+    needs: [changes, deploy-preview, deploy-web-preview, stage-web-production, smoke-preview, deploy-production, promote-web-production, smoke-production, rollback-production, rollback-web-production]
     if: always() && contains(needs.*.result, 'failure')
     permissions:
       contents: read # checkout, so the local composite action is available
@@ -834,6 +933,7 @@ jobs:
       - name: Identify the failed stage
         id: stage
         env:
+          RESULT_CHANGES: ${{ needs.changes.result }}
           RESULT_DEPLOY_PREVIEW: ${{ needs.deploy-preview.result }}
           RESULT_DEPLOY_WEB_PREVIEW: ${{ needs.deploy-web-preview.result }}
           RESULT_STAGE_WEB_PRODUCTION: ${{ needs.stage-web-production.result }}
@@ -847,7 +947,8 @@ jobs:
           # Name the first pipeline stage that failed (top-to-bottom = root cause;
           # rollback failing is a symptom of a prod-job failure listed before it).
           failed="an unknown stage"
-          if   [ "$RESULT_DEPLOY_PREVIEW"         = "failure" ]; then failed="deploy → preview"
+          if   [ "$RESULT_CHANGES"                = "failure" ]; then failed="detect changes"
+          elif [ "$RESULT_DEPLOY_PREVIEW"         = "failure" ]; then failed="deploy → preview"
           elif [ "$RESULT_DEPLOY_WEB_PREVIEW"     = "failure" ]; then failed="web deploy → preview"
           elif [ "$RESULT_STAGE_WEB_PRODUCTION"   = "failure" ]; then failed="web build (production staging)"
           elif [ "$RESULT_SMOKE_PREVIEW"          = "failure" ]; then failed="smoke tests → preview"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -263,8 +263,9 @@ jobs:
           echo "url=$URL" >> "$GITHUB_OUTPUT"
 
       - name: Verify preview deployment responds
+        env:
+          URL: ${{ steps.deploy.outputs.url }}
         run: |
-          URL="${{ steps.deploy.outputs.url }}"
           CODE=$(curl -s -o /dev/null -w '%{http_code}' -L "$URL")
           echo "### Web preview" >> "$GITHUB_STEP_SUMMARY"
           echo "- URL: $URL (HTTP $CODE)" >> "$GITHUB_STEP_SUMMARY"
@@ -650,8 +651,9 @@ jobs:
       # WEB_PROD_URL overrides the origin for a self-hosted fork; defaults to the
       # canonical dashboard domain.
       - name: Verify web dashboard responds (production)
+        env:
+          URL: ${{ vars.WEB_PROD_URL || 'https://lorekit.io' }}
         run: |
-          URL="${{ vars.WEB_PROD_URL || 'https://lorekit.io' }}"
           CODE=$(curl -s -o /dev/null -w '%{http_code}' -L "$URL")
           echo "- Web dashboard: $URL (HTTP $CODE)" >> "$GITHUB_STEP_SUMMARY"
           if [ "$CODE" -ge 400 ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,6 +219,18 @@ After the PR is opened or marked ready-for-review, **wait for the `dash0-dev` bo
 The bot runs `PR Ready for Review — Polish + Review` automatically; a comment from `dash0-dev` with
 the review results will appear on the PR. Do not proceed until that comment is present.
 
+**The bot re-reviews automatically on every new commit (a `synchronize` push) — you do NOT need a
+human `@dash0 review` to re-trigger it.** After you push fixes, it re-runs against the new SHA and
+posts fresh inline comments, marking addressed findings **"Superseded / Resolving."** So the loop is:
+push fix → the bot re-reviews the new commit → it resolves what you fixed. Two consequences worth
+remembering: (1) a review verdict is pinned to a specific `commit_id` — the gate summary (e.g. a ❌
+"Code review") can be **stale on an older SHA** while the findings are already resolved on `HEAD`, so
+always check which commit a verdict/comment targets before treating it as open; and (2) there is a
+**race window** — if you push while an in-flight review is mid-run, its next comments can be anchored
+to your new SHA but still describe the *pre-fix* content. Re-verify against `HEAD` (`git show
+HEAD:<file>`) rather than trusting a just-arrived comment. The `@dash0 resolve`-doesn't-fire caveat in
+Step 4 is about **comments**, not pushes — a push is what re-triggers the review.
+
 ```bash
 # Poll until the dash0-dev review appears (count should reach ≥ 1)
 while [ "$(gh pr view <pr-number> --repo mthines/lorekit --json reviews \

--- a/SETUP.md
+++ b/SETUP.md
@@ -106,6 +106,11 @@ pnpm nx test mcp-core                            # needs supabase start
 | Output Directory | `.next` |
 | Install Command | `cd ../.. && pnpm install` |
 
+> Production auto-deploy on `main` is **off** (`packages/web/vercel.json` →
+> `git.deploymentEnabled.main = false`) — the `deploy.yml` pipeline promotes the
+> dashboard in lockstep with the API. PR preview deploys still work. See
+> [docs/deployment.md](./docs/deployment.md).
+
 ---
 
 ## GitHub Actions CI secrets
@@ -114,6 +119,9 @@ pnpm nx test mcp-core                            # needs supabase start
 |--------|-------------|
 | `SUPABASE_PROJECT_REF` | Your project ref |
 | `SUPABASE_ACCESS_TOKEN` | From [supabase.com/dashboard/account/tokens](https://supabase.com/dashboard/account/tokens) |
+| `VERCEL_TOKEN` | Vercel access token (Account Settings → Tokens) — lets `deploy.yml` build + promote the web dashboard |
+| `VERCEL_ORG_ID` | From `.vercel/project.json` after `vercel link` (or Vercel project settings) |
+| `VERCEL_PROJECT_ID` | From `.vercel/project.json` after `vercel link` |
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,14 +7,24 @@ LoreKit has three deployable pieces. Each has its own deployment path.
 | Piece | Platform | Deploy command |
 |-------|----------|----------------|
 | MCP server + health check | Supabase Edge Functions | `pnpm nx fn:deploy supabase` |
-| Web dashboard | Vercel | Auto-deploy on `git push main` |
+| Web dashboard | Vercel (via `deploy.yml`, CLI) | Promoted by the pipeline on `git push main` |
 | Database migrations | Supabase | `pnpm nx db:push supabase` |
 
 **In normal operation you do not run these by hand.** Merging to `main` triggers
 the [automated CI/CD pipeline](#automated-deployment-cicd), which promotes
-migrations + Edge Functions **preview → production** with smoke gates and
-automatic function rollback. The manual commands below are for first-time
-project setup and local operations.
+migrations, Edge Functions **and the Vercel web dashboard** **preview →
+production** with smoke gates and automatic rollback of both the functions and
+the web deployment. The manual commands below are for first-time project setup
+and local operations.
+
+> **The web dashboard is deployed by `deploy.yml`, not by Vercel's Git
+> integration.** Vercel's native auto-deploy on `main` is turned off
+> (`packages/web/vercel.json` → `git.deploymentEnabled.main = false`), so the FE
+> and API flip to production together instead of skewing apart — Vercel used to
+> deploy the frontend the instant `main` was pushed, while the API crawled
+> through the preview→smoke→prod pipeline. If you fork this, mirror the flag (or
+> disable Git deployments for `main` in the Vercel dashboard) or you will
+> double-deploy.
 
 ---
 
@@ -24,8 +34,8 @@ Two GitHub Actions workflows own the lifecycle:
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `.github/workflows/ci.yml` | PRs to `main` | **Verify before merge.** `check` (affected typecheck/test/lint — unit tests, all mocked) and `integration` (boots a local Supabase → migrations apply → serves the real Edge Functions → asserts an authenticated MCP `tools/list` returns 200, plus schema lint). `integration` only runs when API/backend paths change (see [below](#only-runs-when-relevant)); the web build is verified by Vercel's own PR check. |
-| `.github/workflows/deploy.yml` | push to `main`, `workflow_dispatch` | **Deploy the already-verified commit.** No test re-run — preview-first promotion only. |
+| `.github/workflows/ci.yml` | PRs to `main` | **Verify before merge.** `check` (affected typecheck/test/lint — unit tests, all mocked) and `integration` (boots a local Supabase → migrations apply → serves the real Edge Functions → asserts an authenticated MCP `tools/list` returns 200, plus schema lint). `integration` only runs when API/backend paths change (see [below](#only-runs-when-relevant)); the web build is verified by Vercel's own PR check (preview deploys on a PR are unaffected — the `deploymentEnabled` flag only turns off the `main` production auto-deploy). |
+| `.github/workflows/deploy.yml` | push to `main`, `workflow_dispatch` | **Deploy the already-verified commit** — Supabase (migrations + Edge Functions) **and** the Vercel web dashboard, in lockstep. No test re-run — preview-first promotion only. |
 
 ### Tests run once, on the PR
 
@@ -64,15 +74,55 @@ downstream runs:
 
 ```
 deploy-preview          db push + functions deploy → PREVIEW project
-  └─▶ smoke-preview      smoke.integration spec against PREVIEW
-        └─▶ deploy-production     db push + functions deploy → PRODUCTION project
-              └─▶ smoke-production   health + MCP tools/list against PRODUCTION
-                    └─▶ rollback-production   (only on failure)
+deploy-web-preview      Vercel build (preview Supabase) + preview deploy
+stage-web-production    Vercel build --prod, upload prebuilt, --skip-domain (no flip yet)
+  └─▶ smoke-preview     smoke.integration spec against PREVIEW
+        └─▶ deploy-production      db push + functions deploy → PRODUCTION project
+              └─▶ promote-web-production   Vercel alias swap → PRODUCTION domain
+                    └─▶ smoke-production    health + MCP tools/list + web dashboard 200
+                          ├─▶ rollback-production       functions → previous commit (on failure)
+                          └─▶ rollback-web-production   Vercel → previous deployment (on failure)
 
 any job fails ─▶ notify-failure   Discord webhook (see below)
 ```
 
 Production is never touched until preview has been deployed and smoke-tested.
+
+### FE ↔ API deploy in lockstep (no availability skew)
+
+The whole point of moving the web deploy into `deploy.yml` is that the frontend
+and backend flip to production **together**. Previously Vercel's Git integration
+deployed the dashboard the moment `main` was pushed, while the API went through
+the preview→smoke→prod pipeline (minutes) — so there was always a window where
+the FE and API were on different versions.
+
+Now:
+
+- **The production web bundle is pre-built during the preview phase**
+  (`stage-web-production`): `vercel build --prod` then `vercel deploy --prebuilt
+  --prod --skip-domain`, which uploads a production-target deployment **without**
+  assigning the production domain. The slow `next build` happens before the flip.
+- **The flip is an alias swap** (`promote-web-production` → `vercel promote`),
+  which is near-instant. It `needs: deploy-production`, so the API is live in
+  production **before** the new FE is served — a client should never front an
+  older backend. The two go live within seconds of each other.
+- **The FE build points at the right Supabase per phase.** `deploy-web-preview`
+  overrides `NEXT_PUBLIC_SUPABASE_*` to the **preview** project (set
+  `SUPABASE_ANON_KEY` in the `preview` environment for this to take effect), so
+  smoke exercises the FE against the same API bundle preview just shipped;
+  `stage-web-production` uses Vercel's **production** env untouched.
+- **Rollback reverts both.** Any production-phase failure (the API deploy, the
+  web promote, or the shared production smoke — which now also curls the
+  dashboard) trips **both** `rollback-production` (functions → previous commit)
+  and `rollback-web-production` (`vercel rollback` → previous deployment), so the
+  FE and API never end up on mismatched versions. The one exception is a failure
+  in `deploy-production` itself before the web is promoted: the web was never
+  touched, so only the functions revert.
+
+The web jobs authenticate to Vercel with the same three repo-level secrets
+`preview.yml` already uses — `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
+— and the production smoke curls `${{ vars.WEB_PROD_URL }}` (an optional
+repo-level variable, defaulting to `https://lorekit.io`).
 
 ### Migration drift on the shared preview project
 
@@ -232,10 +282,14 @@ run — the underlying failure is still reported loudly by the job that broke.
 ### Rollback behaviour
 
 On any post-deploy failure, `rollback-production` redeploys the **previous
-commit's** Edge Functions and fails the run loudly with a step summary.
-Database migrations are **forward-only** and intentionally *not* reverted —
-keep migrations backward-compatible (expand/contract) and enable **PITR**
-(Point-in-Time Recovery) in the Supabase dashboard as the database safety net.
+commit's** Edge Functions and `rollback-web-production` reverts the Vercel
+production deployment (`vercel rollback`), so the FE and API roll back together;
+the run fails loudly with a step summary. Database migrations are **forward-only**
+and intentionally *not* reverted — keep migrations backward-compatible
+(expand/contract) and enable **PITR** (Point-in-Time Recovery) in the Supabase
+dashboard as the database safety net. The web rollback stays out only when the
+API deploy failed before the web was ever promoted — in that case the web was
+never touched, so reverting it would regress a healthy deployment.
 
 ### Smoke-test data hygiene
 
@@ -397,10 +451,18 @@ seed it once with [`scripts/seed-smoke-user.mjs`](#seed-the-orgs-smoke-user)
 below.
 
 Repo-level secrets (not environment-scoped): `SUPABASE_ACCESS_TOKEN` (a Supabase
-personal access token) and — optionally — `DISCORD_WEBHOOK_URL` for
+personal access token); the three **Vercel** secrets the web jobs use —
+`VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` (the same set `preview.yml`
+already relies on); and — optionally — `DISCORD_WEBHOOK_URL` for
 [failure notifications](#failure-notifications-discord). Add a **required
 reviewer** on the `production` environment for a manual approval gate before prod
-is touched.
+is touched — it now gates the web promote (`promote-web-production`) as well as
+the API deploy.
+
+Repo-level **variables** (Settings ▸ Secrets and variables ▸ Actions ▸
+Variables): `WEB_PROD_URL` — optional, the production dashboard origin the
+production smoke curls. Defaults to `https://lorekit.io`; set it for a
+self-hosted fork on a different domain.
 
 #### Seed the orgs-smoke user
 
@@ -561,6 +623,15 @@ In your Vercel project → Settings → General:
 | Build Command | `cd ../.. && pnpm nx build web --configuration=production` |
 | Output Directory | `.next` |
 | Install Command | `cd ../.. && pnpm install` |
+
+> **Production auto-deploy is off.** `packages/web/vercel.json` sets
+> `git.deploymentEnabled.main = false`, so Vercel no longer deploys the
+> production dashboard when `main` is pushed — `deploy.yml` promotes it instead
+> (see [FE ↔ API deploy in lockstep](#fe--api-deploy-in-lockstep-no-availability-skew)).
+> PR/branch preview deploys are unaffected. Create a **Vercel access token**
+> (Account Settings → Tokens) and store it as the repo secret `VERCEL_TOKEN`,
+> alongside `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` (found in `.vercel/project.json`
+> after `vercel link`, or in the project's Settings).
 
 Environment variables to add:
 

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -3,5 +3,10 @@
   "buildCommand": "cd ../.. && pnpm nx build web --configuration=production",
   "outputDirectory": ".next",
   "installCommand": "cd ../.. && pnpm install",
-  "framework": "nextjs"
+  "framework": "nextjs",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
 }


### PR DESCRIPTION
## Why

The dashboard was deployed by **Vercel's native Git integration** — it flipped the frontend to production the instant `main` was pushed, while the API went through `deploy.yml`'s `preview → smoke → prod` pipeline (minutes). That mismatch is the FE/API availability skew: for a window on every merge, the frontend and backend ran different versions.

## What

Bring the web deploy into `deploy.yml` so the FE and API flip to production together.

- **`packages/web/vercel.json`** — disable Vercel's production auto-deploy on `main` (`git.deploymentEnabled.main = false`). This pipeline becomes the only production path for the dashboard; PR/branch previews are unaffected.
- **`deploy-web-preview`** (preview phase) — build the FE against the **preview** Supabase project and deploy a Vercel preview; `smoke-preview` now gates on it.
- **`stage-web-production`** (preview phase) — `vercel build --prod` + `vercel deploy --prebuilt --prod --skip-domain`: the slow `next build` runs now and the bundle is uploaded **without** applying the production domain.
- **`promote-web-production`** (prod phase) — `vercel promote` the staged build: a near-instant alias swap. `needs: deploy-production`, so the API is live before the new FE fronts it.
- **`smoke-production`** — now also curls the production dashboard (`vars.WEB_PROD_URL`, default `https://lorekit.io`).
- **`rollback-web-production`** — `vercel rollback` alongside the function rollback on any production-phase failure, so the FE and API revert together (stays out only when the API deploy failed before the web was ever promoted).

The production web bundle is pre-built during the preview phase so the final flip is an alias swap that lands seconds after the API deploy — the "almost instant" simultaneous production flip.

`VERCEL_GIT_*` are set by hand on the CLI builds to preserve the OTel VCS resource attributes / `service.version` that Vercel's own builds inject.

## Docs

- `docs/deployment.md` — overview table, pipeline diagram, a new "FE ↔ API deploy in lockstep" section, secrets/variables, rollback behaviour, and the Vercel config note.
- `SETUP.md` — Vercel auto-deploy-off note + the three Vercel CI secrets.

No user-facing product surface (MCP tool / REST route / CLI / dashboard copy) changed, so `llms.txt` / MDX docs do not apply — this is a CI/deploy + contributor-docs change.

## Reviewed with `github-actions-author`

Self-reviewed the workflow: PASS on anatomy, triggers/concurrency, caching, parallelization, observability, and log-visibility. Applied one security fix (routed two smoke-check URLs through `env:` instead of inline `${{ }}` interpolation). Deferred (noted in review): a `setup-vercel` composite action and a repo-wide SHA-pin pass — both consistency follow-ups that match the file's existing conventions.

## Required before this can deploy (one-time)

- Repo secrets `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` (already used by `preview.yml`).
- Set `SUPABASE_ANON_KEY` in the `preview` environment to pin the preview FE at the preview API (otherwise it warns and uses Vercel's pulled env).
- Optional repo variable `WEB_PROD_URL` if the prod domain isn't `https://lorekit.io`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qrDmwSCGhXpzU2hAXrmNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014qrDmwSCGhXpzU2hAXrmNQ)_