### PR TITLE
test(smoke): make live-smoke cleanup resilient so a teardown flake can't fail a deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -450,7 +450,21 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run integration test against preview endpoint
-        run: pnpm nx test mcp-server -- smoke.integration
+        # Retry once on a transient live-endpoint flake before failing the deploy.
+        # The suite self-cleans and re-mints keys per run, so a re-run is safe; a
+        # real regression still fails after the second attempt. (The specs' own
+        # teardown is also soft-bounded so a slow sweep never fails a green run.)
+        run: |
+          for attempt in 1 2; do
+            pnpm nx test mcp-server -- smoke.integration && break
+            rc=$?
+            if [ "$attempt" -eq 2 ]; then
+              echo "::error::smoke.integration failed after $attempt attempts"
+              exit "$rc"
+            fi
+            echo "::warning::smoke.integration failed (attempt $attempt/2) — retrying in 10s (transient live-endpoint flake)..."
+            sleep 10
+          done
         env:
           LOREKIT_SMOKE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co/functions/v1/mcp
           LOREKIT_SMOKE_TOKEN: ${{ secrets.LOREKIT_SMOKE_TOKEN }}
@@ -537,7 +551,20 @@ jobs:
           LOREKIT_REST_BASE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co/functions/v1
           LOREKIT_SMOKE_TOKEN: ${{ secrets.LOREKIT_SMOKE_TOKEN }}
           LOREKIT_SMOKE_JWT: ${{ steps.smokejwt.outputs.jwt }}
-        run: node scripts/smoke-rest.mjs
+        # Retry once on a transient live-endpoint flake. The specs self-clean with
+        # per-run timestamped keys, so a re-run is safe; a real failure still fails
+        # after the second attempt.
+        run: |
+          for attempt in 1 2; do
+            node scripts/smoke-rest.mjs && break
+            rc=$?
+            if [ "$attempt" -eq 2 ]; then
+              echo "::error::REST smoke failed after $attempt attempts"
+              exit "$rc"
+            fi
+            echo "::warning::REST smoke failed (attempt $attempt/2) — retrying in 10s (transient live-endpoint flake)..."
+            sleep 10
+          done
 
       - name: Smoke cleanup — sweep orphaned artefacts from preview
         if: always()

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -286,7 +286,20 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run MCP server smoke tests
-        run: pnpm nx test mcp-server -- smoke.integration
+        # Retry once on a transient live-endpoint flake (kept in lockstep with
+        # deploy.yml's smoke-preview). The suite self-cleans and re-mints keys per
+        # run, so a re-run is safe; a real regression still fails after attempt 2.
+        run: |
+          for attempt in 1 2; do
+            pnpm nx test mcp-server -- smoke.integration && break
+            rc=$?
+            if [ "$attempt" -eq 2 ]; then
+              echo "::error::smoke.integration failed after $attempt attempts"
+              exit "$rc"
+            fi
+            echo "::warning::smoke.integration failed (attempt $attempt/2) — retrying in 10s (transient live-endpoint flake)..."
+            sleep 10
+          done
         env:
           LOREKIT_SMOKE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co/functions/v1/mcp
           LOREKIT_SMOKE_TOKEN: ${{ secrets.LOREKIT_SMOKE_TOKEN }}
@@ -363,7 +376,19 @@ jobs:
           LOREKIT_REST_BASE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co/functions/v1
           LOREKIT_SMOKE_TOKEN: ${{ secrets.LOREKIT_SMOKE_TOKEN }}
           LOREKIT_SMOKE_JWT: ${{ steps.smokejwt.outputs.jwt }}
-        run: node scripts/smoke-rest.mjs
+        # Retry once on a transient live-endpoint flake (lockstep with deploy.yml).
+        # Specs self-clean with per-run timestamped keys, so a re-run is safe.
+        run: |
+          for attempt in 1 2; do
+            node scripts/smoke-rest.mjs && break
+            rc=$?
+            if [ "$attempt" -eq 2 ]; then
+              echo "::error::REST smoke failed after $attempt attempts"
+              exit "$rc"
+            fi
+            echo "::warning::REST smoke failed (attempt $attempt/2) — retrying in 10s (transient live-endpoint flake)..."
+            sleep 10
+          done
 
   report:
     name: Post result comment

--- a/packages/mcp-server/src/byod-smoke.integration.spec.ts
+++ b/packages/mcp-server/src/byod-smoke.integration.spec.ts
@@ -20,7 +20,12 @@
  */
 
 import { describe, it, expect, afterAll } from 'vitest';
-import { createSmokeNamespace, describeSweepFailures, sweepSmokeArtefacts } from './smoke-cleanup.js';
+import {
+  createSmokeNamespace,
+  describeSweepFailures,
+  runBestEffortCleanup,
+  sweepSmokeArtefacts,
+} from './smoke-cleanup.js';
 
 const BASE_URL = (process.env['LOREKIT_BYOD_URL'] ?? '').replace(/\/$/, '');
 const TOKEN    = process.env['LOREKIT_BYOD_TOKEN'];
@@ -114,23 +119,28 @@ describe.skipIf(SKIP)('LoreKit BYOD smoke tests (integration)', () => {
   // Best-effort cleanup — run regardless of pass/fail so the BYOD project
   // stays tidy across repeated CI runs.
   afterAll(async () => {
-    // `Promise.allSettled` used to swallow every rejection here, so a BYOD
-    // project could accumulate rows run after run with nothing in the log to
-    // say so. The sweep is sequential (a live endpoint with a per-user rate
-    // limit) and names whatever it could not remove.
     // Keyed by the memory key (what a leak is actually named), with the scope
     // recovered from it, so a reported leftover can be pasted straight into a
     // manual delete.
     const scopeOfKey = new Map<string, string>(
       (Object.keys(SCOPES) as ScopeName[]).map((s) => [keys[s], SCOPES[s]]),
     );
-    const report = await sweepSmokeArtefacts([...scopeOfKey.keys()], async (key) => {
-      await mcpCall('memory.delete', { scope: scopeOfKey.get(key), key, force: true });
-    });
-    // `sweeperCovers: false` — the orphan sweeper targets LOREKIT_REST_BASE_URL,
-    // and this suite writes to its own project (LOREKIT_BYOD_URL) over MCP.
-    const warning = describeSweepFailures(report, 'BYOD smoke', { sweeperCovers: false });
-    if (warning) console.warn(warning);
+    // The sweep runs with bounded concurrency (see sweepSmokeArtefacts), wrapped
+    // in runBestEffortCleanup so a slow teardown against the BYOD endpoint warns
+    // and yields instead of failing a green run. `sweeperCovers: false` — the
+    // orphan sweeper targets LOREKIT_REST_BASE_URL, and this suite writes to its
+    // own project (LOREKIT_BYOD_URL) over MCP, so a leftover must be deleted by
+    // hand (named in the warning).
+    await runBestEffortCleanup(
+      async () => {
+        const report = await sweepSmokeArtefacts([...scopeOfKey.keys()], async (key) => {
+          await mcpCall('memory.delete', { scope: scopeOfKey.get(key), key, force: true });
+        });
+        const warning = describeSweepFailures(report, 'BYOD smoke', { sweeperCovers: false });
+        if (warning) console.warn(warning);
+      },
+      { softTimeoutMs: 20_000, context: 'BYOD smoke' },
+    );
   }, 30_000);
 
   // ── 1. Write — all four scope types in parallel ──────────────────────────────

--- a/packages/mcp-server/src/memories-api.integration.spec.ts
+++ b/packages/mcp-server/src/memories-api.integration.spec.ts
@@ -19,6 +19,7 @@ import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import {
   createSmokeNamespace,
   describeSweepFailures,
+  runBestEffortCleanup,
   sweepSmokeArtefacts,
   type SmokeNamespace,
 } from './smoke-cleanup.js';
@@ -115,6 +116,10 @@ async function listKeys(archived: boolean): Promise<unknown[]> {
 // succeeds; locally each round-trip is sub-ms so this never bites. 30s is the
 // ceiling per test, not an expected duration.
 const REMOTE_TEST_TIMEOUT = 30_000;
+// Best-effort teardown self-bounds below the hook ceiling above, so a slow
+// sweep against a laggy live endpoint warns and yields instead of timing out
+// the hook and failing a green run. Kept under REMOTE_TEST_TIMEOUT with margin.
+const CLEANUP_SOFT_TIMEOUT = 20_000;
 
 /**
  * Hard-delete one key by its NATURAL key.
@@ -155,10 +160,15 @@ describe.skipIf(SKIP)('LoreKit memories API — smoke tests (integration)', { ti
     // key whose test threw before the assignment; those rows accumulated in the
     // live project on every deploy.
     //
-    // Hooks use hookTimeout (10s default), NOT the suite `timeout` above — and
-    // this chains one DELETE per key at hosted latency, so give it the same 30s
-    // ceiling as the tests.
-    await sweepMintedKeys(NS, 'memories REST smoke');
+    // The sweep runs with bounded concurrency (see sweepSmokeArtefacts), and
+    // runBestEffortCleanup soft-bounds it below the hook ceiling — so a laggy
+    // live endpoint can never make cleanup time out the hook and fail a run
+    // whose assertions all passed. Anything left is caught by the always-on
+    // scripts/smoke-cleanup.mjs sweep.
+    await runBestEffortCleanup(() => sweepMintedKeys(NS, 'memories REST smoke'), {
+      softTimeoutMs: CLEANUP_SOFT_TIMEOUT,
+      context: 'memories REST smoke',
+    });
   }, REMOTE_TEST_TIMEOUT);
 
   // 1. list — baseline ────────────────────────────────────────────────────────
@@ -995,7 +1005,10 @@ describe.skipIf(SKIP)('LoreKit memories API — audit trail read-back (integrati
     // By key, not by `auditId`: the id is only set once the create test has
     // asserted its way to the end, so a failure anywhere before that left the
     // row behind. The key exists from the moment it was minted.
-    await sweepMintedKeys(AUDIT_NS, 'memories REST audit read-back');
+    await runBestEffortCleanup(() => sweepMintedKeys(AUDIT_NS, 'memories REST audit read-back'), {
+      softTimeoutMs: CLEANUP_SOFT_TIMEOUT,
+      context: 'memories REST audit read-back',
+    });
   }, REMOTE_TEST_TIMEOUT);
 
   it('the audit_log capability probe ran and reported a definite result', () => {

--- a/packages/mcp-server/src/orgs-api.integration.spec.ts
+++ b/packages/mcp-server/src/orgs-api.integration.spec.ts
@@ -29,7 +29,7 @@
  */
 
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
-import { createSmokeNamespace } from './smoke-cleanup.js';
+import { createSmokeNamespace, runBestEffortCleanup } from './smoke-cleanup.js';
 
 const BASE = (process.env['LOREKIT_REST_BASE_URL'] ?? 'http://localhost:54321/functions/v1').replace(/\/$/, '');
 const JWT = process.env['LOREKIT_SMOKE_JWT'];
@@ -97,6 +97,10 @@ async function restFetch(
 // vitest's 5s default at hosted latency though each call succeeds. Ceiling per
 // test, not an expected duration; sub-ms locally so it never bites there.
 const REMOTE_TEST_TIMEOUT = 30_000;
+// Best-effort teardown self-bounds below the hook ceiling: a purge against a
+// laggy live endpoint warns and yields instead of timing out the hook and
+// failing a run whose assertions passed. See runBestEffortCleanup.
+const CLEANUP_SOFT_TIMEOUT = 20_000;
 
 /**
  * ── Org cleanup: PURGE, never DELETE ─────────────────────────────────────────
@@ -176,9 +180,12 @@ describe.skipIf(SKIP)('LoreKit orgs API — smoke tests (integration)', { timeou
   afterAll(async () => {
     // Purge, not delete — see purgeOrg. The old `DELETE` left a soft-deleted org
     // in the live project on every single run, unreachable by any later read.
-    // Hooks use hookTimeout (10s default), not the suite `timeout`; give this
-    // live-endpoint cleanup the same 30s ceiling.
-    await purgeOrg(TEST_SLUG);
+    // runBestEffortCleanup soft-bounds the purge below the hook ceiling so a
+    // laggy live endpoint can't fail a green run on teardown alone.
+    await runBestEffortCleanup(() => purgeOrg(TEST_SLUG), {
+      softTimeoutMs: CLEANUP_SOFT_TIMEOUT,
+      context: 'orgs REST smoke',
+    });
   }, REMOTE_TEST_TIMEOUT);
 
   // 1. auth: no token → 401/403 ───────────────────────────────────────────────
@@ -375,7 +382,10 @@ describe.skipIf(SKIP)('LoreKit orgs API — audit trail read-back (integration)'
   });
 
   afterAll(async () => {
-    await purgeOrg(AUDIT_SLUG);
+    await runBestEffortCleanup(() => purgeOrg(AUDIT_SLUG), {
+      softTimeoutMs: CLEANUP_SOFT_TIMEOUT,
+      context: 'orgs REST audit read-back',
+    });
   }, REMOTE_TEST_TIMEOUT);
 
   it('the audit_log capability probe ran and reported a definite result', () => {
@@ -519,7 +529,10 @@ describe.skipIf(SKIP)('LoreKit orgs API — audit trail read-back (integration)'
  */
 describe.skipIf(SKIP || !isLkToken)('LoreKit orgs API — api_key tier (integration)', () => {
   afterAll(async () => {
-    await purgeOrg(TOKEN_SLUG, API_TOKEN);
+    await runBestEffortCleanup(() => purgeOrg(TOKEN_SLUG, API_TOKEN), {
+      softTimeoutMs: CLEANUP_SOFT_TIMEOUT,
+      context: 'orgs REST api_key tier',
+    });
   }, REMOTE_TEST_TIMEOUT);
 
   // ── permission gating ─────────────────────────────────────────────────────

--- a/packages/mcp-server/src/smoke-cleanup.spec.ts
+++ b/packages/mcp-server/src/smoke-cleanup.spec.ts
@@ -188,9 +188,21 @@ describe('runBestEffortCleanup', () => {
     expect(ran).toBe(true);
   });
 
-  it('resolves (never rejects) when cleanup throws', async () => {
+  it('resolves (never rejects) when cleanup throws asynchronously', async () => {
     await expect(
       runBestEffortCleanup(async () => { throw new Error('boom'); }, { softTimeoutMs: 1000, context: 'ctx' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves (never rejects) when cleanup throws SYNCHRONOUSLY', async () => {
+    // A non-async fn that throws before returning a promise must still be caught:
+    // `fn()` was called before `.catch` was attached, which rejected this helper
+    // and leaked the timer. `Promise.resolve().then(fn)` closes it.
+    const syncThrow = (() => {
+      throw new Error('sync boom');
+    }) as () => Promise<void>;
+    await expect(
+      runBestEffortCleanup(syncThrow, { softTimeoutMs: 1000, context: 'ctx' }),
     ).resolves.toBeUndefined();
   });
 

--- a/packages/mcp-server/src/smoke-cleanup.spec.ts
+++ b/packages/mcp-server/src/smoke-cleanup.spec.ts
@@ -19,6 +19,8 @@ import {
   SMOKE_ARTEFACT_PATTERN,
   createSmokeNamespace,
   describeSweepFailures,
+  runBestEffortCleanup,
+  SWEEP_CONCURRENCY,
   smokeArtefactAgeMs,
   smokeArtefactTimestamp,
   sweepSmokeArtefacts,
@@ -140,15 +142,17 @@ describe('createSmokeNamespace', () => {
 });
 
 describe('sweepSmokeArtefacts', () => {
-  it('deletes every name and reports them as removed', async () => {
+  it('deletes every name and reports them, in input order', async () => {
     const seen: string[] = [];
     const report = await sweepSmokeArtefacts(['a', 'b', 'c'], async (n) => { seen.push(n); });
-    expect(seen).toEqual(['a', 'b', 'c']);
+    // Every name is deleted; the report preserves INPUT order regardless of the
+    // (now concurrent) completion order.
+    expect(seen.sort()).toEqual(['a', 'b', 'c']);
     expect(report.removed).toEqual(['a', 'b', 'c']);
     expect(report.failed).toEqual([]);
   });
 
-  it('keeps going after a failure and never throws', async () => {
+  it('keeps going after a failure and never throws, preserving order', async () => {
     // A cleanup hook that throws turns "one row leaked" into "the suite failed",
     // masking the real result — and stops the remaining artefacts being removed.
     const report = await sweepSmokeArtefacts(['a', 'b', 'c'], async (n) => {
@@ -158,15 +162,49 @@ describe('sweepSmokeArtefacts', () => {
     expect(report.failed).toEqual([{ name: 'b', reason: 'HTTP 500' }]);
   });
 
-  it('deletes sequentially, so a cleanup burst cannot trip the rate limit', async () => {
+  it('deletes with bounded concurrency, so a burst cannot trip the rate limit', async () => {
+    // Parallel enough to beat the hook timeout at hosted latency, capped at
+    // SWEEP_CONCURRENCY so a cleanup burst never approaches 120 req/min. With
+    // more names than the cap, in-flight peaks AT the cap and never above it.
+    const names = Array.from({ length: SWEEP_CONCURRENCY * 2 }, (_, i) => `k${i}`);
     let inFlight = 0;
     let maxInFlight = 0;
-    await sweepSmokeArtefacts(['a', 'b', 'c'], async () => {
+    await sweepSmokeArtefacts(names, async () => {
       maxInFlight = Math.max(maxInFlight, ++inFlight);
       await new Promise((r) => setTimeout(r, 1));
       inFlight--;
     });
-    expect(maxInFlight).toBe(1);
+    expect(maxInFlight).toBeGreaterThan(1); // genuinely concurrent
+    expect(maxInFlight).toBeLessThanOrEqual(SWEEP_CONCURRENCY); // never a burst
+  });
+});
+
+describe('runBestEffortCleanup', () => {
+  it('resolves normally when cleanup finishes in time', async () => {
+    let ran = false;
+    await expect(
+      runBestEffortCleanup(async () => { ran = true; }, { softTimeoutMs: 1000, context: 'ctx' }),
+    ).resolves.toBeUndefined();
+    expect(ran).toBe(true);
+  });
+
+  it('resolves (never rejects) when cleanup throws', async () => {
+    await expect(
+      runBestEffortCleanup(async () => { throw new Error('boom'); }, { softTimeoutMs: 1000, context: 'ctx' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('resolves via the soft timeout when cleanup overruns, without waiting for it', async () => {
+    // A teardown is not a test: a slow sweep must warn and yield, not time out
+    // the hook. The race resolves at the soft bound even though the cleanup
+    // promise is still pending.
+    let settled = false;
+    const slow = runBestEffortCleanup(
+      () => new Promise<void>((r) => setTimeout(r, 10_000)),
+      { softTimeoutMs: 5, context: 'ctx' },
+    ).then(() => { settled = true; });
+    await slow;
+    expect(settled).toBe(true);
   });
 });
 

--- a/packages/mcp-server/src/smoke-cleanup.ts
+++ b/packages/mcp-server/src/smoke-cleanup.ts
@@ -241,11 +241,17 @@ export async function runBestEffortCleanup(
     // Don't let a pending guard timer keep the process alive after teardown.
     if (typeof timer.unref === 'function') timer.unref();
   });
-  const attempt = fn().catch((err) => {
-    console.warn(
-      `\n  ⚠ SMOKE CLEANUP ERRORED (${opts.context}) — ${err instanceof Error ? err.message : String(err)}`,
-    );
-  });
+  // `Promise.resolve().then(fn)` — NOT `fn().catch(...)` — so a SYNCHRONOUS throw
+  // inside fn becomes a rejection this `.catch` handles, instead of propagating
+  // out before the handler is attached (which would reject this function and skip
+  // the `finally`, leaking the timer — the exact thing the docblock rules out).
+  const attempt = Promise.resolve()
+    .then(fn)
+    .catch((err) => {
+      console.warn(
+        `\n  ⚠ SMOKE CLEANUP ERRORED (${opts.context}) — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
   try {
     await Promise.race([attempt, guard]);
   } finally {

--- a/packages/mcp-server/src/smoke-cleanup.ts
+++ b/packages/mcp-server/src/smoke-cleanup.ts
@@ -160,6 +160,16 @@ export interface SweepReport {
 }
 
 /**
+ * The most deletes a sweep runs at once. Bounded on purpose: parallel enough
+ * that a namespace of a dozen-plus keys sweeps in a couple of round-trips
+ * instead of one-DELETE-per-key at hosted latency (which pushed the `afterAll`
+ * hook past its timeout and failed a deploy on cleanup alone), yet small enough
+ * that a burst can never approach the per-user rate limit (120 req/min). The
+ * spec asserts the cap, so raising it is a deliberate edit.
+ */
+export const SWEEP_CONCURRENCY = 5;
+
+/**
  * Hard-delete every minted name, never throwing.
  *
  * Cleanup runs in `afterAll`, where a throw would turn "the suite passed but a
@@ -167,24 +177,80 @@ export interface SweepReport {
  * COLLECTED and returned for the caller to log loudly — a leak must be visible,
  * but it must not be reported as a test failure it is not.
  *
- * Deletions are sequential on purpose: these run against a live endpoint with a
- * per-user rate limit (120 req/min), and a burst of parallel deletes from a
- * cleanup hook is the last thing that should trip it.
+ * Deletions run with BOUNDED concurrency ({@link SWEEP_CONCURRENCY}) — fast
+ * enough that the teardown never approaches the hook timeout, capped so it never
+ * bursts past the live endpoint's rate limit. The report preserves INPUT order
+ * regardless of completion order, so callers and tests stay stable.
  */
 export async function sweepSmokeArtefacts(
   names: readonly string[],
   hardDelete: HardDelete,
 ): Promise<SweepReport> {
-  const report: SweepReport = { removed: [], failed: [] };
-  for (const name of names) {
-    try {
-      await hardDelete(name);
-      report.removed.push(name);
-    } catch (err) {
-      report.failed.push({ name, reason: err instanceof Error ? err.message : String(err) });
+  // Slot i holds name i's outcome, so the report is assembled in input order
+  // no matter which worker finishes first. `cursor++` hands each worker the
+  // next index — safe without a lock because there is no await between the read
+  // and the increment (JS runs this synchronously).
+  const results = new Array<{ name: string; ok: boolean; reason?: string }>(names.length);
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    for (let i = cursor++; i < names.length; i = cursor++) {
+      const name = names[i];
+      try {
+        await hardDelete(name);
+        results[i] = { name, ok: true };
+      } catch (err) {
+        results[i] = { name, ok: false, reason: err instanceof Error ? err.message : String(err) };
+      }
     }
   }
+  const workers = Math.min(SWEEP_CONCURRENCY, names.length);
+  await Promise.all(Array.from({ length: workers }, () => worker()));
+
+  const report: SweepReport = { removed: [], failed: [] };
+  for (const r of results) {
+    if (r.ok) report.removed.push(r.name);
+    else report.failed.push({ name: r.name, reason: r.reason ?? 'unknown' });
+  }
   return report;
+}
+
+/**
+ * Run a best-effort cleanup step that can NEVER fail the suite.
+ *
+ * A teardown sweep is not a test: if it is slow or errors, the run must still
+ * report the truth about what was under test. This races the cleanup against a
+ * soft timeout set well under vitest's hook ceiling — if cleanup overruns, it
+ * warns and returns (the always-on `scripts/smoke-cleanup.mjs` sweep removes
+ * whatever was left); if it throws, that is swallowed with a warning too. Either
+ * way the returned promise resolves, so the enclosing `afterAll` can neither
+ * time out nor reject on cleanup alone.
+ */
+export async function runBestEffortCleanup(
+  fn: () => Promise<void>,
+  opts: { softTimeoutMs: number; context: string },
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const guard = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      console.warn(
+        `\n  ⚠ SMOKE CLEANUP TIMED OUT (${opts.context}) after ${opts.softTimeoutMs}ms — ` +
+          'leaving the rest to `scripts/smoke-cleanup.mjs`.',
+      );
+      resolve();
+    }, opts.softTimeoutMs);
+    // Don't let a pending guard timer keep the process alive after teardown.
+    if (typeof timer.unref === 'function') timer.unref();
+  });
+  const attempt = fn().catch((err) => {
+    console.warn(
+      `\n  ⚠ SMOKE CLEANUP ERRORED (${opts.context}) — ${err instanceof Error ? err.message : String(err)}`,
+    );
+  });
+  try {
+    await Promise.race([attempt, guard]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 /**

--- a/packages/mcp-server/src/smoke.integration.spec.ts
+++ b/packages/mcp-server/src/smoke.integration.spec.ts
@@ -20,6 +20,7 @@ import { describe, it, expect, afterAll } from 'vitest';
 import {
   createSmokeNamespace,
   describeSweepFailures,
+  runBestEffortCleanup,
   sweepSmokeArtefacts,
 } from './smoke-cleanup.js';
 
@@ -117,11 +118,16 @@ describe.skipIf(SKIP)('LoreKit MCP smoke tests (integration)', () => {
   // must be visible in the log without turning a passing suite red. Anything
   // this misses is picked up by `node scripts/smoke-cleanup.mjs`.
   afterAll(async () => {
-    const report = await sweepSmokeArtefacts(NS.minted(), async (key) => {
-      await mcpCall('memory.delete', { scope: SCOPE, key, force: true });
-    });
-    const warning = describeSweepFailures(report, `MCP smoke, scope=${SCOPE}`);
-    if (warning) console.warn(warning);
+    await runBestEffortCleanup(
+      async () => {
+        const report = await sweepSmokeArtefacts(NS.minted(), async (key) => {
+          await mcpCall('memory.delete', { scope: SCOPE, key, force: true });
+        });
+        const warning = describeSweepFailures(report, `MCP smoke, scope=${SCOPE}`);
+        if (warning) console.warn(warning);
+      },
+      { softTimeoutMs: 20_000, context: `MCP smoke, scope=${SCOPE}` },
+    );
   }, 30_000);
 
   // 1. write — create ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

The first deploy on merge to `main` (the new lockstep pipeline) failed at `smoke-preview`. All **67 REST assertions passed** — the suite failed only because the `afterAll` **cleanup hook timed out at 30s**:

```
Error: Hook timed out in 30000ms.
 ❯ src/memories-api.integration.spec.ts
Tests: 67 passed (67), 1 file failed
```

The sweep deleted **one key per minted name, sequentially**, at hosted latency. A namespace of a dozen-plus keys plus a latency blip tips the teardown past the hook ceiling — **failing a green run on cleanup alone**. (Production was never touched: the preview gate did its job, `deploy-production`/`promote` skipped, and rollback correctly stayed out — there was nothing in prod to revert.)

## What

**Root cause** — `packages/mcp-server/src/smoke-cleanup.ts`:
- `sweepSmokeArtefacts` now deletes with **bounded concurrency** (`SWEEP_CONCURRENCY = 5`): parallel enough to finish in a couple of round-trips instead of one-per-key, but capped so a burst can never approach the per-user rate limit (120 req/min — the original reason it was sequential). The report preserves **input order** regardless of completion order.
- New **`runBestEffortCleanup(fn, { softTimeoutMs, context })`** races cleanup against a soft timeout set **below** the hook ceiling: a slow *or* throwing sweep **warns and yields** instead of failing the suite. It defers `fn` via `Promise.resolve().then(fn)` so even a *synchronous* throw is caught (never rejects, never leaks the timer). The always-on `scripts/smoke-cleanup.mjs` orphan sweeper removes anything left.

**All four live suites** wrap their `afterAll` sweep in it — `memories-api`, `orgs-api`, `smoke.integration`, and `byod-smoke`.

**Belt-and-suspenders** — the two live smoke steps in `deploy.yml` (`smoke-preview`) and `preview.yml` **retry once** on a transient flake before failing. The suites self-clean and re-mint timestamped keys per run, so a re-run is safe and a genuine regression still fails after the second attempt.

## Testing

- `smoke-cleanup.spec.ts` updated: the old "deletes sequentially (`maxInFlight === 1`)" test becomes "bounded concurrency" (asserts `1 < maxInFlight ≤ SWEEP_CONCURRENCY`), report-order tests preserved, and new coverage for `runBestEffortCleanup` (resolves on success, on async throw, on **synchronous** throw, and via the soft timeout without waiting for the slow cleanup).
- Full `mcp-server` unit suite green (the 4 live integration specs self-skip without a token). Typecheck clean.

## Docs

No user-facing surface (MCP tool / REST route / CLI / dashboard) changed — this is test-infra + CI resilience, so `llms.txt` / MDX docs don't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qrDmwSCGhXpzU2hAXrmNQ