### PR TITLE
ci(deploy): link the Vercel project before promote/rollback (fix 403 wrong-team scope)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -686,6 +686,14 @@ jobs:
       - name: Install Vercel CLI
         run: pnpm add -g vercel@58
 
+      # Link the project so the CLI operates under the project's TEAM. Without
+      # this, `vercel promote` falls back to the token's DEFAULT team (e.g.
+      # "dash0") and 403s, because the staged deployment lives under the project's
+      # team (VERCEL_ORG_ID). `vercel pull` writes .vercel/project.json, exactly
+      # as the stage/deploy jobs do before their own Vercel calls.
+      - name: Link the Vercel project (production scope)
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
+
       - name: Promote staged build to production
         run: |
           if [ -z "$STAGED_URL" ]; then
@@ -920,6 +928,12 @@ jobs:
 
       - name: Install Vercel CLI
         run: pnpm add -g vercel@58
+
+      # Link the project so `vercel rollback` operates under the project's TEAM
+      # (VERCEL_ORG_ID) rather than the token's default team, which would 403.
+      # Same reason as promote-web-production's link step.
+      - name: Link the Vercel project (production scope)
+        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
 
       - name: Roll back production web to the previous deployment
         run: |


### PR DESCRIPTION
## Why

The production deploy failed at `promote-web-production`:

```
vercel promote "$STAGED_URL" --token="$VERCEL_TOKEN" --yes
Error: Not authorized: Trying to access resource under scope "dash0".
You must re-authenticate to this scope or use a token with access to this scope. (403)
```

This is a **wrong Vercel *team scope***, not a wrong project or a smoke flake:

- The Vercel token's **default team is `dash0`**, but the LoreKit project lives under the **`mads-thines-projects`** team (visible in the staged URL: `lorekit-…-mads-thines-projects.vercel.app`).
- The `stage-web-production` / `deploy-web-preview` jobs run **`vercel pull`** first, which links the project via `VERCEL_ORG_ID` and pins the team — so their `vercel build` / `vercel deploy` worked.
- When `actions/checkout` was added to `promote-web-production` / `rollback-web-production` (so `pnpm/action-setup` could read `packageManager`), **no `vercel pull` was added** — so `vercel promote` / `vercel rollback` had no project link and fell back to the token's default team (`dash0`) → 403.

## Fallout from that run (no user-facing regression)

The rest of the pipeline behaved correctly: `deploy-production` (API) succeeded, and because the web promote then failed, the lockstep rule **rolled the functions back to the previous commit** and **skipped** the web rollback (the alias was never swapped — nothing to revert). Since the commits in flight only touched tests/workflows/`vercel.json` (no edge-function or web-app code), that rollback was effectively a no-op and production stayed healthy (`smoke-production` verified health + MCP + the dashboard all 200).

## The fix

Add a **`vercel pull --yes --environment=production`** link step before the `vercel promote` and `vercel rollback` calls, mirroring the stage/deploy jobs, so both resolve the project's team scope (`VERCEL_ORG_ID`) instead of the token's default team.

## Docs

No user-facing surface changed — CI-only. `llms.txt` / MDX docs don't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qrDmwSCGhXpzU2hAXrmNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014qrDmwSCGhXpzU2hAXrmNQ)_