### PR TITLE
ci(deploy): pass --scope to vercel promote/rollback (fix Vercel bug #11712 team-scope 403)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -669,6 +669,11 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
       STAGED_URL: ${{ needs.stage-web-production.outputs.deployment_url }}
+      # The team slug `vercel promote` must run under. See the promote step for
+      # why this is REQUIRED (Vercel bug #11712). Defaults to the project's team;
+      # matches the hardcoded VERCEL_SCOPE in packages/mcp-core/src/cors-origins.ts.
+      # Override with a repo variable if the project moves Vercel accounts.
+      VERCEL_SCOPE: ${{ vars.VERCEL_SCOPE || 'mads-thines-projects' }}
     steps:
       # Checkout is required BEFORE pnpm/action-setup — it reads `packageManager`
       # from the repo's package.json (no `version:` is pinned on the action).
@@ -686,14 +691,6 @@ jobs:
       - name: Install Vercel CLI
         run: pnpm add -g vercel@58
 
-      # Link the project so the CLI operates under the project's TEAM. Without
-      # this, `vercel promote` falls back to the token's DEFAULT team (e.g.
-      # "dash0") and 403s, because the staged deployment lives under the project's
-      # team (VERCEL_ORG_ID). `vercel pull` writes .vercel/project.json, exactly
-      # as the stage/deploy jobs do before their own Vercel calls.
-      - name: Link the Vercel project (production scope)
-        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
-
       - name: Promote staged build to production
         run: |
           if [ -z "$STAGED_URL" ]; then
@@ -702,9 +699,17 @@ jobs:
           fi
           # Assign the production domain to the already-built, already-uploaded
           # deployment — the instant alias swap that flips the FE to production.
-          vercel promote "$STAGED_URL" --token="$VERCEL_TOKEN" --yes
+          #
+          # `--scope` is REQUIRED, not optional: `vercel promote` ignores both a
+          # team-scoped token AND a linked .vercel/project.json (Vercel bug
+          # https://github.com/vercel/vercel/issues/11712), so without it the CLI
+          # falls back to the token's DEFAULT team and 403s with "Trying to access
+          # resource under scope '<default-team>'". `vercel deploy` (in the stage
+          # job) does NOT have this bug, which is why staging worked and only the
+          # flip failed. Passing the team slug forces the correct scope.
+          vercel promote "$STAGED_URL" --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN" --yes
           echo "### Web production promoted" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Promoted \`$STAGED_URL\` to the production domain." >> "$GITHUB_STEP_SUMMARY"
+          echo "- Promoted \`$STAGED_URL\` to the production domain (scope \`$VERCEL_SCOPE\`)." >> "$GITHUB_STEP_SUMMARY"
 
   # ── 4. Post-deploy verification against PRODUCTION ───────────────────────────
   smoke-production:
@@ -912,6 +917,8 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      # Same team-scope requirement as promote-web-production (Vercel bug #11712).
+      VERCEL_SCOPE: ${{ vars.VERCEL_SCOPE || 'mads-thines-projects' }}
     steps:
       # Checkout is required BEFORE pnpm/action-setup — it reads `packageManager`
       # from the repo's package.json (no `version:` is pinned on the action).
@@ -929,20 +936,16 @@ jobs:
       - name: Install Vercel CLI
         run: pnpm add -g vercel@58
 
-      # Link the project so `vercel rollback` operates under the project's TEAM
-      # (VERCEL_ORG_ID) rather than the token's default team, which would 403.
-      # Same reason as promote-web-production's link step.
-      - name: Link the Vercel project (production scope)
-        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
-
       - name: Roll back production web to the previous deployment
         run: |
           # `vercel rollback` with no target reverts to the deployment immediately
           # prior to the current production deployment — i.e. the one live before
-          # this run's (now-promoted) deployment. Best-effort: rollback-production
+          # this run's (now-promoted) deployment. `--scope` is REQUIRED for the
+          # same reason as promote (Vercel bug #11712 — rollback ignores the
+          # token's team and the linked project). Best-effort: rollback-production
           # already fails the run loudly, so a rollback hiccup here is a warning,
           # not a second hard fail.
-          if vercel rollback --token="$VERCEL_TOKEN" --yes; then
+          if vercel rollback --scope="$VERCEL_SCOPE" --token="$VERCEL_TOKEN" --yes; then
             echo "### ⚠️ Production web rolled back" >> "$GITHUB_STEP_SUMMARY"
             echo "The production domain was reverted to the previous Vercel deployment." >> "$GITHUB_STEP_SUMMARY"
           else

--- a/SETUP.md
+++ b/SETUP.md
@@ -123,6 +123,14 @@ pnpm nx test mcp-core                            # needs supabase start
 | `VERCEL_ORG_ID` | From `.vercel/project.json` after `vercel link` (or Vercel project settings) |
 | `VERCEL_PROJECT_ID` | From `.vercel/project.json` after `vercel link` |
 
+Optional repo **variables** (Settings → Secrets and variables → Actions →
+Variables):
+
+| Variable | Description |
+|----------|-------------|
+| `VERCEL_SCOPE` | Your Vercel **team slug** for `vercel promote`/`rollback`. Defaults to `mads-thines-projects` — **a fork must set its own**, or the production promote 403s ([Vercel bug #11712](https://github.com/vercel/vercel/issues/11712)). |
+| `WEB_PROD_URL` | Production dashboard origin the prod smoke curls. Defaults to `https://lorekit.io`. |
+
 ---
 
 ## Supabase Auth configuration

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -460,9 +460,17 @@ is touched — it now gates the web promote (`promote-web-production`) as well a
 the API deploy.
 
 Repo-level **variables** (Settings ▸ Secrets and variables ▸ Actions ▸
-Variables): `WEB_PROD_URL` — optional, the production dashboard origin the
-production smoke curls. Defaults to `https://lorekit.io`; set it for a
-self-hosted fork on a different domain.
+Variables), both optional:
+
+- `WEB_PROD_URL` — the production dashboard origin the production smoke curls.
+  Defaults to `https://lorekit.io`; set it for a self-hosted fork on a different
+  domain.
+- `VERCEL_SCOPE` — the Vercel **team slug** that `vercel promote` / `vercel
+  rollback` run under. Defaults to `mads-thines-projects` (this project's team,
+  matching the hardcoded `VERCEL_SCOPE` in `packages/mcp-core/src/cors-origins.ts`).
+  **A fork MUST set this to its own team slug** — `promote`/`rollback` ignore the
+  token's team and the linked project ([Vercel bug #11712](https://github.com/vercel/vercel/issues/11712)),
+  so an unset value would try to promote into `mads-thines-projects` and 403.
 
 #### Seed the orgs-smoke user
 


### PR DESCRIPTION
## Root cause (confirmed this time, not guessed)

The web promote 403'd **again** — `Error: Not authorized: Trying to access resource under scope "dash0"` — even after the previous `vercel pull` link fix (#359). The run log is decisive:

```
> Downloaded project settings to .../.vercel/project.json   ← the link step ran
vercel promote "$STAGED_URL" --token=... --yes
Error: Not authorized: Trying to access resource under scope "dash0". (403)
```

The project **was** linked, and `vercel promote` **still** used the token's default team (`dash0`). This is a known Vercel CLI bug — [**vercel/vercel#11712**](https://github.com/vercel/vercel/issues/11712): `vercel promote` (and `rollback`) **ignore both a team-scoped token and the linked `.vercel/project.json`**, unlike `vercel deploy`. That asymmetry is exactly what we saw across three runs: `stage-web-production`'s `vercel deploy` always succeeded to the project's team (`mads-thines-projects`), and only the `promote` flip failed.

The [confirmed workaround in that issue](https://github.com/vercel/vercel/issues/11712) is to pass **`--scope=<team>` explicitly**.

## The fix

- **Drop** the ineffective `vercel pull` link steps from `promote-web-production` / `rollback-web-production` (the log proves they don't change promote's scope).
- **Pass `--scope="$VERCEL_SCOPE"`** to `vercel promote` and `vercel rollback`, from a new `VERCEL_SCOPE` env — a repo variable `VERCEL_SCOPE` defaulting to the project's team slug **`mads-thines-projects`**. That's the same value already hardcoded as `VERCEL_SCOPE` in `packages/mcp-core/src/cors-origins.ts` ("Update VERCEL_SCOPE if the project moves Vercel accounts"), so there's precedent and **no new secret is required**.

## Why this one works (confidence)

- The token **already has access** to the `mads-thines-projects` team — `stage-web-production` deploys there successfully every run. The 403 was never about access; it was the CLI resolving the *wrong* team. Forcing `--scope` to the team the token can already reach resolves it.
- `--scope` accepting a team slug is the documented, issue-confirmed workaround — not an inference.

## Current production state

Healthy. The prior failed run rolled the API functions back to the previous commit and skipped the web rollback (nothing was promoted), and the in-flight commits only touched CI/tests/`vercel.json` — no function or web-app code — so production kept serving (`smoke-production` verified health + MCP + dashboard all 200). The web simply hasn't been promoted through the pipeline yet; this PR is what lets it.

## Docs

CI-only change — no user-facing surface, so `llms.txt` / MDX docs don't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qrDmwSCGhXpzU2hAXrmNQ

---
_Generated by [Claude Code](https://claude.ai/code/session_014qrDmwSCGhXpzU2hAXrmNQ)_