### PR TITLE
feat(web): resolve /lore?memoryId= deep links by fetching the memory by id

### DIFF
--- a/packages/web/src/components/providers/MemorySidebarProvider.tsx
+++ b/packages/web/src/components/providers/MemorySidebarProvider.tsx
@@ -8,8 +8,11 @@
  * sidebar survives page refreshes and is shareable via URL.
  *
  * URL params used:
- *   lesson  – JSON-encoded { scope, key } identifying the open lesson.
- *             Absent (not in URL) when no lesson is selected.
+ *   lesson    – JSON-encoded { scope, key } identifying the open lesson.
+ *               Absent (not in URL) when no lesson is selected.
+ *   memoryId  – Plain DB row id (NOT JSON-encoded). A robust deep-link form that
+ *               fetches the memory by id, so the sheet opens even when the row is
+ *               outside the Explorer's recent/active window. Absent when unused.
  *
  * ## SSR & hydration
  * `useUrlState` reads from `useSearchParams()`, which is empty on the server.
@@ -28,9 +31,10 @@
  */
 
 import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useUrlState } from '@/lib/hooks/useUrlState';
 import { LessonDetailSheet } from '@/components/lore/LessonDetailSheet';
-import { useLoreData } from '@/lib/queries/lore';
+import { useLoreData, useMemoryById } from '@/lib/queries/lore';
 import type { LessonEntry } from '@/components/lore/LessonCard';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -97,25 +101,40 @@ export function MemorySidebarProvider({ children }: MemorySidebarProviderProps) 
   // The same query is used by the Lore Explorer — zero extra network requests.
   const { data } = useLoreData();
 
+  // The robust deep-link form: a plain `?memoryId=<id>` (NOT JSON-encoded, so it
+  // never has to invert the dashboard's useUrlState encoding). Read directly from
+  // the search params rather than through useUrlState, then fetched by id — this
+  // resolves the memory even when it is outside the Explorer's recent/active
+  // window, the case where the `?lesson=` scope+key form opens blank.
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
+  const memoryId = searchParams.get('memoryId');
+  const { data: memoryByIdLesson } = useMemoryById(memoryId);
+
   const openLesson = useMemo<LessonEntry | null>(() => {
-    if (!lessonRef) return null;
-    // 1. Try the active-memories cache (covers all non-archived lessons).
-    if (data?.lessons) {
-      const found = data.lessons.find(
-        (l) => l.scope === lessonRef.scope && l.key === lessonRef.key,
-      );
-      if (found) return found;
+    // 1. The `lesson` (scope+key) param — resolved from the active cache or a
+    //    caller-supplied prefetch (e.g. an archived memory).
+    if (lessonRef) {
+      if (data?.lessons) {
+        const found = data.lessons.find(
+          (l) => l.scope === lessonRef.scope && l.key === lessonRef.key,
+        );
+        if (found) return found;
+      }
+      if (
+        prefetched &&
+        prefetched.scope === lessonRef.scope &&
+        prefetched.key === lessonRef.key
+      ) {
+        return prefetched;
+      }
     }
-    // 2. Fall back to the caller-supplied prefetched lesson (e.g. archived).
-    if (
-      prefetched &&
-      prefetched.scope === lessonRef.scope &&
-      prefetched.key === lessonRef.key
-    ) {
-      return prefetched;
-    }
+    // 2. The `memoryId` param — fetched by id directly, so it resolves regardless
+    //    of the recent/active window.
+    if (memoryId && memoryByIdLesson) return memoryByIdLesson;
     return null;
-  }, [lessonRef, data, prefetched]);
+  }, [lessonRef, data, prefetched, memoryId, memoryByIdLesson]);
 
   const openLessonById = useCallback(
     (ref: LessonRef, lesson?: LessonEntry) => {
@@ -139,7 +158,16 @@ export function MemorySidebarProvider({ children }: MemorySidebarProviderProps) 
       setPrefetched(null);
       setLessonRef(null);
     }
-  }, [lessonRef, setLessonRef]);
+    // The `memoryId` deep-link param is a plain search param (not useUrlState),
+    // so strip it directly. Only one of `lesson` / `memoryId` is ever set at a
+    // time, so this never races the setLessonRef navigation above.
+    if (memoryId !== null) {
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete('memoryId');
+      const qs = params.toString();
+      router.replace(`${pathname}${qs ? `?${qs}` : ''}`, { scroll: false });
+    }
+  }, [lessonRef, setLessonRef, memoryId, searchParams, router, pathname]);
 
   const contextValue = useMemo<MemorySidebarContextValue>(
     () => ({
@@ -147,11 +175,12 @@ export function MemorySidebarProvider({ children }: MemorySidebarProviderProps) 
       openLessonRef: lessonRef,
       openLessonById,
       closeLesson,
-      // isOpen derives from the ref, not the resolved lesson, so it is truthy
-      // immediately after openLessonById() — even before the lore data loads.
-      isOpen: lessonRef !== null,
+      // isOpen derives from the ref (or the memoryId param), not the resolved
+      // lesson, so it is truthy immediately after openLessonById() or on a
+      // `?memoryId=` visit — even before the lore data / by-id fetch loads.
+      isOpen: lessonRef !== null || memoryId !== null,
     }),
-    [openLesson, lessonRef, openLessonById, closeLesson],
+    [openLesson, lessonRef, openLessonById, closeLesson, memoryId],
   );
 
   return (

--- a/packages/web/src/components/providers/MemorySidebarProvider.tsx
+++ b/packages/web/src/components/providers/MemorySidebarProvider.tsx
@@ -35,14 +35,10 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useUrlState } from '@/lib/hooks/useUrlState';
 import { LessonDetailSheet } from '@/components/lore/LessonDetailSheet';
 import { useLoreData, useMemoryById } from '@/lib/queries/lore';
+import { resolveOpenLesson, type LessonRef } from '@/lib/open-lesson';
 import type { LessonEntry } from '@/components/lore/LessonCard';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
-
-interface LessonRef {
-  scope: string;
-  key: string;
-}
 
 interface MemorySidebarContextValue {
   /** The fully-resolved open lesson, or null while loading or when closed. */
@@ -112,29 +108,20 @@ export function MemorySidebarProvider({ children }: MemorySidebarProviderProps) 
   const memoryId = searchParams.get('memoryId');
   const { data: memoryByIdLesson } = useMemoryById(memoryId);
 
-  const openLesson = useMemo<LessonEntry | null>(() => {
-    // 1. The `lesson` (scope+key) param — resolved from the active cache or a
-    //    caller-supplied prefetch (e.g. an archived memory).
-    if (lessonRef) {
-      if (data?.lessons) {
-        const found = data.lessons.find(
-          (l) => l.scope === lessonRef.scope && l.key === lessonRef.key,
-        );
-        if (found) return found;
-      }
-      if (
-        prefetched &&
-        prefetched.scope === lessonRef.scope &&
-        prefetched.key === lessonRef.key
-      ) {
-        return prefetched;
-      }
-    }
-    // 2. The `memoryId` param — fetched by id directly, so it resolves regardless
-    //    of the recent/active window.
-    if (memoryId && memoryByIdLesson) return memoryByIdLesson;
-    return null;
-  }, [lessonRef, data, prefetched, memoryId, memoryByIdLesson]);
+  // Resolution precedence lives in the pure `resolveOpenLesson` (unit-tested):
+  // `lesson` strictly wins, so a cache-missing `lesson` shows nothing rather
+  // than falling through to whatever `memoryId` is still in the URL.
+  const openLesson = useMemo<LessonEntry | null>(
+    () =>
+      resolveOpenLesson({
+        lessonRef,
+        cacheLessons: data?.lessons,
+        prefetched,
+        memoryId,
+        memoryByIdLesson,
+      }),
+    [lessonRef, data, prefetched, memoryId, memoryByIdLesson],
+  );
 
   const openLessonById = useCallback(
     (ref: LessonRef, lesson?: LessonEntry) => {
@@ -159,8 +146,10 @@ export function MemorySidebarProvider({ children }: MemorySidebarProviderProps) 
       setLessonRef(null);
     }
     // The `memoryId` deep-link param is a plain search param (not useUrlState),
-    // so strip it directly. Only one of `lesson` / `memoryId` is ever set at a
-    // time, so this never races the setLessonRef navigation above.
+    // so strip it directly. In the common flows only one of `lesson` / `memoryId`
+    // is set, so this is a single navigation; and the pure `resolveOpenLesson`
+    // gives `lesson` strict precedence, so even if both ever linger the sheet
+    // still never shows the wrong memory.
     if (memoryId !== null) {
       const params = new URLSearchParams(searchParams.toString());
       params.delete('memoryId');

--- a/packages/web/src/components/providers/MemorySidebarProvider.tsx
+++ b/packages/web/src/components/providers/MemorySidebarProvider.tsx
@@ -13,6 +13,10 @@
  *   memoryId  – Plain DB row id (NOT JSON-encoded). A robust deep-link form that
  *               fetches the memory by id, so the sheet opens even when the row is
  *               outside the Explorer's recent/active window. Absent when unused.
+ *               It is a deep-link ENTRY point, not the open/closed flag: closing
+ *               the sheet records the dismissal locally and leaves the param in
+ *               the URL (see `activeMemoryId`), because stripping it would be a
+ *               second navigation racing the Explorer's own scope/filter write.
  *
  * ## SSR & hydration
  * `useUrlState` reads from `useSearchParams()`, which is empty on the server.
@@ -31,11 +35,11 @@
  */
 
 import { createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
-import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { useUrlState } from '@/lib/hooks/useUrlState';
 import { LessonDetailSheet } from '@/components/lore/LessonDetailSheet';
 import { useLoreData, useMemoryById } from '@/lib/queries/lore';
-import { resolveOpenLesson, type LessonRef } from '@/lib/open-lesson';
+import { activeMemoryId, resolveOpenLesson, type LessonRef } from '@/lib/open-lesson';
 import type { LessonEntry } from '@/components/lore/LessonCard';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -103,9 +107,12 @@ export function MemorySidebarProvider({ children }: MemorySidebarProviderProps) 
   // resolves the memory even when it is outside the Explorer's recent/active
   // window, the case where the `?lesson=` scope+key form opens blank.
   const searchParams = useSearchParams();
-  const router = useRouter();
-  const pathname = usePathname();
-  const memoryId = searchParams.get('memoryId');
+  const urlMemoryId = searchParams.get('memoryId');
+  // Closing the sheet dismisses the id locally rather than rewriting the URL —
+  // the pure `activeMemoryId` docblock has the why (a second router.replace in
+  // the same tick clobbers the Explorer's scope/filter write).
+  const [dismissedMemoryId, setDismissedMemoryId] = useState<string | null>(null);
+  const memoryId = activeMemoryId(urlMemoryId, dismissedMemoryId);
   const { data: memoryByIdLesson } = useMemoryById(memoryId);
 
   // Resolution precedence lives in the pure `resolveOpenLesson` (unit-tested):
@@ -145,18 +152,12 @@ export function MemorySidebarProvider({ children }: MemorySidebarProviderProps) 
       setPrefetched(null);
       setLessonRef(null);
     }
-    // The `memoryId` deep-link param is a plain search param (not useUrlState),
-    // so strip it directly. In the common flows only one of `lesson` / `memoryId`
-    // is set, so this is a single navigation; and the pure `resolveOpenLesson`
-    // gives `lesson` strict precedence, so even if both ever linger the sheet
-    // still never shows the wrong memory.
-    if (memoryId !== null) {
-      const params = new URLSearchParams(searchParams.toString());
-      params.delete('memoryId');
-      const qs = params.toString();
-      router.replace(`${pathname}${qs ? `?${qs}` : ''}`, { scroll: false });
-    }
-  }, [lessonRef, setLessonRef, memoryId, searchParams, router, pathname]);
+    // Dismiss the `memoryId` deep link in local state — no navigation, so this
+    // can never race the scope/filter write LoreExplorer makes in the same tick.
+    // A null id is a no-op; the pure `resolveOpenLesson` still gives `lesson`
+    // strict precedence, so a lingering param never shows the wrong memory.
+    setDismissedMemoryId(urlMemoryId);
+  }, [lessonRef, setLessonRef, urlMemoryId]);
 
   const contextValue = useMemo<MemorySidebarContextValue>(
     () => ({

--- a/packages/web/src/content/docs/deep-links.mdx
+++ b/packages/web/src/content/docs/deep-links.mdx
@@ -12,7 +12,8 @@ The LoreKit dashboard keeps its entire view state in the URL. Every scope filter
 | Destination | Path |
 | --- | --- |
 | The memory Explorer | `/lore` |
-| One memory's detail sheet | `/lore?lesson=…` |
+| One memory by id (robust) | `/lore?memoryId=…` |
+| One memory's detail sheet (scope + key) | `/lore?lesson=…` |
 | A scope-filtered Explorer | `/lore?scope=…` |
 
 ## How dashboard URLs are encoded
@@ -50,16 +51,26 @@ https://lorekit.io/lore?scope=%22global%22
 https://lorekit.io/lore?scope=%22repo%3A%3Aacme%2Fwidget%22
 ```
 
-## Link to a specific memory
+## Link to a specific memory by id (recommended)
 
-Open a memory's detail sheet directly. The link sets `lesson` (which opens the sheet) plus `scope`, so the list behind the sheet is filtered to the memory's own scope:
+The robust way to open one memory is by its **id** — a plain, un-encoded query parameter:
+
+```text
+https://lorekit.io/lore?memoryId=mem_7f3a92
+```
+
+Unlike every other Explorer parameter, `memoryId` is **not** JSON-encoded — it is the raw row id, so there is nothing to double-encode and nothing to get wrong when a tool builds the link by hand (`{base}/lore?memoryId=<id>`). The dashboard fetches that memory **by id directly**, so the detail sheet opens even when the memory is outside the Explorer's recent/active window — the case where the scope + key form below opens blank. Archived memories are the one exception: they are addressed by scope + key and open from the archived list, so `memoryId` returns nothing for them.
+
+## Link to a specific memory by scope + key
+
+The older form opens a memory's detail sheet via its `scope` + `key`. The link sets `lesson` (which opens the sheet) plus `scope`, so the list behind the sheet is filtered to the memory's own scope:
 
 ```text
 # opens the "prefer-guard-clauses" memory in the global scope
 https://lorekit.io/lore?scope=%22global%22&lesson=%7B%22scope%22%3A%22global%22%2C%22key%22%3A%22prefer-guard-clauses%22%7D
 ```
 
-The detail sheet reads from a recent, unfiltered set, so a memory older than that window or an archived one can still open blank — a dashboard limitation the link itself cannot fix.
+The detail sheet resolves this form from a recent, unfiltered set, so a memory older than that window or an archived one can still open blank. When you have the memory's id, prefer `?memoryId=` above — it fetches by id and does not have this limitation.
 
 ## Link to a search or a filtered view
 

--- a/packages/web/src/content/docs/deep-links.mdx
+++ b/packages/web/src/content/docs/deep-links.mdx
@@ -56,10 +56,10 @@ https://lorekit.io/lore?scope=%22repo%3A%3Aacme%2Fwidget%22
 The robust way to open one memory is by its **id** — a plain, un-encoded query parameter:
 
 ```text
-https://lorekit.io/lore?memoryId=mem_7f3a92
+https://lorekit.io/lore?memoryId=9b2c1d34-5e6f-4a7b-8c9d-0e1f2a3b4c5d
 ```
 
-Unlike every other Explorer parameter, `memoryId` is **not** JSON-encoded — it is the raw row id, so there is nothing to double-encode and nothing to get wrong when a tool builds the link by hand (`{base}/lore?memoryId=<id>`). The dashboard fetches that memory **by id directly**, so the detail sheet opens even when the memory is outside the Explorer's recent/active window — the case where the scope + key form below opens blank. Archived memories are the one exception: they are addressed by scope + key and open from the archived list, so `memoryId` returns nothing for them.
+The id is the memory's UUID (the `id` column) — `GET /memories/:id` validates it, so a non-UUID value 400s. Unlike every other Explorer parameter, `memoryId` is **not** JSON-encoded — it is the raw UUID, so there is nothing to double-encode and nothing to get wrong when a tool builds the link by hand (`{base}/lore?memoryId=<uuid>`). The dashboard fetches that memory **by id directly**, so the detail sheet opens even when the memory is outside the Explorer's recent/active window — the case where the scope + key form below opens blank. Archived memories are the one exception: they are addressed by scope + key and open from the archived list, so `memoryId` returns nothing for them.
 
 ## Link to a specific memory by scope + key
 

--- a/packages/web/src/lib/api/memories.ts
+++ b/packages/web/src/lib/api/memories.ts
@@ -98,6 +98,25 @@ export function readActivityRequest(
 }
 
 /**
+ * `GET /memories/:id` — a single memory addressed by DB row id.
+ *
+ * Unlike the scope+key list reads, this resolves one row directly, so a
+ * deep-linked memory (`/lore?memoryId=…`) opens even when it is outside the
+ * Explorer's recent/active window. Archived rows 404 — they are addressed by
+ * scope+key and open from the archived list.
+ */
+export function getMemoryByIdRequest(
+  accessToken: string,
+  id: string,
+  signal?: AbortSignal,
+): Promise<MemoryEntry> {
+  return restFetch<MemoryEntry>(`/memories/${encodeURIComponent(id)}`, {
+    accessToken,
+    ...(signal ? { signal } : {}),
+  });
+}
+
+/**
  * `PATCH /memories/:id` — a partial column update.
  *
  * Preferred over the `POST /memories` upsert for edits: it touches only the

--- a/packages/web/src/lib/open-lesson.spec.ts
+++ b/packages/web/src/lib/open-lesson.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * The detail-sheet resolution precedence between the two deep-link params
+ * (`lesson` scope+key and the plain `memoryId`).
+ *
+ * The load-bearing rule is that `lesson` STRICTLY wins: a `?lesson=` that misses
+ * the active cache must show nothing, never fall through to whatever `?memoryId=`
+ * is still in the URL — otherwise a stale `memoryId` silently displays the wrong
+ * memory. The `memoryId` deep-link path is exercised here too, so the headline
+ * behaviour is covered.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { MemoryEntry } from '@lorekit/schemas/memory';
+import { lessonFromMemoryEntry } from './lesson-entry';
+import { resolveOpenLesson } from './open-lesson';
+
+function lesson(scope: string, key: string) {
+  const entry: MemoryEntry = {
+    id: `id-${scope}-${key}`,
+    scope,
+    key,
+    value: 'v',
+    tags: [],
+    source_agent: null,
+    trigger: null,
+    created_at: '2026-07-01T00:00:00.000Z',
+    updated_at: '2026-07-02T00:00:00.000Z',
+    expires_at: null,
+    archived_at: null,
+  };
+  return lessonFromMemoryEntry(entry);
+}
+
+const A = lesson('global', 'a');
+const B = lesson('global', 'b');
+
+describe('resolveOpenLesson', () => {
+  it('resolves the lesson ref from the active cache', () => {
+    expect(
+      resolveOpenLesson({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: [A, B],
+        prefetched: null,
+        memoryId: null,
+        memoryByIdLesson: null,
+      }),
+    ).toBe(A);
+  });
+
+  it('falls back to a caller-supplied prefetch when the lesson is not in the cache', () => {
+    expect(
+      resolveOpenLesson({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: [],
+        prefetched: A,
+        memoryId: null,
+        memoryByIdLesson: null,
+      }),
+    ).toBe(A);
+  });
+
+  it('resolves a memoryId memory when no lesson ref is set — the deep-link path', () => {
+    expect(
+      resolveOpenLesson({
+        lessonRef: null,
+        cacheLessons: [],
+        prefetched: null,
+        memoryId: 'id-global-a',
+        memoryByIdLesson: A,
+      }),
+    ).toBe(A);
+  });
+
+  it('gives the lesson ref strict precedence — a cache-missing lesson shows nothing, never the memoryId memory', () => {
+    // Regression: without strict precedence a lesson that misses the cache fell
+    // through and returned B (the memoryId memory).
+    expect(
+      resolveOpenLesson({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: [],
+        prefetched: null,
+        memoryId: 'id-global-b',
+        memoryByIdLesson: B,
+      }),
+    ).toBeNull();
+  });
+
+  it('ignores memoryId while a lesson ref resolves', () => {
+    expect(
+      resolveOpenLesson({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: [A],
+        prefetched: null,
+        memoryId: 'id-global-b',
+        memoryByIdLesson: B,
+      }),
+    ).toBe(A);
+  });
+
+  it('returns null when nothing is open', () => {
+    expect(
+      resolveOpenLesson({
+        lessonRef: null,
+        cacheLessons: [],
+        prefetched: null,
+        memoryId: null,
+        memoryByIdLesson: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null while the memoryId fetch is still loading', () => {
+    expect(
+      resolveOpenLesson({
+        lessonRef: null,
+        cacheLessons: [],
+        prefetched: null,
+        memoryId: 'id-global-a',
+        memoryByIdLesson: undefined,
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/web/src/lib/open-lesson.spec.ts
+++ b/packages/web/src/lib/open-lesson.spec.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect } from 'vitest';
 import type { MemoryEntry } from '@lorekit/schemas/memory';
 import { lessonFromMemoryEntry } from './lesson-entry';
-import { resolveOpenLesson } from './open-lesson';
+import { activeMemoryId, resolveOpenLesson } from './open-lesson';
 
 function lesson(scope: string, key: string) {
   const entry: MemoryEntry = {
@@ -119,5 +119,24 @@ describe('resolveOpenLesson', () => {
         memoryByIdLesson: undefined,
       }),
     ).toBeNull();
+  });
+});
+
+describe('activeMemoryId', () => {
+  it('is the URL param while nothing has been dismissed', () => {
+    expect(activeMemoryId('id-a', null)).toBe('id-a');
+  });
+
+  it('goes null once that exact id is dismissed — how the sheet closes without a navigation', () => {
+    expect(activeMemoryId('id-a', 'id-a')).toBeNull();
+  });
+
+  it('re-opens for a different id, so a later deep link still works after a close', () => {
+    expect(activeMemoryId('id-b', 'id-a')).toBe('id-b');
+  });
+
+  it('is null when the URL carries no memoryId at all', () => {
+    expect(activeMemoryId(null, null)).toBeNull();
+    expect(activeMemoryId(null, 'id-a')).toBeNull();
   });
 });

--- a/packages/web/src/lib/open-lesson.ts
+++ b/packages/web/src/lib/open-lesson.ts
@@ -1,0 +1,54 @@
+import type { LessonEntry } from '@/components/lore/LessonCard';
+
+export interface LessonRef {
+  scope: string;
+  key: string;
+}
+
+/**
+ * Resolve which memory the detail sheet shows from the two independent
+ * deep-link params the sidebar reads: the `lesson` scope+key ref and the plain
+ * `memoryId`.
+ *
+ * `lesson` **strictly wins**: when a `lessonRef` is set the sheet shows that
+ * memory or nothing — it never falls through to `memoryId`. Without that rule,
+ * a `?lesson=` that misses the active-cache (and carries no prefetch) would fall
+ * through and silently display whatever `?memoryId=` happened to still be in the
+ * URL — the wrong memory. `memoryId` resolves only when no `lesson` is set,
+ * which is the deep-link case it exists for.
+ *
+ * Pure and dependency-free (type-only import), so it is unit-testable in the
+ * node vitest project — the reason the resolution lives here rather than inline
+ * in the client provider.
+ */
+export function resolveOpenLesson(args: {
+  lessonRef: LessonRef | null;
+  cacheLessons: LessonEntry[] | undefined;
+  prefetched: LessonEntry | null;
+  memoryId: string | null;
+  memoryByIdLesson: LessonEntry | null | undefined;
+}): LessonEntry | null {
+  const { lessonRef, cacheLessons, prefetched, memoryId, memoryByIdLesson } = args;
+
+  if (lessonRef) {
+    // 1. The active-memories cache (covers all non-archived lessons).
+    const found = cacheLessons?.find(
+      (l) => l.scope === lessonRef.scope && l.key === lessonRef.key,
+    );
+    if (found) return found;
+    // 2. A caller-supplied prefetch (e.g. an archived memory not in the cache).
+    if (
+      prefetched &&
+      prefetched.scope === lessonRef.scope &&
+      prefetched.key === lessonRef.key
+    ) {
+      return prefetched;
+    }
+    // Set but unresolved: show nothing — never fall through to `memoryId`.
+    return null;
+  }
+
+  // No `lesson` — the `memoryId` deep link, fetched by id directly.
+  if (memoryId && memoryByIdLesson) return memoryByIdLesson;
+  return null;
+}

--- a/packages/web/src/lib/open-lesson.ts
+++ b/packages/web/src/lib/open-lesson.ts
@@ -21,6 +21,27 @@ export interface LessonRef {
  * node vitest project — the reason the resolution lives here rather than inline
  * in the client provider.
  */
+/**
+ * The `memoryId` that is still open: the URL's param, unless the user has
+ * dismissed that exact id.
+ *
+ * Closing the sheet deliberately does NOT strip `?memoryId=` from the URL. That
+ * strip needed its own `router.replace`, built from the pre-mutation search
+ * params, and the Lore Explorer calls `closeLesson()` in the same tick as its
+ * own scope / filter writes — so the second navigation landed last and clobbered
+ * the scope or filter the user had just set. Dismissal is local state instead,
+ * keyed BY id so a later deep link to a different memory still opens the sheet.
+ * The cost is that the param survives in the URL, which only means a refresh
+ * re-opens the deep link it names.
+ */
+export function activeMemoryId(
+  memoryId: string | null,
+  dismissedMemoryId: string | null,
+): string | null {
+  if (memoryId === null || memoryId === dismissedMemoryId) return null;
+  return memoryId;
+}
+
 export function resolveOpenLesson(args: {
   lessonRef: LessonRef | null;
   cacheLessons: LessonEntry[] | undefined;

--- a/packages/web/src/lib/queries/lore-auth.spec.ts
+++ b/packages/web/src/lib/queries/lore-auth.spec.ts
@@ -8,9 +8,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { RestApiError } from '@/lib/api/rest';
 import {
   NotAuthenticatedError,
   isNotAuthenticated,
+  isUnretryableRequest,
+  retryMemoryById,
   retryUnlessSignedOut,
 } from './lore';
 
@@ -37,5 +40,41 @@ describe('retryUnlessSignedOut', () => {
     expect(retryUnlessSignedOut(0, transient)).toBe(true);
     expect(retryUnlessSignedOut(2, transient)).toBe(true);
     expect(retryUnlessSignedOut(3, transient)).toBe(false);
+  });
+});
+
+describe('isUnretryableRequest', () => {
+  it('recognises the two answers a bad or unresolvable memoryId gets', () => {
+    expect(isUnretryableRequest(new RestApiError(404, 'Not found'))).toBe(true);
+    expect(isUnretryableRequest(new RestApiError(400, 'Invalid uuid'))).toBe(true);
+  });
+
+  it('leaves anything that might succeed on a second attempt alone', () => {
+    expect(isUnretryableRequest(new RestApiError(500, 'Boom'))).toBe(false);
+    expect(isUnretryableRequest(new RestApiError(429, 'Slow down'))).toBe(false);
+    expect(isUnretryableRequest(new RestApiError(401, 'Unauthorized'))).toBe(false);
+    expect(isUnretryableRequest(new Error('fetch failed'))).toBe(false);
+    expect(isUnretryableRequest({ status: 404 })).toBe(false);
+  });
+});
+
+describe('retryMemoryById', () => {
+  it('never retries a 404 — an archived or unknown id answers the same every time', () => {
+    expect(retryMemoryById(0, new RestApiError(404, 'Not found'))).toBe(false);
+  });
+
+  it('never retries a 400 — the id is not a UUID and will not become one', () => {
+    expect(retryMemoryById(0, new RestApiError(400, 'Invalid uuid'))).toBe(false);
+  });
+
+  it('still never retries a signed-out read', () => {
+    expect(retryMemoryById(0, new NotAuthenticatedError())).toBe(false);
+  });
+
+  it('keeps the default budget for a failure that might be transient', () => {
+    const transient = new RestApiError(503, 'Service unavailable');
+    expect(retryMemoryById(0, transient)).toBe(true);
+    expect(retryMemoryById(2, transient)).toBe(true);
+    expect(retryMemoryById(3, transient)).toBe(false);
   });
 });

--- a/packages/web/src/lib/queries/lore.ts
+++ b/packages/web/src/lib/queries/lore.ts
@@ -10,7 +10,13 @@ import type { DateRange } from '@/components/ui/DateRangePicker';
 import { normalizeTags } from '@/lib/tag-filter';
 import { lessonFromMemoryEntry } from '@/lib/lesson-entry';
 import { browserAccessToken } from '@/lib/api/session-browser';
-import { activityRequest, listFacetsRequest, listMemoriesRequest, listScopesRequest } from '@/lib/api/memories';
+import {
+  activityRequest,
+  getMemoryByIdRequest,
+  listFacetsRequest,
+  listMemoriesRequest,
+  listScopesRequest,
+} from '@/lib/api/memories';
 import { normalizeFilters, type FacetValue, type Filter } from '@/lib/filters';
 
 export interface LoreData {
@@ -190,6 +196,30 @@ export function useLoreData() {
     queryKey: ['lore'],
     queryFn: ({ signal }) => fetchLoreData(signal),
     // Lore explorer is read-heavy — keep data for 90 s before refetching.
+    staleTime: 90_000,
+    retry: retryUnlessSignedOut,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Single memory by DB row id.
+//
+// Resolves a `/lore?memoryId=…` deep link directly, so the detail sheet opens
+// regardless of whether the row is in the Explorer's recent/active window — the
+// limitation the `?lesson=` scope+key form has, since it only resolves against
+// the loaded page set. Disabled (no fetch) when `id` is null.
+// ---------------------------------------------------------------------------
+
+export function useMemoryById(id: string | null) {
+  return useQuery<LessonEntry | null>({
+    queryKey: ['memory-by-id', id],
+    enabled: id !== null,
+    queryFn: async ({ signal }) => {
+      if (!id) return null;
+      const token = await requireBrowserToken();
+      const entry = await getMemoryByIdRequest(token, id, signal);
+      return lessonFromMemoryEntry(entry);
+    },
     staleTime: 90_000,
     retry: retryUnlessSignedOut,
   });

--- a/packages/web/src/lib/queries/lore.ts
+++ b/packages/web/src/lib/queries/lore.ts
@@ -17,6 +17,7 @@ import {
   listMemoriesRequest,
   listScopesRequest,
 } from '@/lib/api/memories';
+import { RestApiError } from '@/lib/api/rest';
 import { normalizeFilters, type FacetValue, type Filter } from '@/lib/filters';
 
 export interface LoreData {
@@ -80,6 +81,27 @@ export function isNotAuthenticated(error: unknown): boolean {
  */
 export function retryUnlessSignedOut(failureCount: number, error: unknown): boolean {
   return !isNotAuthenticated(error) && failureCount < 3;
+}
+
+/**
+ * True when the API answered that the REQUEST cannot succeed, whoever asks and
+ * however often: the id is not a UUID (`400`, `GET /memories/:id` validates it)
+ * or it names no memory this account can see (`404` — an archived, purged or
+ * foreign row). Both are documented outcomes of a hand-built `?memoryId=` deep
+ * link, not transport failures.
+ */
+export function isUnretryableRequest(error: unknown): boolean {
+  return error instanceof RestApiError && (error.status === 400 || error.status === 404);
+}
+
+/**
+ * {@link useMemoryById}'s retry policy: {@link retryUnlessSignedOut} plus the two
+ * answers a by-id read gets when the id itself is the problem. The signed-out
+ * rule alone retries everything else, so a deep link to an archived or bad id
+ * spent four requests and four renders reaching the same 404.
+ */
+export function retryMemoryById(failureCount: number, error: unknown): boolean {
+  return !isUnretryableRequest(error) && retryUnlessSignedOut(failureCount, error);
 }
 
 async function requireBrowserToken(): Promise<string> {
@@ -221,7 +243,7 @@ export function useMemoryById(id: string | null) {
       return lessonFromMemoryEntry(entry);
     },
     staleTime: 90_000,
-    retry: retryUnlessSignedOut,
+    retry: retryMemoryById,
   });
 }
 


### PR DESCRIPTION
## What

Adds a plain `?memoryId=<uuid>` deep-link form to the `/lore` Explorer that fetches one memory **by its DB row id** (a UUID) and opens its detail sheet directly:

```text
https://lorekit.io/lore?memoryId=9b2c1d34-5e6f-4a7b-8c9d-0e1f2a3b4c5d
```

## Why

The existing `?lesson=<{scope,key}>` form resolves the open memory only against the Explorer's recent/active page set (`useLoreData`), so a link to a memory outside that window opens a **blank sheet** — a limitation the docs already called out. External tools that build memory links (e.g. a PR-reviewer bot linking the memories that influenced a review) hit this regularly, and the scope+key form also requires inverting the dashboard's `useUrlState` encoding (URL-encoded JSON), which is fragile to hand-build.

`?memoryId=` fixes both:
- It fetches the row by id via the existing `GET /memories/:id`, so it opens **regardless of the recent/active window**.
- It is a **raw UUID** — nothing to double-encode — so a tool can build `{base}/lore?memoryId=<uuid>` trivially. (`GET /memories/:id` validates the UUID, so a non-UUID value 400s.)

## How

- **`getMemoryByIdRequest`** (`lib/api/memories.ts`) — typed wrapper over the existing `GET /memories/:id` endpoint.
- **`useMemoryById`** (`lib/queries/lore.ts`) — fetches and maps to a `LessonEntry` through the single `lessonFromMemoryEntry` mapper; disabled when no id.
- **`resolveOpenLesson`** (`lib/open-lesson.ts`, pure + unit-tested) — the detail-sheet resolution precedence: `lesson` **strictly wins**, so a cache-missing `lesson` shows nothing rather than falling through to a stale `memoryId` (which would display the wrong memory).
- **`MemorySidebarProvider`** — reads `memoryId` from the **raw search params** (deliberately not `useUrlState`, so there's no JSON encoding and no change to the web↔CLI param-parity set) and resolves the sheet via `resolveOpenLesson`.
- **`activeMemoryId`** (`lib/open-lesson.ts`, pure + unit-tested) — closing the sheet dismisses that exact id in **local state** and deliberately does **not** strip `?memoryId=` from the URL: the strip needed its own `router.replace` built from the pre-mutation search params, and the Explorer calls `closeLesson()` in the same tick as its own scope / filter writes, so that second navigation landed last and clobbered the scope or filter the user had just set. Keying the dismissal by id means a later deep link to a different memory still opens; the cost is that the param survives, so a refresh re-opens the link it names.
- **`deep-links.mdx`** — documents `?memoryId=` as the recommended single-memory link and reframes the scope+key form as the alternative.

Archived rows are the one exception — they 404 by id and remain openable via scope+key from the archived list. Documented.

## Verification

- `nx typecheck web` — pass
- `nx lint web` — 0 errors (pre-existing warnings only)
- `open-lesson.spec.ts` — 11/11 (7 `resolveOpenLesson`, covering the `memoryId` deep-link path and the strict-precedence regression; 4 `activeMemoryId`, covering dismiss / re-open-a-different-id / no-param)
- `lore-auth.spec.ts` — 10/10, including 6 new cases for the by-id retry policy (`isUnretryableRequest`, `retryMemoryById`: never retry a 404 or a 400, never retry a signed-out read, keep the default budget for a transient failure)
- CLI `test/deeplink.test.mjs` — 41/41 pass (incl. web↔CLI `useUrlState` param-parity and docs-URL reproducibility)
- web unit tests (`lesson-entry`, `api/rest`, `useUrlState`, `open-lesson`) — pass

## Companion

Pairs with an agent-skills change (PR #80) that builds `{base}/lore?memoryId=<uuid>` for the memories that influenced a PR review, replacing the fragile encoded scope+lesson link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZutnpuj1geCMfczuCB35o
