### PR TITLE
feat(web): clickable PR chip on memory cards

### DIFF
--- a/packages/web/src/components/memory/MemoryCard.test.stories.tsx
+++ b/packages/web/src/components/memory/MemoryCard.test.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, within } from 'storybook/test';
+import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { MemoryCard, memoryFromLesson } from './MemoryCard';
 
@@ -58,6 +58,58 @@ export const NoChipWithoutPr: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.queryByRole('link', { name: /pull request/i })).toBeNull();
+  },
+};
+
+/**
+ * The chip forced the card root from a <button> to a <div> with a stretched
+ * open-button behind a `pointer-events-none` body (an anchor may not nest in a
+ * button). These two pin the halves of that restructure that the presence tests
+ * above cannot see: the card still opens, and the chip does not open it.
+ */
+export const CardStillOpens: Story = {
+  args: {
+    memory: memoryFromLesson({
+      ...BASE,
+      key: 'aw-lessons::card-opens',
+      origin_repo: 'mthines/lorekit',
+      origin_pr: 482,
+    }),
+    onClick: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    // The body is pointer-events-none; the whole-card action is the stretched
+    // button behind it, which is what a click anywhere on the card resolves to.
+    await userEvent.click(canvas.getByRole('button', { name: /open memory/i }));
+    await expect(args.onClick).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const ChipClickDoesNotOpenMemory: Story = {
+  args: {
+    memory: memoryFromLesson({
+      ...BASE,
+      key: 'aw-lessons::chip-click',
+      origin_repo: 'mthines/lorekit',
+      origin_pr: 482,
+    }),
+    onClick: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    // The chip is a real link with target="_blank"; swallow the navigation so
+    // the assertion is about the card's onClick, not about a popped-open tab.
+    canvasElement.addEventListener(
+      'click',
+      (event) => {
+        if ((event.target as HTMLElement).closest('a')) event.preventDefault();
+      },
+      true,
+    );
+
+    await userEvent.click(canvas.getByRole('link', { name: /open pull request #482 on github/i }));
+    await expect(args.onClick).not.toHaveBeenCalled();
   },
 };
 

--- a/packages/web/src/components/memory/MemoryCard.test.stories.tsx
+++ b/packages/web/src/components/memory/MemoryCard.test.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import { MemoryCard, memoryFromLesson } from './MemoryCard';
+
+/**
+ * Interaction tests for the memory card's PR chip: a card recorded from a GitHub
+ * PR (`origin_repo` + `origin_pr`) renders a real link straight to that PR, so
+ * you can jump to it without opening the memory. `/Tests` namespace + test tag +
+ * `chromatic.disableSnapshot` so these run their `play` functions without adding
+ * a visual snapshot.
+ */
+const meta: Meta<typeof MemoryCard> = {
+  title: 'Components/MemoryCard/Tests',
+  component: MemoryCard,
+  tags: ['test'],
+  parameters: { chromatic: { disableSnapshot: true }, layout: 'padded' },
+};
+
+export default meta;
+type Story = StoryObj<typeof MemoryCard>;
+
+const BASE = {
+  scope: 'global',
+  scope_type: 'global' as const,
+  value: 'Branch a worktree from the stacked PR head, never main.',
+  tags: ['loop::aw-lessons'],
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+};
+
+export const JumpsToPullRequest: Story = {
+  args: {
+    memory: memoryFromLesson({
+      ...BASE,
+      key: 'aw-lessons::worktree-isolation',
+      origin_repo: 'mthines/lorekit',
+      origin_pr: 482,
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = await canvas.findByRole('link', { name: /open pull request #482 on github/i });
+    await expect(link).toHaveAttribute('href', 'https://github.com/mthines/lorekit/pull/482');
+    await expect(link).toHaveAttribute('target', '_blank');
+    await expect(link).toHaveTextContent('#482');
+  },
+};
+
+export const NoChipWithoutPr: Story = {
+  args: {
+    memory: memoryFromLesson({
+      ...BASE,
+      key: 'aw-lessons::no-provenance',
+      // No origin_repo / origin_pr — the chip must not appear.
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('link', { name: /pull request/i })).toBeNull();
+  },
+};
+
+export const NoChipWhenRepoButNoPr: Story = {
+  args: {
+    memory: memoryFromLesson({
+      ...BASE,
+      key: 'aw-lessons::repo-only',
+      origin_repo: 'mthines/lorekit',
+      // origin_pr absent — a repo alone is not enough for a PR link.
+    }),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByRole('link', { name: /pull request/i })).toBeNull();
+  },
+};

--- a/packages/web/src/components/memory/MemoryCard.tsx
+++ b/packages/web/src/components/memory/MemoryCard.tsx
@@ -18,11 +18,12 @@
 import type { ReactNode } from 'react';
 import { memo } from 'react';
 import { motion, useReducedMotion } from 'motion/react';
-import { Clock, Bot, Zap, Timer } from 'lucide-react';
+import { Clock, Bot, Zap, Timer, GitPullRequest } from 'lucide-react';
 import { ScopeBadge } from './ScopeBadge';
 import { OwnershipBadge } from './OwnershipBadge';
 import type { ScopePrefix } from './scope-meta';
 import type { MemoryOwner } from '@/lib/ownership';
+import { originPullRequestUrl } from '@/lib/origin';
 
 // ── Model ───────────────────────────────────────────────────────────────────
 
@@ -44,6 +45,12 @@ export interface MemoryCardModel {
   org?: MemoryOwner;
   /** ISO expiry timestamp. Null/undefined = never expires. */
   expiresAt?: string | null;
+  /**
+   * GitHub pull-request link, derived from the origin (`origin_repo` + `origin_pr`).
+   * Null when the memory has no PR provenance — the card shows the chip only when
+   * both are present, so you can jump to the PR without opening the memory.
+   */
+  pr?: { url: string; label: string } | null;
 }
 
 /** Adapt a Lore Explorer lesson (LessonEntry-shaped) into the card model. */
@@ -60,7 +67,12 @@ export function memoryFromLesson(lesson: {
   archived_at?: string | null;
   org?: MemoryOwner;
   expires_at?: string | null;
+  origin_repo?: string | null;
+  origin_pr?: number | null;
 }): MemoryCardModel {
+  // A PR chip needs both a valid repo and PR number; `originPullRequestUrl`
+  // returns null unless both are present and well-formed.
+  const prUrl = originPullRequestUrl(lesson);
   return {
     scope: lesson.scope,
     scopeType: lesson.scope_type,
@@ -75,6 +87,7 @@ export function memoryFromLesson(lesson: {
     archived: Boolean(lesson.archived_at),
     org: lesson.org,
     expiresAt: lesson.expires_at ?? null,
+    pr: prUrl ? { url: prUrl, label: `#${lesson.origin_pr}` } : null,
   };
 }
 
@@ -225,6 +238,7 @@ export const MemoryCard = memo(function MemoryCard({
     timestamp,
     org,
     expiresAt,
+    pr,
   } = memory;
 
   const keyCode = (
@@ -243,6 +257,25 @@ export const MemoryCard = memo(function MemoryCard({
       <Clock className="size-3" aria-hidden />
       {formatRelativeTime(timestamp)}
     </span>
+  );
+
+  // A real link (not nested in the card's open-button), so a click jumps to the
+  // PR instead of opening the memory. `pointer-events-auto` lets it sit above
+  // the card layout's stretched open-button overlay; `stopPropagation` is belt
+  // and braces for the row layout where the whole card is still a button.
+  const prChip = pr && (
+    <a
+      href={pr.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={(e) => e.stopPropagation()}
+      aria-label={`Open pull request ${pr.label} on GitHub`}
+      title={`Open pull request ${pr.label} on GitHub`}
+      className="pointer-events-auto flex shrink-0 items-center gap-1 rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-bg)] px-1.5 py-0.5 font-mono text-xs text-[var(--color-content-tertiary)] transition-colors duration-150 hover:border-[var(--color-accent)] hover:text-[var(--color-accent)]"
+    >
+      <GitPullRequest className="size-3" aria-hidden />
+      {pr.label}
+    </a>
   );
 
   // ── Compact (dropdown row) ──────────────────────────────────────────────────
@@ -348,45 +381,62 @@ export const MemoryCard = memo(function MemoryCard({
   // ── Card (lore explorer) ────────────────────────────────────────────────────
   // Header mirrors the row layout — [scope pill] key … timestamp — so the card
   // and the activity row read the same; only the leading icon and density differ.
+  //
+  // The card root is a <div>, not a <button>, so the PR chip can be a real <a>
+  // inside it — an anchor nested in a button is invalid HTML. The whole-card
+  // "open" action is a stretched <button> overlay behind the content; the content
+  // is pointer-events-none so clicks fall through to that button, except the PR
+  // chip, which re-enables pointer events and sits on top.
   const withPath = showScopePath ?? false;
   const hasMeta = showMeta && Boolean(sourceAgent || trigger);
   return (
-    <motion.button
-      type="button"
-      onClick={onClick}
-      aria-pressed={selected}
+    <motion.div
       {...motionProps}
       className={[
-        'group w-full rounded-xl border p-4 text-left transition-all duration-150',
+        'group relative w-full rounded-xl border transition-all duration-150',
         selected
           ? SELECTED_CARD
           : 'border-[var(--color-border)] bg-[var(--color-bg-raised)] hover:bg-[var(--color-bg-elevated)]',
         className,
       ].join(' ')}
     >
-      <div className="mb-2 flex flex-wrap items-center gap-1.5">
-        {showScope && <ScopeBadge scope={scope} type={type} label />}
-        <OwnershipBadge org={org} />
-        {keyCode}
-        <ExpiryBadge expiresAt={expiresAt} />
-        {timeEl && <span className="ml-auto">{timeEl}</span>}
-      </div>
-
-      {showPreview && (
-        <p className="mb-3 line-clamp-2 text-xs text-[var(--color-content-secondary)]">{preview}</p>
-      )}
-
-      {(hasMeta || withPath) && (
-        <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--color-content-tertiary)]">
-          {showMeta && sourceAgent && <MetaChip icon={Bot}>{sourceAgent}</MetaChip>}
-          {showMeta && trigger && <MetaChip icon={Zap}>{trigger}</MetaChip>}
-          {withPath && (
-            <ScopeBadge scope={scope} type={type} showBadge={false} showPath className="min-w-0" />
+      <button
+        type="button"
+        onClick={onClick}
+        aria-pressed={selected}
+        aria-label={`Open memory ${memoryKey}`}
+        className="absolute inset-0 z-0 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+      />
+      <div className="pointer-events-none relative z-10 p-4 text-left">
+        <div className="mb-2 flex flex-wrap items-center gap-1.5">
+          {showScope && <ScopeBadge scope={scope} type={type} label />}
+          <OwnershipBadge org={org} />
+          {keyCode}
+          <ExpiryBadge expiresAt={expiresAt} />
+          {(prChip || timeEl) && (
+            <span className="ml-auto flex items-center gap-1.5">
+              {prChip}
+              {timeEl}
+            </span>
           )}
         </div>
-      )}
 
-      {showTags && <Tags tags={tags} />}
-    </motion.button>
+        {showPreview && (
+          <p className="mb-3 line-clamp-2 text-xs text-[var(--color-content-secondary)]">{preview}</p>
+        )}
+
+        {(hasMeta || withPath) && (
+          <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--color-content-tertiary)]">
+            {showMeta && sourceAgent && <MetaChip icon={Bot}>{sourceAgent}</MetaChip>}
+            {showMeta && trigger && <MetaChip icon={Zap}>{trigger}</MetaChip>}
+            {withPath && (
+              <ScopeBadge scope={scope} type={type} showBadge={false} showPath className="min-w-0" />
+            )}
+          </div>
+        )}
+
+        {showTags && <Tags tags={tags} />}
+      </div>
+    </motion.div>
   );
 });

--- a/packages/web/src/components/memory/MemoryCard.tsx
+++ b/packages/web/src/components/memory/MemoryCard.tsx
@@ -265,9 +265,10 @@ export const MemoryCard = memo(function MemoryCard({
   );
 
   // A real link (not nested in the card's open-button), so a click jumps to the
-  // PR instead of opening the memory. `pointer-events-auto` lets it sit above
-  // the card layout's stretched open-button overlay; `stopPropagation` is belt
-  // and braces for the row layout where the whole card is still a button.
+  // PR instead of opening the memory. Rendered by the card layout only.
+  // `pointer-events-auto` lets it sit above that layout's stretched open-button
+  // overlay; `stopPropagation` keeps a chip click from reaching any clickable
+  // ancestor a caller may wrap the card in.
   const prChip = pr && (
     <a
       href={pr.url}

--- a/packages/web/src/components/memory/MemoryCard.tsx
+++ b/packages/web/src/components/memory/MemoryCard.tsx
@@ -155,13 +155,18 @@ export function expiryStatus(iso: string | null | undefined): { label: string; u
   return null;
 }
 
-function ExpiryBadge({ expiresAt }: { expiresAt?: string | null }) {
+// `pointer-events-auto` is load-bearing: the card layout renders the badge inside
+// a `pointer-events-none` body, which would also suppress the native `title`
+// tooltip below. Re-enabling pointer events makes the badge its own hit target,
+// so it forwards `onClick` to keep the whole-card "open" action intact.
+function ExpiryBadge({ expiresAt, onClick }: { expiresAt?: string | null; onClick?: () => void }) {
   const status = expiryStatus(expiresAt);
   if (!status) return null;
   return (
     <span
+      onClick={onClick}
       className={[
-        'flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-px text-xs',
+        'pointer-events-auto flex shrink-0 items-center gap-1 rounded-full border px-1.5 py-px text-xs',
         status.urgent
           ? 'border-amber-400/30 bg-amber-400/10 text-amber-400'
           : 'border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] text-[var(--color-content-tertiary)]',
@@ -385,8 +390,10 @@ export const MemoryCard = memo(function MemoryCard({
   // The card root is a <div>, not a <button>, so the PR chip can be a real <a>
   // inside it — an anchor nested in a button is invalid HTML. The whole-card
   // "open" action is a stretched <button> overlay behind the content; the content
-  // is pointer-events-none so clicks fall through to that button, except the PR
-  // chip, which re-enables pointer events and sits on top.
+  // is pointer-events-none so clicks fall through to that button, except the two
+  // elements that re-enable pointer events and sit on top: the PR chip (its own
+  // link target) and the expiry badge (so its native tooltip still shows on
+  // hover — it forwards the click back to the open action).
   const withPath = showScopePath ?? false;
   const hasMeta = showMeta && Boolean(sourceAgent || trigger);
   return (
@@ -412,7 +419,7 @@ export const MemoryCard = memo(function MemoryCard({
           {showScope && <ScopeBadge scope={scope} type={type} label />}
           <OwnershipBadge org={org} />
           {keyCode}
-          <ExpiryBadge expiresAt={expiresAt} />
+          <ExpiryBadge expiresAt={expiresAt} onClick={onClick} />
           {(prChip || timeEl) && (
             <span className="ml-auto flex items-center gap-1.5">
               {prChip}


### PR DESCRIPTION
## What

A memory recorded from a GitHub PR (`origin_repo` + `origin_pr`) now shows a clickable **PR chip** on its Explorer card, so you can jump straight to the pull request instead of opening the memory and using the detail sheet's link.

The chip sits in the card header, next to the timestamp:

```
[scope] [owner] key … [⇄ #482] [2m ago]
```

## How

- **`memoryFromLesson`** derives the PR link from the existing pure `originPullRequestUrl` (repo + PR validated — malformed repo, path-traversal, or a non-integer PR all yield no link). The chip renders only when both a valid repo and PR number are present.
- **Card layout** — the card root becomes a `<div>` with a **stretched open-button overlay** so the PR chip can be a real `<a>` (an anchor nested in a `<button>` is invalid HTML). The card content is `pointer-events-none` so clicks fall through to the open-button, except the chip, which re-enables pointer events and sits on top. The open action, selection, hover, focus ring, and animation are all preserved. Row/compact layouts are unchanged.
- The chip is a real link (`target="_blank"`, `rel="noopener noreferrer"`), keyboard-focusable, with an `aria-label` — and `stopPropagation` so it never also opens the memory.

## Tests

`MemoryCard.test.stories.tsx` (screenshot-free interaction tests) covers all three cases:
- PR present → a link with the correct `https://github.com/<repo>/pull/<n>` href and `target="_blank"`
- no origin → no chip
- repo but no PR → no chip

## Verification

- `nx typecheck web` — pass
- `nx lint web` — 0 errors (pre-existing warnings only)
- Storybook interaction + visual suite — **53/53 pass**, no snapshot changes (the button→div restructure is visually identical when no chip is present, and the card stories with `origin_pr` fixtures aren't in a captured screenshot crop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZutnpuj1geCMfczuCB35o

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZutnpuj1geCMfczuCB35o)_