### PR TITLE
fix(web): resolve ?lesson= deep links outside the recent window

### DIFF
--- a/packages/web/src/components/providers/MemorySidebarProvider.tsx
+++ b/packages/web/src/components/providers/MemorySidebarProvider.tsx
@@ -56,9 +56,18 @@ interface MemorySidebarContextValue {
   openLessonRef: LessonRef | null;
   /**
    * Open the sidebar for a specific lesson. Reacts immediately (optimistic).
+   *
    * Pass the full `lesson` object when the caller already has it (e.g. from
    * the archived list) so the sidebar can render without a separate lookup.
-   * Active-list callers omit it; the provider resolves it from useLoreData.
+   * Active-list callers omit it; the provider resolves it from `useLoreData`.
+   *
+   * Omitting it is only free for a caller that renders its OWN list from
+   * `useLoreData` — `NavigationCommands` and `MemoryExpandButton` both do, so
+   * the memory is in the provider's `cacheLessons` by construction and
+   * `lessonResolvedLocally` keeps the click off the network. A caller that
+   * sources the ref from anywhere else (a URL, a search result, a webhook
+   * payload) and omits the prefetch triggers a `useLessonByRef` fetch — which
+   * is correct, and is the deep-link path, but it is a network round-trip.
    */
   openLessonById: (ref: LessonRef, lesson?: LessonEntry) => void;
   /** Close the sidebar. Reacts immediately (optimistic). */

--- a/packages/web/src/components/providers/MemorySidebarProvider.tsx
+++ b/packages/web/src/components/providers/MemorySidebarProvider.tsx
@@ -38,7 +38,7 @@ import { createContext, useCallback, useContext, useMemo, useRef, useState } fro
 import { useSearchParams } from 'next/navigation';
 import { useUrlState } from '@/lib/hooks/useUrlState';
 import { LessonDetailSheet } from '@/components/lore/LessonDetailSheet';
-import { useLoreData, useMemoryById } from '@/lib/queries/lore';
+import { useLoreData, useMemoryById, useLessonByRef } from '@/lib/queries/lore';
 import { activeMemoryId, resolveOpenLesson, type LessonRef } from '@/lib/open-lesson';
 import type { LessonEntry } from '@/components/lore/LessonCard';
 
@@ -115,6 +115,20 @@ export function MemorySidebarProvider({ children }: MemorySidebarProviderProps) 
   const memoryId = activeMemoryId(urlMemoryId, dismissedMemoryId);
   const { data: memoryByIdLesson } = useMemoryById(memoryId);
 
+  // A shared `?lesson={scope,key}` link opens blank when the memory is outside
+  // the Explorer's recent/active window — the sheet only resolved the ref
+  // against the loaded page set. Fetch it by scope+key as a fallback, but only
+  // when it isn't already resolvable locally: an in-app click always supplies a
+  // prefetch, so only a cold deep-link visit reaches the network.
+  const lessonResolvedLocally = Boolean(
+    lessonRef &&
+      (data?.lessons?.some((l) => l.scope === lessonRef.scope && l.key === lessonRef.key) ||
+        (prefetched &&
+          prefetched.scope === lessonRef.scope &&
+          prefetched.key === lessonRef.key)),
+  );
+  const { data: lessonByRef } = useLessonByRef(lessonResolvedLocally ? null : lessonRef);
+
   // Resolution precedence lives in the pure `resolveOpenLesson` (unit-tested):
   // `lesson` strictly wins, so a cache-missing `lesson` shows nothing rather
   // than falling through to whatever `memoryId` is still in the URL.
@@ -124,10 +138,11 @@ export function MemorySidebarProvider({ children }: MemorySidebarProviderProps) 
         lessonRef,
         cacheLessons: data?.lessons,
         prefetched,
+        lessonByRef,
         memoryId,
         memoryByIdLesson,
       }),
-    [lessonRef, data, prefetched, memoryId, memoryByIdLesson],
+    [lessonRef, data, prefetched, lessonByRef, memoryId, memoryByIdLesson],
   );
 
   const openLessonById = useCallback(

--- a/packages/web/src/components/providers/MemorySidebarProvider.tsx
+++ b/packages/web/src/components/providers/MemorySidebarProvider.tsx
@@ -39,7 +39,12 @@ import { useSearchParams } from 'next/navigation';
 import { useUrlState } from '@/lib/hooks/useUrlState';
 import { LessonDetailSheet } from '@/components/lore/LessonDetailSheet';
 import { useLoreData, useMemoryById, useLessonByRef } from '@/lib/queries/lore';
-import { activeMemoryId, resolveOpenLesson, type LessonRef } from '@/lib/open-lesson';
+import {
+  activeMemoryId,
+  lessonResolvedLocally,
+  resolveOpenLesson,
+  type LessonRef,
+} from '@/lib/open-lesson';
 import type { LessonEntry } from '@/components/lore/LessonCard';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -118,16 +123,17 @@ export function MemorySidebarProvider({ children }: MemorySidebarProviderProps) 
   // A shared `?lesson={scope,key}` link opens blank when the memory is outside
   // the Explorer's recent/active window — the sheet only resolved the ref
   // against the loaded page set. Fetch it by scope+key as a fallback, but only
-  // when it isn't already resolvable locally: an in-app click always supplies a
-  // prefetch, so only a cold deep-link visit reaches the network.
-  const lessonResolvedLocally = Boolean(
-    lessonRef &&
-      (data?.lessons?.some((l) => l.scope === lessonRef.scope && l.key === lessonRef.key) ||
-        (prefetched &&
-          prefetched.scope === lessonRef.scope &&
-          prefetched.key === lessonRef.key)),
-  );
-  const { data: lessonByRef } = useLessonByRef(lessonResolvedLocally ? null : lessonRef);
+  // when it isn't already resolvable locally, so only a cold deep-link visit
+  // reaches the network. The predicate is the pure, unit-tested
+  // `lessonResolvedLocally` — see its docblock for why the active-memories
+  // cache, not the click-prefetch, is what covers the palette and the header
+  // dropdown (both call `openLessonById` with the ref alone).
+  const resolvedLocally = lessonResolvedLocally({
+    lessonRef,
+    cacheLessons: data?.lessons,
+    prefetched,
+  });
+  const { data: lessonByRef } = useLessonByRef(resolvedLocally ? null : lessonRef);
 
   // Resolution precedence lives in the pure `resolveOpenLesson` (unit-tested):
   // `lesson` strictly wins, so a cache-missing `lesson` shows nothing rather

--- a/packages/web/src/content/docs/deep-links.mdx
+++ b/packages/web/src/content/docs/deep-links.mdx
@@ -59,7 +59,7 @@ The robust way to open one memory is by its **id** — a plain, un-encoded query
 https://lorekit.io/lore?memoryId=9b2c1d34-5e6f-4a7b-8c9d-0e1f2a3b4c5d
 ```
 
-The id is the memory's UUID (the `id` column) — `GET /memories/:id` validates it, so a non-UUID value 400s. Unlike every other Explorer parameter, `memoryId` is **not** JSON-encoded — it is the raw UUID, so there is nothing to double-encode and nothing to get wrong when a tool builds the link by hand (`{base}/lore?memoryId=<uuid>`). The dashboard fetches that memory **by id directly**, so the detail sheet opens even when the memory is outside the Explorer's recent/active window — the case where the scope + key form below opens blank. Archived memories are the one exception: they are addressed by scope + key and open from the archived list, so `memoryId` returns nothing for them.
+The id is the memory's UUID (the `id` column) — `GET /memories/:id` validates it, so a non-UUID value 400s. Unlike every other Explorer parameter, `memoryId` is **not** JSON-encoded — it is the raw UUID, so there is nothing to double-encode and nothing to get wrong when a tool builds the link by hand (`{base}/lore?memoryId=<uuid>`). The dashboard fetches that memory **by id directly**, so the detail sheet opens even when the memory is outside the Explorer's recent/active window. Archived memories are the one exception: `GET /memories/:id` skips archived rows, so `memoryId` returns nothing for them — open them from the archived list.
 
 ## Link to a specific memory by scope + key
 
@@ -70,7 +70,7 @@ The older form opens a memory's detail sheet via its `scope` + `key`. The link s
 https://lorekit.io/lore?scope=%22global%22&lesson=%7B%22scope%22%3A%22global%22%2C%22key%22%3A%22prefer-guard-clauses%22%7D
 ```
 
-The detail sheet resolves this form from a recent, unfiltered set, so a memory older than that window or an archived one can still open blank. When you have the memory's id, prefer `?memoryId=` above — it fetches by id and does not have this limitation.
+The detail sheet resolves this form from the active-memory cache, and when the memory is outside that recent window it fetches it by scope + key — so any **active** memory opens, however old. An **archived** memory is the exception: the by-key read returns only active rows, so an archived deep link opens blank; open it from the archived list instead. (`?memoryId=` above has the same archived limitation, since `GET /memories/:id` also skips archived rows.)
 
 ## Link to a search or a filtered view
 

--- a/packages/web/src/lib/api/memories.ts
+++ b/packages/web/src/lib/api/memories.ts
@@ -40,6 +40,26 @@ export function listMemoriesRequest(
   });
 }
 
+/**
+ * A single memory by its natural key (scope + key), or null when none matches.
+ *
+ * There is no scope+key GET route — `GET /memories/:id` is UUID-only — but the
+ * list route applies `key` as an exact match (`.eq`, not the substring `q`
+ * filter), so `?scope=&key=&limit=1` is a precise one-row read: the same query
+ * `updateLesson` uses to resolve a row. This wrapper hides the page envelope so
+ * callers read it as the get-by-ref it is.
+ */
+export function getMemoryByRefRequest(
+  accessToken: string,
+  scope: string,
+  key: string,
+  signal?: AbortSignal,
+): Promise<MemoryEntry | null> {
+  return listMemoriesRequest(accessToken, { scope, key, limit: 1 }, signal).then(
+    (page) => page.entries[0] ?? null,
+  );
+}
+
 export function listScopesRequest(accessToken: string, signal?: AbortSignal): Promise<ScopesResponse> {
   return restFetch<ScopesResponse>('/memories/scopes', {
     accessToken,

--- a/packages/web/src/lib/open-lesson.spec.ts
+++ b/packages/web/src/lib/open-lesson.spec.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect } from 'vitest';
 import type { MemoryEntry } from '@lorekit/schemas/memory';
 import { lessonFromMemoryEntry } from './lesson-entry';
-import { activeMemoryId, resolveOpenLesson } from './open-lesson';
+import { activeMemoryId, lessonResolvedLocally, resolveOpenLesson } from './open-lesson';
 
 function lesson(scope: string, key: string) {
   const entry: MemoryEntry = {
@@ -183,6 +183,92 @@ describe('resolveOpenLesson', () => {
         memoryByIdLesson: null,
       }),
     ).toBeNull();
+  });
+});
+
+describe('lessonResolvedLocally', () => {
+  // The gate on `useLessonByRef`. True suppresses the by-scope+key fetch, so
+  // every case here is really "does an in-app click stay off the network".
+
+  it('is false with no lesson ref — there is nothing to resolve, so nothing to fetch', () => {
+    expect(
+      lessonResolvedLocally({ lessonRef: null, cacheLessons: [A, B], prefetched: A }),
+    ).toBe(false);
+  });
+
+  it('is true from the active cache alone — the command palette / header-dropdown click', () => {
+    // `NavigationCommands` and `MemoryExpandButton` call `openLessonById(ref)`
+    // with NO prefetch; they render from the same `useLoreData()` query, so the
+    // cache arm is the only thing keeping those two clicks off the network.
+    expect(
+      lessonResolvedLocally({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: [A, B],
+        prefetched: null,
+      }),
+    ).toBe(true);
+  });
+
+  it('is true from a prefetch alone — the Lore Explorer click, which passes the lesson', () => {
+    expect(
+      lessonResolvedLocally({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: [],
+        prefetched: A,
+      }),
+    ).toBe(true);
+  });
+
+  it('is false when neither source holds it — the cold deep-link visit that must fetch', () => {
+    expect(
+      lessonResolvedLocally({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: [B],
+        prefetched: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('ignores a prefetch for a different ref, so a stale one cannot suppress the fetch', () => {
+    expect(
+      lessonResolvedLocally({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: [],
+        prefetched: B,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false while the cache is still loading', () => {
+    expect(
+      lessonResolvedLocally({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: undefined,
+        prefetched: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('agrees with resolveOpenLesson: whenever it says true, the resolver resolves without the fetch', () => {
+    // The property that makes the gate safe — a "resolved locally" verdict the
+    // resolver disagreed with would suppress the fetch and then show nothing.
+    const ref = { scope: 'global', key: 'a' };
+    for (const local of [
+      { cacheLessons: [A, B], prefetched: null },
+      { cacheLessons: [], prefetched: A },
+      { cacheLessons: [A], prefetched: A },
+    ]) {
+      expect(lessonResolvedLocally({ lessonRef: ref, ...local })).toBe(true);
+      expect(
+        resolveOpenLesson({
+          lessonRef: ref,
+          ...local,
+          lessonByRef: null,
+          memoryId: null,
+          memoryByIdLesson: null,
+        }),
+      ).toBe(A);
+    }
   });
 });
 

--- a/packages/web/src/lib/open-lesson.spec.ts
+++ b/packages/web/src/lib/open-lesson.spec.ts
@@ -41,6 +41,7 @@ describe('resolveOpenLesson', () => {
         lessonRef: { scope: 'global', key: 'a' },
         cacheLessons: [A, B],
         prefetched: null,
+        lessonByRef: null,
         memoryId: null,
         memoryByIdLesson: null,
       }),
@@ -53,6 +54,7 @@ describe('resolveOpenLesson', () => {
         lessonRef: { scope: 'global', key: 'a' },
         cacheLessons: [],
         prefetched: A,
+        lessonByRef: null,
         memoryId: null,
         memoryByIdLesson: null,
       }),
@@ -65,6 +67,7 @@ describe('resolveOpenLesson', () => {
         lessonRef: null,
         cacheLessons: [],
         prefetched: null,
+        lessonByRef: null,
         memoryId: 'id-global-a',
         memoryByIdLesson: A,
       }),
@@ -79,6 +82,7 @@ describe('resolveOpenLesson', () => {
         lessonRef: { scope: 'global', key: 'a' },
         cacheLessons: [],
         prefetched: null,
+        lessonByRef: null,
         memoryId: 'id-global-b',
         memoryByIdLesson: B,
       }),
@@ -91,6 +95,7 @@ describe('resolveOpenLesson', () => {
         lessonRef: { scope: 'global', key: 'a' },
         cacheLessons: [A],
         prefetched: null,
+        lessonByRef: null,
         memoryId: 'id-global-b',
         memoryByIdLesson: B,
       }),
@@ -103,6 +108,7 @@ describe('resolveOpenLesson', () => {
         lessonRef: null,
         cacheLessons: [],
         prefetched: null,
+        lessonByRef: null,
         memoryId: null,
         memoryByIdLesson: null,
       }),
@@ -115,8 +121,66 @@ describe('resolveOpenLesson', () => {
         lessonRef: null,
         cacheLessons: [],
         prefetched: null,
+        lessonByRef: null,
         memoryId: 'id-global-a',
         memoryByIdLesson: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  it('resolves a lesson by its fetched scope+key when it is outside the cache — the "opens blank" fix', () => {
+    // A shared `?lesson=` link to a memory not in the recent window: the
+    // by-scope+key fetch resolves it instead of the sheet opening blank.
+    expect(
+      resolveOpenLesson({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: [],
+        prefetched: null,
+        lessonByRef: A,
+        memoryId: null,
+        memoryByIdLesson: null,
+      }),
+    ).toBe(A);
+  });
+
+  it('prefers the cache over the by-ref fetch when both resolve the lesson', () => {
+    const cached = lesson('global', 'a');
+    expect(
+      resolveOpenLesson({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: [cached],
+        prefetched: null,
+        lessonByRef: A,
+        memoryId: null,
+        memoryByIdLesson: null,
+      }),
+    ).toBe(cached);
+  });
+
+  it('ignores a by-ref result for a different ref', () => {
+    // The fetch is keyed by scope+key; a stale result for another ref must not
+    // resolve the current one.
+    expect(
+      resolveOpenLesson({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: [],
+        prefetched: null,
+        lessonByRef: B,
+        memoryId: null,
+        memoryByIdLesson: null,
+      }),
+    ).toBeNull();
+  });
+
+  it('returns null while the by-ref fetch is still loading', () => {
+    expect(
+      resolveOpenLesson({
+        lessonRef: { scope: 'global', key: 'a' },
+        cacheLessons: [],
+        prefetched: null,
+        lessonByRef: undefined,
+        memoryId: null,
+        memoryByIdLesson: null,
       }),
     ).toBeNull();
   });

--- a/packages/web/src/lib/open-lesson.ts
+++ b/packages/web/src/lib/open-lesson.ts
@@ -46,10 +46,11 @@ export function resolveOpenLesson(args: {
   lessonRef: LessonRef | null;
   cacheLessons: LessonEntry[] | undefined;
   prefetched: LessonEntry | null;
+  lessonByRef: LessonEntry | null | undefined;
   memoryId: string | null;
   memoryByIdLesson: LessonEntry | null | undefined;
 }): LessonEntry | null {
-  const { lessonRef, cacheLessons, prefetched, memoryId, memoryByIdLesson } = args;
+  const { lessonRef, cacheLessons, prefetched, lessonByRef, memoryId, memoryByIdLesson } = args;
 
   if (lessonRef) {
     // 1. The active-memories cache (covers all non-archived lessons).
@@ -65,7 +66,17 @@ export function resolveOpenLesson(args: {
     ) {
       return prefetched;
     }
-    // Set but unresolved: show nothing — never fall through to `memoryId`.
+    // 3. Fetched by scope+key directly, so a `?lesson=` deep link resolves even
+    //    when the memory is outside the recent/active cache window — the
+    //    "opens blank" case for a shared link to any older memory.
+    if (
+      lessonByRef &&
+      lessonByRef.scope === lessonRef.scope &&
+      lessonByRef.key === lessonRef.key
+    ) {
+      return lessonByRef;
+    }
+    // Set but still unresolved: show nothing — never fall through to `memoryId`.
     return null;
   }
 

--- a/packages/web/src/lib/open-lesson.ts
+++ b/packages/web/src/lib/open-lesson.ts
@@ -42,6 +42,48 @@ export function activeMemoryId(
   return memoryId;
 }
 
+/**
+ * Does this entry answer that ref? The ONE scope+key comparison in this module.
+ *
+ * Every resolution arm below and `lessonResolvedLocally` ask the same question,
+ * and `lessonResolvedLocally` only means anything if it asks it the same way the
+ * resolver does — a predicate that decided "already resolvable" on a rule the
+ * resolver disagreed with would suppress the fetch AND then show nothing.
+ */
+function matchesRef(entry: LessonEntry | null | undefined, ref: LessonRef): entry is LessonEntry {
+  return entry !== null && entry !== undefined && entry.scope === ref.scope && entry.key === ref.key;
+}
+
+/**
+ * Is the open `lessonRef` already answerable without going to the network?
+ *
+ * The gate on `useLessonByRef`: true means some local source already holds the
+ * memory, so the by-scope+key fetch stays disabled and only a cold deep-link
+ * visit — a `?lesson=` URL opened in a fresh tab — reaches the network.
+ *
+ * Two independent local sources, NOT one. A click-prefetch is the obvious one,
+ * but only `LoreExplorer` passes a second argument to `openLessonById`; the
+ * command palette and the header memory dropdown pass the ref alone. What keeps
+ * THOSE off the network is the active-memories cache — they render their own
+ * lists from the same `useLoreData()` query the provider reads, so the clicked
+ * memory is in `cacheLessons` by construction. Drop the cache arm and every
+ * in-app click from those two surfaces issues a redundant fetch.
+ *
+ * Pure, so the guarantee is unit-testable rather than asserted in a comment.
+ */
+export function lessonResolvedLocally(args: {
+  lessonRef: LessonRef | null;
+  cacheLessons: LessonEntry[] | undefined;
+  prefetched: LessonEntry | null;
+}): boolean {
+  const { lessonRef, cacheLessons, prefetched } = args;
+  if (!lessonRef) return false;
+  return (
+    (cacheLessons?.some((l) => matchesRef(l, lessonRef)) ?? false) ||
+    matchesRef(prefetched, lessonRef)
+  );
+}
+
 export function resolveOpenLesson(args: {
   lessonRef: LessonRef | null;
   cacheLessons: LessonEntry[] | undefined;
@@ -54,26 +96,16 @@ export function resolveOpenLesson(args: {
 
   if (lessonRef) {
     // 1. The active-memories cache (covers all non-archived lessons).
-    const found = cacheLessons?.find(
-      (l) => l.scope === lessonRef.scope && l.key === lessonRef.key,
-    );
+    const found = cacheLessons?.find((l) => matchesRef(l, lessonRef));
     if (found) return found;
     // 2. A caller-supplied prefetch (e.g. an archived memory not in the cache).
-    if (
-      prefetched &&
-      prefetched.scope === lessonRef.scope &&
-      prefetched.key === lessonRef.key
-    ) {
+    if (matchesRef(prefetched, lessonRef)) {
       return prefetched;
     }
     // 3. Fetched by scope+key directly, so a `?lesson=` deep link resolves even
     //    when the memory is outside the recent/active cache window — the
     //    "opens blank" case for a shared link to any older memory.
-    if (
-      lessonByRef &&
-      lessonByRef.scope === lessonRef.scope &&
-      lessonByRef.key === lessonRef.key
-    ) {
+    if (matchesRef(lessonByRef, lessonRef)) {
       return lessonByRef;
     }
     // Set but still unresolved: show nothing — never fall through to `memoryId`.

--- a/packages/web/src/lib/queries/lore.ts
+++ b/packages/web/src/lib/queries/lore.ts
@@ -248,6 +248,36 @@ export function useMemoryById(id: string | null) {
 }
 
 // ---------------------------------------------------------------------------
+// Single memory by its natural key (scope + key).
+//
+// Resolves a `/lore?lesson={scope,key}` deep link directly via an exact
+// `GET /memories?scope=&key=&limit=1` (the same read `updateLesson` uses to find
+// a row), so the detail sheet opens even when the memory is outside the
+// Explorer's recent/active window — the "opens blank" case for a shared
+// `?lesson=` link to any older memory. Disabled (no fetch) when `ref` is null.
+// ---------------------------------------------------------------------------
+
+export function useLessonByRef(ref: { scope: string; key: string } | null) {
+  return useQuery<LessonEntry | null>({
+    queryKey: ['lesson-by-ref', ref?.scope, ref?.key],
+    enabled: ref !== null,
+    queryFn: async ({ signal }) => {
+      if (!ref) return null;
+      const token = await requireBrowserToken();
+      const page = await listMemoriesRequest(
+        token,
+        { scope: ref.scope, key: ref.key, limit: 1 },
+        signal,
+      );
+      const entry = page.entries[0];
+      return entry ? lessonFromMemoryEntry(entry) : null;
+    },
+    staleTime: 90_000,
+    retry: retryUnlessSignedOut,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Paginated lesson list — mirrors `useAuditLog` exactly.
 // ---------------------------------------------------------------------------
 

--- a/packages/web/src/lib/queries/lore.ts
+++ b/packages/web/src/lib/queries/lore.ts
@@ -13,6 +13,7 @@ import { browserAccessToken } from '@/lib/api/session-browser';
 import {
   activityRequest,
   getMemoryByIdRequest,
+  getMemoryByRefRequest,
   listFacetsRequest,
   listMemoriesRequest,
   listScopesRequest,
@@ -250,11 +251,11 @@ export function useMemoryById(id: string | null) {
 // ---------------------------------------------------------------------------
 // Single memory by its natural key (scope + key).
 //
-// Resolves a `/lore?lesson={scope,key}` deep link directly via an exact
-// `GET /memories?scope=&key=&limit=1` (the same read `updateLesson` uses to find
-// a row), so the detail sheet opens even when the memory is outside the
-// Explorer's recent/active window — the "opens blank" case for a shared
-// `?lesson=` link to any older memory. Disabled (no fetch) when `ref` is null.
+// Resolves a `/lore?lesson={scope,key}` deep link directly via
+// `getMemoryByRefRequest` (a precise one-row read — see its doc), so the detail
+// sheet opens even when the memory is outside the Explorer's recent/active
+// window — the "opens blank" case for a shared `?lesson=` link to any older
+// memory. Disabled (no fetch) when `ref` is null.
 // ---------------------------------------------------------------------------
 
 export function useLessonByRef(ref: { scope: string; key: string } | null) {
@@ -264,12 +265,7 @@ export function useLessonByRef(ref: { scope: string; key: string } | null) {
     queryFn: async ({ signal }) => {
       if (!ref) return null;
       const token = await requireBrowserToken();
-      const page = await listMemoriesRequest(
-        token,
-        { scope: ref.scope, key: ref.key, limit: 1 },
-        signal,
-      );
-      const entry = page.entries[0];
+      const entry = await getMemoryByRefRequest(token, ref.scope, ref.key, signal);
       return entry ? lessonFromMemoryEntry(entry) : null;
     },
     staleTime: 90_000,


### PR DESCRIPTION
## What

Fixes the actual "the links don't work" problem: a shared `/lore?lesson={scope,key}` link opened **blank** whenever the memory was outside the Explorer's recent/active window. The detail sheet only resolved the `lesson` ref against the loaded page set (`useLoreData`), so any older memory — which is most memories in a report/CLI/write-confirmation link — rendered nothing.

## Fix (at the resolver — no link generator changes)

Every existing `?lesson=` link keeps working as-is; the resolution just gets a fallback:

- **`getMemoryByRefRequest(token, scope, key)`** (`api/memories.ts`) — a get-by-natural-key. There's no scope+key GET route (`GET /memories/:id` is UUID-only), but the list route applies `key` as an exact `.eq` match, so `?scope=&key=&limit=1` is a precise **one-row** read (the same query `updateLesson` uses). The wrapper hides the page envelope and returns `MemoryEntry | null`, so callers read it as the get it is.
- **`useLessonByRef(ref)`** — the query hook around that get; mirrors `useMemoryById`.
- **`resolveOpenLesson`** gains a `lessonByRef` fallback, tried after the cache and the click-prefetch. `lesson` still strictly wins over `memoryId`.
- The provider only fires the fetch on a **cold deep-link visit** — an in-app click is already resolvable locally, so normal navigation never hits the network. Two sources cover that, not one: the Lore Explorer click passes a prefetch, while the command palette and the header memory dropdown pass the ref alone and are covered by the active-memories cache (they render their lists from the same `useLoreData()` query). The predicate is the pure, unit-tested `lessonResolvedLocally`.

Net effect: `?lesson=` now opens **any active memory**, however old — same robustness `?memoryId=` has. Archived memories remain the one exception (the by-key read returns only active rows), same limitation as `?memoryId=`.

## Why not switch links to `?memoryId=`, or add a new endpoint?

The link logic was fine — the resolver just gave up when the memory wasn't already loaded. Fixing the resolver fixes **all** link sources (reviewer reports, `lorekit link`, write-confirmations, dashboard shares) at once. And a dedicated scope+key GET endpoint would be new Edge + Node + schema + tests for the identical query, so this reuses the existing list-with-exact-key read behind a get-shaped wrapper instead.

## Tests / docs

- `open-lesson.spec.ts` — 22 cases: the by-ref fallback, cache-preference, wrong-ref and loading states, plus `lessonResolvedLocally` (cache-only, prefetch-only, neither, stale ref, loading cache, and a resolver-agreement property).
- `deep-links.mdx` — updated: the scope+key form now opens any active memory; archived is the documented exception.

## Verification

- `nx typecheck web` — pass
- `nx lint web` — 0 errors (pre-existing warnings only)
- Storybook interaction + visual — **55/55**
- CLI `test/deeplink.test.mjs` — **41/41**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZutnpuj1geCMfczuCB35o
