### PR TITLE
feat(memory): add kind + host as first-class taxonomy properties

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -43,6 +43,8 @@ Store or update a lesson. Requires a token with write permission (`lk_rw_*` or `
 | `tags` | | Array of tag strings, e.g. `["skill::aw", "source::manual"]` |
 | `source_agent` | | Name of the agent writing this lesson |
 | `trigger` | | What triggered the write (`stuck-loop`, `pr-webhook`, `manual`) |
+| `kind` | | Bucket kind: `lesson`, `bus`, or `signal`. Omit to have it inferred from a `loop::<host>-lessons` tag. See **Taxonomy** below. |
+| `host` | | Owning skill/agent (e.g. `reviewer`, `aw`). Omit to have it inferred from a `loop::<host>-lessons` tag. |
 | `org` | | Org slug to write under (org-owned write). Omit for a personal memory. You must be a write-capable member (`member`/`admin`/`owner`, not `viewer`) of the org — verified server-side; supplying an org you're not authorized for is rejected. |
 | `ttl_days` | | Integer 1–365. The memory auto-expires after this many days. Mutually exclusive with `ttl_minutes` and `ttl_seconds`; supply at most one. On an update, refreshes the expiry; omitting all three leaves the existing expiry unchanged. |
 | `ttl_minutes` | | Integer 1–525600 (365 days in minutes). The memory auto-expires after this many minutes. Mutually exclusive with `ttl_days` and `ttl_seconds`. |
@@ -79,6 +81,18 @@ The `lorekit` CLI fills these in automatically from git and the CI environment
 friends to override. Over the hosted MCP server the client has to supply them —
 the server can only see what the call carries. The GitHub webhook receiver
 records the PR, head branch, and head SHA of the delivery it ingested.
+
+**Taxonomy (`kind` / `host`).** A self-improvement loop's bucket carries two
+facts: WHAT KIND of memory it is and WHICH HOST owns it. `kind` is a closed
+vocabulary — `lesson` (procedural, read every run), `bus` (a transient outcome
+event, read only at promotion time), or `signal` (a durable per-repo filter,
+read every run) — and `host` is the owning skill or agent. Both are first-class
+columns, so a caller can filter (`GET /memories?kind=lesson&host=reviewer`) and
+usage analytics can group by family and owner. You may set them explicitly; if
+you omit them the server infers them from a `loop::<host>-lessons` tag
+(`loop::review-outcomes` → `bus`/`review`, `loop::reviewer-comment-relevance` →
+`signal`/`reviewer`), so a tagged write records them without extra arguments. On
+an update the last KNOWN value wins, exactly like `origin_*`.
 
 **Scope→org binding.** If you omit `org` but the scope is **bound to an org** (an admin set that up — see [org-sharing.md](./org-sharing.md#scope--org-binding-auto-routing)), the write auto-routes to that org **when you're a write-capable member**. If you're *not* a member, it's saved to your personal lore instead (never rejected) and the response carries a `notice` explaining that. An explicit `org` always overrides the binding.
 

--- a/packages/cli/bin/lorekit.mjs
+++ b/packages/cli/bin/lorekit.mjs
@@ -600,7 +600,7 @@ const KNOWN_FLAGS = [
   'dir', 'project', 'global', 'endpoint', 'token', 'mode', 'store',
   'from', 'to', 'apply', 'yes', 'hooks', 'no-hooks', 'force', 'deep', 'adapter',
   'event', 'json', 'scope', 'threshold', 'help', 'version', 'telemetry',
-  'value', 'tags', 'source-agent', 'trigger', 'ttl-days', 'clear-ttl', 'org', 'remote', 'local',
+  'value', 'tags', 'source-agent', 'trigger', 'kind', 'host', 'ttl-days', 'clear-ttl', 'org', 'remote', 'local',
   'link', 'base', 'q', 'owner', 'range', 'view', 'archived',
   'origin-repo', 'origin-branch', 'origin-commit', 'origin-pr', 'no-origin',
 ];

--- a/packages/cli/src/lessons-view.mjs
+++ b/packages/cli/src/lessons-view.mjs
@@ -37,18 +37,39 @@ export function scopeList({ projectScope, branchScope, repoScope } = {}) {
   return [...new Set([projectScope, branchScope, repoScope, 'global'].filter(Boolean))];
 }
 
+// Infer { kind, host } from a memory's loop tags — the CLI-local mirror of
+// `@lorekit/schemas` `inferKindHost` (the CLI has no schemas dependency). Kept
+// deliberately small and in lockstep with that source, including the 64-char
+// host clamp. Lets the offline store, whose rows carry no kind/host column,
+// still be filtered and badged by taxonomy from the tags it does store.
+function inferKindHostFromTags(tags) {
+  if (!Array.isArray(tags)) return {};
+  for (const tag of tags) {
+    if (tag === 'loop::review-outcomes') return { kind: 'bus', host: 'review' };
+    if (tag === 'loop::reviewer-comment-relevance') return { kind: 'signal', host: 'reviewer' };
+    const m = typeof tag === 'string' ? /^loop::(.+)-lessons$/.exec(tag) : null;
+    if (m && m[1] && m[1].length <= 64) return { kind: 'lesson', host: m[1] };
+  }
+  return {};
+}
+
 // Normalize an entry from either store (local markdown row or hosted DB row)
 // into one stable shape the view + `--json` output can rely on. Remote rows may
-// spell the timestamp `updated_at`; local rows use `updated`.
+// spell the timestamp `updated_at`; local rows use `updated`. When a row carries
+// no explicit kind/host (every offline row, and any remote row written before
+// migration 00056), fall back to the taxonomy inferred from its tags so the
+// badge and the `--kind`/`--host` filter behave the same in both sections.
 export function normalizeEntry(e = {}) {
+  const tags = Array.isArray(e.tags) ? e.tags : [];
+  const inferred = inferKindHostFromTags(tags);
   return {
     scope: e.scope ?? null,
     key: e.key ?? null,
     value: e.value == null ? '' : String(e.value),
     updated: e.updated ?? e.updated_at ?? null,
-    tags: Array.isArray(e.tags) ? e.tags : [],
-    kind: e.kind ?? null,
-    host: e.host ?? null,
+    tags,
+    kind: e.kind ?? inferred.kind ?? null,
+    host: e.host ?? inferred.host ?? null,
   };
 }
 
@@ -410,6 +431,20 @@ export function clusterDuplicates(entries = [], threshold = 0.8) {
 // — a per-scope read failure is captured on the group, never thrown, so one bad
 // scope can't abort the listing. `store` may be a local or remote store.
 export async function gather(store, scopes, filters = {}) {
+  // Parse the taxonomy filters into value sets. `filters` is passed to the store
+  // too (the remote narrows server-side); we ALSO post-filter the normalized
+  // entries here so the offline store — which ignores kind/host in its own
+  // `list()` — stays consistent with remote. Post-filtering the remote rows is
+  // idempotent (they were already narrowed) and matches on the same inferred
+  // taxonomy a row without explicit columns gets in normalizeEntry.
+  const wanted = (v) =>
+    v == null ? null : new Set(String(v).split(',').map((s) => s.trim()).filter(Boolean));
+  const kindSet = wanted(filters.kind);
+  const hostSet = wanted(filters.host);
+  const keep = (e) =>
+    (!kindSet || (e.kind != null && kindSet.has(e.kind))) &&
+    (!hostSet || (e.host != null && hostSet.has(e.host)));
+
   const groups = [];
   let total = 0;
   for (const scope of scopes) {
@@ -423,7 +458,7 @@ export async function gather(store, scopes, filters = {}) {
       groups.push({ scope, entries: [], error: describeError(res) });
       continue;
     }
-    const entries = (res.entries || []).map(normalizeEntry);
+    const entries = (res.entries || []).map(normalizeEntry).filter(keep);
     total += entries.length;
     groups.push({ scope, entries, error: null });
   }

--- a/packages/cli/src/lessons-view.mjs
+++ b/packages/cli/src/lessons-view.mjs
@@ -47,6 +47,8 @@ export function normalizeEntry(e = {}) {
     value: e.value == null ? '' : String(e.value),
     updated: e.updated ?? e.updated_at ?? null,
     tags: Array.isArray(e.tags) ? e.tags : [],
+    kind: e.kind ?? null,
+    host: e.host ?? null,
   };
 }
 
@@ -407,13 +409,13 @@ export function clusterDuplicates(entries = [], threshold = 0.8) {
 // `store.list({scope})` contract. Returns ordered per-scope groups plus a total
 // — a per-scope read failure is captured on the group, never thrown, so one bad
 // scope can't abort the listing. `store` may be a local or remote store.
-export async function gather(store, scopes) {
+export async function gather(store, scopes, filters = {}) {
   const groups = [];
   let total = 0;
   for (const scope of scopes) {
     let res;
     try {
-      res = await store.list({ scope });
+      res = await store.list({ scope, ...filters });
     } catch (e) {
       res = { ok: false, networkError: (e && e.message) || 'error' };
     }
@@ -456,7 +458,11 @@ export function renderSection(header, section) {
     }
     for (const e of g.entries) {
       const when = e.updated ? `  ${c.dim(`(updated ${shortDate(e.updated)})`)}` : '';
-      log(`    ${c.cyan('•')} ${g.scope}::${e.key}${when}`);
+      // Taxonomy badge — the kind (and host, when known) so the three families
+      // are visible at a glance in the list. Omitted for rows written before the
+      // taxonomy existed (NULL kind).
+      const badge = e.kind ? ` ${c.dim(`[${e.kind}${e.host ? `·${e.host}` : ''}]`)}` : '';
+      log(`    ${c.cyan('•')} ${g.scope}::${e.key}${badge}${when}`);
       if (e.value) log(`      ${c.dim(preview(e.value))}`);
     }
   }

--- a/packages/cli/src/list.mjs
+++ b/packages/cli/src/list.mjs
@@ -41,6 +41,11 @@ export async function list(args) {
   // Default to every applicable scope; `--scope <s>` narrows to one (an explicit
   // scope outside the applicable set is honoured — the user asked for it).
   const scopes = args.scope && typeof args.scope === 'string' ? [args.scope] : scopeList(scopeInfo);
+  // Optional taxonomy filters — `--kind lesson --host reviewer` narrows to one
+  // family/owner. Comma lists are honoured by the remote store's query builder.
+  const filters = {};
+  if (typeof args.kind === 'string') filters.kind = args.kind;
+  if (typeof args.host === 'string') filters.host = args.host;
 
   // `--link` short-circuits: print the Explorer deep link for the current
   // context (the most-specific applicable scope, or `--scope`), no store reads.
@@ -64,9 +69,9 @@ export async function list(args) {
   // agent-facing control model enforces, honored here in the human read view.
   const { localDenied, remoteDenied } = resolveDenies(root, { env });
 
-  const offline = localDenied ? { groups: [], total: 0 } : await gather(local, scopes);
+  const offline = localDenied ? { groups: [], total: 0 } : await gather(local, scopes, filters);
   const remoteAvailable = !remoteDenied && remote.usable();
-  const remoteResult = remoteAvailable ? await gather(remote, scopes) : { groups: [], total: 0 };
+  const remoteResult = remoteAvailable ? await gather(remote, scopes, filters) : { groups: [], total: 0 };
 
   const offlineSection = localDenied
     ? { available: false, reason: `disabled by deny constraint (${localDenied.source})` }

--- a/packages/cli/src/store/remote.mjs
+++ b/packages/cli/src/store/remote.mjs
@@ -58,10 +58,12 @@ class RemoteStore {
 
   // ── Memory operations → REST ──────────────────────────────────────────────
 
-  async list({ scope, tags, limit } = {}) {
+  async list({ scope, tags, kind, host, limit } = {}) {
     const p = new URLSearchParams();
     if (scope) p.set('scope', scope);
     if (tags?.length) p.set('tags', Array.isArray(tags) ? tags.join(',') : tags);
+    if (kind) p.set('kind', Array.isArray(kind) ? kind.join(',') : kind);
+    if (host) p.set('host', Array.isArray(host) ? host.join(',') : host);
     if (limit) p.set('limit', String(limit));
     const res = await this._rest(`/memories?${p}`);
     if (!res.ok) return { ok: false, error: res.error, networkError: res.networkError };
@@ -92,13 +94,15 @@ class RemoteStore {
 
   async write(args = {}) {
     const {
-      scope, key, value, tags, source_agent, trigger, org, ttl_days, clear_ttl, created_at,
+      scope, key, value, tags, source_agent, trigger, kind, host, org, ttl_days, clear_ttl, created_at,
       origin_repo, origin_branch, origin_commit, origin_pr,
     } = args;
     const body = { scope, key, value };
     if (tags !== undefined) body.tags = tags;
     if (source_agent !== undefined) body.source_agent = source_agent;
     if (trigger !== undefined) body.trigger = trigger;
+    if (kind !== undefined) body.kind = kind;
+    if (host !== undefined) body.host = host;
     if (org !== undefined) body.org = org;
     if (ttl_days !== undefined) body.ttl_days = ttl_days;
     if (clear_ttl !== undefined) body.clear_ttl = clear_ttl;

--- a/packages/cli/src/write.mjs
+++ b/packages/cli/src/write.mjs
@@ -120,6 +120,10 @@ export async function write(args) {
   const tags = args.tags ? String(args.tags).split(',').map((t) => t.trim()).filter(Boolean) : [];
   const sourceAgent = typeof args['source-agent'] === 'string' ? args['source-agent'] : undefined;
   const trigger = typeof args.trigger === 'string' ? args.trigger : undefined;
+  // Taxonomy overrides. Omitted → the server infers kind/host from a
+  // `loop::<host>-lessons` tag, so a tagged write needs neither flag.
+  const kind = typeof args.kind === 'string' ? args.kind : undefined;
+  const host = typeof args.host === 'string' ? args.host : undefined;
   // `--ttl-days` is validated HERE, at the flag seam, rather than being left to the
   // store: a truthiness test silently swallowed `--ttl-days 0` (falsy) and
   // `--ttl-days abc` (NaN, dropped again by the `ttl_days` spread further down), so
@@ -258,6 +262,8 @@ export async function write(args) {
     ...(tags.length ? { tags } : {}),
     ...(sourceAgent ? { source_agent: sourceAgent } : {}),
     ...(trigger ? { trigger } : {}),
+    ...(kind ? { kind } : {}),
+    ...(host ? { host } : {}),
     ...(ttlDays ? { ttl_days: ttlDays } : {}),
     ...(clearTtl ? { clear_ttl: true } : {}),
     ...(orgSlug ? { org: orgSlug } : {}),

--- a/packages/cli/test/list.test.mjs
+++ b/packages/cli/test/list.test.mjs
@@ -47,14 +47,21 @@ test('scopeList drops a null branch/repo scope (no git remote) but keeps global'
 });
 
 test('normalizeEntry maps updated_at → updated and coerces value/tags', () => {
-  const remoteRow = { scope: 'global', key: 'k', value: 42, updated_at: '2026-07-01T00:00:00Z' };
+  const remoteRow = { scope: 'global', key: 'k', value: 42, updated_at: '2026-07-01T00:00:00Z', kind: 'lesson', host: 'reviewer' };
   assert.deepEqual(normalizeEntry(remoteRow), {
     scope: 'global',
     key: 'k',
     value: '42',
     updated: '2026-07-01T00:00:00Z',
     tags: [],
+    kind: 'lesson',
+    host: 'reviewer',
   });
+  // A row without taxonomy columns normalizes them to null.
+  assert.deepEqual(
+    { kind: normalizeEntry({ scope: 'g', key: 'k' }).kind, host: normalizeEntry({ scope: 'g', key: 'k' }).host },
+    { kind: null, host: null },
+  );
   // A local row already uses `updated`; a nullish value becomes ''.
   const localRow = { scope: 'global', key: 'k2', value: null, updated: '2026-07-02', tags: ['a'] };
   assert.equal(normalizeEntry(localRow).value, '');

--- a/packages/mcp-core/src/tools/write.ts
+++ b/packages/mcp-core/src/tools/write.ts
@@ -9,7 +9,7 @@ import { parseCreatedAt } from '../created-at.js';
 import { parseTtl } from '../ttl.js';
 import { parseOrigin } from '../origin.js';
 import { recordAudit } from '../audit.js';
-import { MemoryKindSchema, inferKindHost } from '@lorekit/schemas';
+import { MemoryKindSchema, resolveKindHost } from '@lorekit/schemas';
 
 const MAX_VALUE_BYTES = 65_536;
 
@@ -74,11 +74,10 @@ export async function write(
     ttl_seconds: input.ttl_seconds,
   });
   const origin = parseOrigin(input);
-  // Explicit kind/host win; otherwise recover them from the loop tag. Null when
-  // neither is available, leaving the columns NULL (a non-loop write).
-  const inferred = inferKindHost(input.tags);
-  const kind = input.kind ?? inferred.kind ?? null;
-  const host = input.host ?? inferred.host ?? null;
+  // Explicit kind/host win; otherwise recover them from the loop tag (the shared
+  // resolver owns the vocabulary check + host-length clamp). Null when neither is
+  // available, leaving the columns NULL (a non-loop write).
+  const { kind, host } = resolveKindHost({ kind: input.kind, host: input.host, tags: input.tags });
   const tracer = getTracer();
   const hist = getToolDurationHistogram();
   const startTime = Date.now();

--- a/packages/mcp-core/src/tools/write.ts
+++ b/packages/mcp-core/src/tools/write.ts
@@ -9,6 +9,7 @@ import { parseCreatedAt } from '../created-at.js';
 import { parseTtl } from '../ttl.js';
 import { parseOrigin } from '../origin.js';
 import { recordAudit } from '../audit.js';
+import { MemoryKindSchema, inferKindHost } from '@lorekit/schemas';
 
 const MAX_VALUE_BYTES = 65_536;
 
@@ -19,6 +20,11 @@ export const WriteInputSchema = z.object({
   tags: z.array(z.string()).optional().default([]),
   source_agent: z.string().optional(),
   trigger: z.string().optional(),
+  // Taxonomy — the bucket KIND and owning HOST. Both optional: when omitted
+  // they are derived from a `loop::<host>-lessons` tag by inferKindHost below,
+  // so an older client that only sets tags still records them.
+  kind: MemoryKindSchema.optional(),
+  host: z.string().max(64).optional(),
   // Optional creation-date override for migrating pre-existing memories. When
   // omitted the DB applies its now() default. Validated (and future-dates
   // rejected) by parseCreatedAt below, not by zod, so the error message and the
@@ -68,6 +74,11 @@ export async function write(
     ttl_seconds: input.ttl_seconds,
   });
   const origin = parseOrigin(input);
+  // Explicit kind/host win; otherwise recover them from the loop tag. Null when
+  // neither is available, leaving the columns NULL (a non-loop write).
+  const inferred = inferKindHost(input.tags);
+  const kind = input.kind ?? inferred.kind ?? null;
+  const host = input.host ?? inferred.host ?? null;
   const tracer = getTracer();
   const hist = getToolDurationHistogram();
   const startTime = Date.now();
@@ -82,6 +93,8 @@ export async function write(
       span.setAttribute('lorekit.key', input.key);
       if (input.source_agent) span.setAttribute('lorekit.source_agent', input.source_agent);
       if (input.trigger) span.setAttribute('lorekit.trigger', input.trigger);
+      if (kind) span.setAttribute('lorekit.kind', kind);
+      if (host) span.setAttribute('lorekit.host', host);
       if (createdAt) span.setAttribute('lorekit.created_at', createdAt);
       // Span attribute renamed from lorekit.ttl_days to lorekit.ttl_seconds (intentional:
       // TTL is now stored and forwarded to the DB in seconds; update any dashboards or
@@ -123,6 +136,8 @@ export async function write(
             p_origin_branch: origin.branch,
             p_origin_commit: origin.commit,
             p_origin_pr: origin.pr,
+            p_kind: kind,
+            p_host: host,
           })
           .single();
 

--- a/packages/schemas/src/memory.ts
+++ b/packages/schemas/src/memory.ts
@@ -9,6 +9,22 @@ export const MAX_VALUE_BYTES = 65_536;
 // cannot import zod); re-exported here so existing importers are unaffected.
 export { PURGE_RETENTION_DAYS_DEFAULT };
 
+/**
+ * The three KINDS of memory a self-improvement loop writes — the bucket
+ * taxonomy promoted to a first-class property.
+ *
+ * `lesson` — a procedural "how to do better next time" rule, read every run.
+ * `bus`    — a transient per-item outcome event, read only at promotion time.
+ * `signal` — a durable, learned per-repo filter, read every run.
+ *
+ * A closed vocabulary: adding a kind is a schema change, deliberately, because
+ * the three families drive different read cadences and lifetimes. `host` (the
+ * owning skill/agent) is open free-text, like `source_agent`. The authoritative
+ * reference is agent-skills' `agents/shared/rules/memory-buckets.md`.
+ */
+export const MemoryKindSchema = z.enum(['lesson', 'bus', 'signal']);
+export type MemoryKind = z.infer<typeof MemoryKindSchema>;
+
 export const MemoryWriteSchema = z.object({
   scope: ScopeSchema, key: z.string().min(1).max(512),
   value: z.string().max(MAX_VALUE_BYTES, `value exceeds ${MAX_VALUE_BYTES} bytes`),
@@ -17,6 +33,10 @@ export const MemoryWriteSchema = z.object({
   created_at: z.string().optional(), org: z.string().optional(),
   ttl_days: z.number().int().min(1).max(365).optional(),
   clear_ttl: z.boolean().optional().default(false),
+  // Taxonomy — WHAT KIND of memory this is and WHICH HOST owns it. Both are
+  // optional: an older client omits them and the write path derives them from
+  // the `loop::<host>-lessons` tag via `inferKindHost` (tags.ts).
+  kind: MemoryKindSchema.optional(), host: z.string().max(64).optional(),
   // Provenance — where the memory was RECORDED FROM (vs `scope`, which says
   // where it applies). Every field is independently optional; the shared
   // `parseOrigin` validator (mcp-core / _shared/origin.ts) owns the shape rules.
@@ -130,6 +150,15 @@ export const ListMemoriesQuerySchema = z.object({
   source_agent_mode: ScalarFilterModeSchema.optional().default('in'),
   trigger: ValueListSchema.optional(),
   trigger_mode: ScalarFilterModeSchema.optional().default('in'),
+  /**
+   * Taxonomy filters — the bucket KIND (`lesson`/`bus`/`signal`) and the owning
+   * HOST. Same comma-list + `*_mode` shape as the scalar filters above, so
+   * `?kind=lesson&host=reviewer` reads "reviewer's lessons".
+   */
+  kind: ValueListSchema.optional(),
+  kind_mode: ScalarFilterModeSchema.optional().default('in'),
+  host: ValueListSchema.optional(),
+  host_mode: ScalarFilterModeSchema.optional().default('in'),
   origin_repo: ValueListSchema.optional(),
   origin_repo_mode: ScalarFilterModeSchema.optional().default('in'),
   origin_branch: ValueListSchema.optional(),
@@ -443,6 +472,9 @@ export const MemoryEntrySchema = z.object({
   expires_at: z.string().datetime().nullable(), archived_at: z.string().datetime().nullable(),
   origin_repo: z.string().nullable().optional(), origin_branch: z.string().nullable().optional(),
   origin_commit: z.string().nullable().optional(), origin_pr: z.number().nullable().optional(),
+  // Taxonomy. Optional/nullable so a row written before 00056 (NULL kind/host)
+  // and an older client that reads neither are both unaffected.
+  kind: z.string().nullable().optional(), host: z.string().nullable().optional(),
   // Ownership / authorship. Optional so an older client (and the CLI's
   // RemoteStore, which reads none of them) is unaffected by the addition.
   org_id: z.string().uuid().nullable().optional(),
@@ -463,7 +495,7 @@ export type MemoryEntry = z.infer<typeof MemoryEntrySchema>;
  */
 export const MEMORY_SELECT =
   'id,scope,key,value,tags,source_agent,trigger,created_at,updated_at,expires_at,archived_at,'
-  + 'origin_repo,origin_branch,origin_commit,origin_pr,org_id,created_by,updated_by,orgs(id,name,slug)';
+  + 'origin_repo,origin_branch,origin_commit,origin_pr,kind,host,org_id,created_by,updated_by,orgs(id,name,slug)';
 
 /**
  * Collapse a selected row's `orgs` embed into the flat `org` field.

--- a/packages/schemas/src/tags.spec.ts
+++ b/packages/schemas/src/tags.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeTagList, parseTagsParam, pgArrayLiteral } from './tags.ts';
+import {
+  normalizeTagList,
+  parseTagsParam,
+  pgArrayLiteral,
+  inferKindHost,
+  resolveKindHost,
+} from './tags.ts';
 
 describe('normalizeTagList', () => {
   it('trims, drops empties, and dedupes preserving first-seen order', () => {
@@ -40,5 +46,60 @@ describe('pgArrayLiteral', () => {
 
   it('renders an empty selection as an empty array literal', () => {
     expect(pgArrayLiteral([])).toBe('{}');
+  });
+});
+
+describe('inferKindHost', () => {
+  it('maps a loop lessons tag to lesson + host', () => {
+    expect(inferKindHost(['loop::reviewer-lessons'])).toEqual({ kind: 'lesson', host: 'reviewer' });
+    expect(inferKindHost(['loop::aw-lessons'])).toEqual({ kind: 'lesson', host: 'aw' });
+  });
+
+  it('maps the two named non-lesson buckets to bus / signal', () => {
+    expect(inferKindHost(['loop::review-outcomes'])).toEqual({ kind: 'bus', host: 'review' });
+    expect(inferKindHost(['loop::reviewer-comment-relevance'])).toEqual({
+      kind: 'signal',
+      host: 'reviewer',
+    });
+  });
+
+  it('returns {} for an absent, non-loop, or malformed tag set', () => {
+    expect(inferKindHost(undefined)).toEqual({});
+    expect(inferKindHost(['source::stuck-loop', 'perf'])).toEqual({});
+    expect(inferKindHost([123, null])).toEqual({});
+  });
+
+  it('lets the first recognised loop tag win', () => {
+    expect(inferKindHost(['perf', 'loop::fix-bug-lessons', 'loop::aw-lessons'])).toEqual({
+      kind: 'lesson',
+      host: 'fix-bug',
+    });
+  });
+});
+
+describe('resolveKindHost', () => {
+  it('prefers an explicit, valid kind/host over the tag', () => {
+    expect(
+      resolveKindHost({ kind: 'signal', host: 'custom', tags: ['loop::aw-lessons'] }),
+    ).toEqual({ kind: 'signal', host: 'custom' });
+  });
+
+  it('falls back to inference when explicit values are absent', () => {
+    expect(resolveKindHost({ tags: ['loop::reviewer-lessons'] })).toEqual({
+      kind: 'lesson',
+      host: 'reviewer',
+    });
+  });
+
+  it('ignores an explicit kind outside the closed vocabulary', () => {
+    expect(resolveKindHost({ kind: 'nonsense', tags: ['loop::review-outcomes'] })).toEqual({
+      kind: 'bus',
+      host: 'review',
+    });
+  });
+
+  it('returns nulls when neither explicit nor inferable', () => {
+    expect(resolveKindHost({ tags: ['perf'] })).toEqual({ kind: null, host: null });
+    expect(resolveKindHost({})).toEqual({ kind: null, host: null });
   });
 });

--- a/packages/schemas/src/tags.ts
+++ b/packages/schemas/src/tags.ts
@@ -43,6 +43,64 @@ export function parseTagsParam(raw: string | undefined | null): string[] {
 }
 
 /**
+ * Derive `{ kind, host }` from a memory's loop tags — the back-compat bridge
+ * for the taxonomy columns (migration 00056).
+ *
+ * A loop bucket has always encoded its kind and host in a `loop::…` tag. When a
+ * write does not carry explicit `kind`/`host`, the write path calls this to
+ * recover them from the tags so a memory written by an older client is still
+ * attributable. Pure and total: an absent, unrecognised, or malformed tag set
+ * yields `{}` rather than throwing — the two columns simply stay NULL.
+ *
+ * The mapping (authoritative reference: agent-skills'
+ * `agents/shared/rules/memory-buckets.md`):
+ *   `loop::<host>-lessons`             → { kind: 'lesson', host: '<host>' }
+ *   `loop::review-outcomes`            → { kind: 'bus',    host: 'review' }
+ *   `loop::reviewer-comment-relevance` → { kind: 'signal', host: 'reviewer' }
+ *
+ * First recognised tag wins, so a stray extra `loop::` tag cannot flip the
+ * classification of a bucket that already matched.
+ */
+export function inferKindHost(
+  tags: readonly unknown[] | undefined | null,
+): { kind?: 'lesson' | 'bus' | 'signal'; host?: string } {
+  for (const tag of normalizeTagList(tags as readonly unknown[] | undefined | null)) {
+    if (tag === 'loop::review-outcomes') return { kind: 'bus', host: 'review' };
+    if (tag === 'loop::reviewer-comment-relevance') return { kind: 'signal', host: 'reviewer' };
+    const m = /^loop::(.+)-lessons$/.exec(tag);
+    if (m && m[1]) return { kind: 'lesson', host: m[1] };
+  }
+  return {};
+}
+
+/**
+ * Resolve the effective `{ kind, host }` for a write: an explicit, valid value
+ * wins; otherwise fall back to what {@link inferKindHost} recovers from the
+ * loop tags; otherwise `null`.
+ *
+ * Shared by every write surface (Node server, edge MCP, and the usage-tracking
+ * recorder) so the family/owner STORED on the memory and the family/owner
+ * TRACKED in usage_events are classified identically — a write that omits
+ * `kind` but carries `loop::reviewer-lessons` is a `lesson`/`reviewer` in both
+ * the row and the analytics event. An explicit `kind` outside the closed
+ * vocabulary is ignored (falls through to inference) rather than stored.
+ */
+export function resolveKindHost(params: {
+  kind?: unknown;
+  host?: unknown;
+  tags?: readonly unknown[] | null;
+}): { kind: 'lesson' | 'bus' | 'signal' | null; host: string | null } {
+  const inferred = inferKindHost(params.tags ?? null);
+  const kind =
+    params.kind === 'lesson' || params.kind === 'bus' || params.kind === 'signal'
+      ? params.kind
+      : (inferred.kind ?? null);
+  const host =
+    typeof params.host === 'string' && params.host ? params.host : (inferred.host ?? null);
+  return { kind, host };
+}
+
+/**
  * Build a PostgreSQL array literal (`{"a","b,c"}`) from a label list.
  *
  * postgrest-js's `.contains(column, string[])` / `.overlaps(column, string[])`

--- a/packages/schemas/src/tags.ts
+++ b/packages/schemas/src/tags.ts
@@ -60,6 +60,11 @@ export function parseTagsParam(raw: string | undefined | null): string[] {
  *
  * First recognised tag wins, so a stray extra `loop::` tag cannot flip the
  * classification of a bucket that already matched.
+ *
+ * A host longer than the `memories.host` column bound (64) is skipped, not
+ * returned: inferring an over-long host would turn a write that previously
+ * succeeded into a CHECK-constraint error, and inference must stay
+ * non-destructive. Such a tag simply leaves the columns NULL.
  */
 export function inferKindHost(
   tags: readonly unknown[] | undefined | null,
@@ -68,7 +73,7 @@ export function inferKindHost(
     if (tag === 'loop::review-outcomes') return { kind: 'bus', host: 'review' };
     if (tag === 'loop::reviewer-comment-relevance') return { kind: 'signal', host: 'reviewer' };
     const m = /^loop::(.+)-lessons$/.exec(tag);
-    if (m && m[1]) return { kind: 'lesson', host: m[1] };
+    if (m && m[1] && m[1].length <= 64) return { kind: 'lesson', host: m[1] };
   }
   return {};
 }

--- a/packages/schemas/src/tool-catalog.ts
+++ b/packages/schemas/src/tool-catalog.ts
@@ -48,6 +48,8 @@ export interface JsonSchemaProperty {
   readonly minimum?: number;
   readonly maximum?: number;
   readonly default?: string | number | boolean;
+  /** Closed value vocabulary, e.g. `kind: ['lesson','bus','signal']`. */
+  readonly enum?: readonly string[];
 }
 
 export interface JsonSchemaObject {
@@ -100,6 +102,17 @@ export const MCP_TOOLS: readonly McpToolDoc[] = [
         tags: { type: 'array', items: { type: 'string' }, description: 'Free-form labels, e.g. `["skill::aw", "source::stuck-loop"]`.' },
         source_agent: { type: 'string', description: 'Name of the agent writing this lesson.' },
         trigger: { type: 'string', description: 'What triggered the write: `stuck-loop`, `pr-webhook`, `manual`.' },
+        kind: {
+          type: 'string',
+          enum: ['lesson', 'bus', 'signal'],
+          description:
+            'The bucket kind: `lesson` (procedural, read every run), `bus` (transient outcome event, read at promotion time), or `signal` (durable per-repo filter, read every run). Omit to have it inferred from a `loop::<host>-lessons` tag.',
+        },
+        host: {
+          type: 'string',
+          description:
+            'The owning skill or agent (e.g. `reviewer`, `aw`, `ci-auto-fix`). Omit to have it inferred from a `loop::<host>-lessons` tag.',
+        },
         created_at: {
           type: 'string',
           format: 'date-time',

--- a/packages/web/public/llms.txt
+++ b/packages/web/public/llms.txt
@@ -150,6 +150,8 @@ Store or update a lesson.
 | `tags` |  | array | Free-form labels, e.g. `["skill::aw", "source::stuck-loop"]`. _(array of string)_ |
 | `source_agent` |  | string | Name of the agent writing this lesson. |
 | `trigger` |  | string | What triggered the write: `stuck-loop`, `pr-webhook`, `manual`. |
+| `kind` |  | string | The bucket kind: `lesson` (procedural, read every run), `bus` (transient outcome event, read at promotion time), or `signal` (durable per-repo filter, read every run). Omit to have it inferred from a `loop::<host>-lessons` tag. |
+| `host` |  | string | The owning skill or agent (e.g. `reviewer`, `aw`, `ci-auto-fix`). Omit to have it inferred from a `loop::<host>-lessons` tag. |
 | `created_at` |  | string | Optional ISO 8601 creation date. Use when migrating a pre-existing memory so it is dated by its original time instead of now. Rejected if invalid or in the future. Applies only when the memory is first created. _(date-time)_ |
 | `org` |  | string | Org slug to write under (org-owned write). Omit for a personal memory. You must be a write-capable member (member/admin/owner, not viewer) of the org, verified server-side — supplying an org slug you are not authorized for is rejected. |
 | `ttl_days` |  | integer | Number of days until the memory auto-expires. Omit for a permanent memory. On an update, supplying ttl_days refreshes the expiry; omitting it leaves the existing expiry unchanged. _(1–365)_ |

--- a/supabase/functions/_shared/schemas/memory.ts
+++ b/supabase/functions/_shared/schemas/memory.ts
@@ -14,6 +14,22 @@ export const MAX_VALUE_BYTES = 65_536;
 // cannot import zod); re-exported here so existing importers are unaffected.
 export { PURGE_RETENTION_DAYS_DEFAULT };
 
+/**
+ * The three KINDS of memory a self-improvement loop writes — the bucket
+ * taxonomy promoted to a first-class property.
+ *
+ * `lesson` — a procedural "how to do better next time" rule, read every run.
+ * `bus`    — a transient per-item outcome event, read only at promotion time.
+ * `signal` — a durable, learned per-repo filter, read every run.
+ *
+ * A closed vocabulary: adding a kind is a schema change, deliberately, because
+ * the three families drive different read cadences and lifetimes. `host` (the
+ * owning skill/agent) is open free-text, like `source_agent`. The authoritative
+ * reference is agent-skills' `agents/shared/rules/memory-buckets.md`.
+ */
+export const MemoryKindSchema = z.enum(['lesson', 'bus', 'signal']);
+export type MemoryKind = z.infer<typeof MemoryKindSchema>;
+
 export const MemoryWriteSchema = z.object({
   scope: ScopeSchema, key: z.string().min(1).max(512),
   value: z.string().max(MAX_VALUE_BYTES, `value exceeds ${MAX_VALUE_BYTES} bytes`),
@@ -22,6 +38,10 @@ export const MemoryWriteSchema = z.object({
   created_at: z.string().optional(), org: z.string().optional(),
   ttl_days: z.number().int().min(1).max(365).optional(),
   clear_ttl: z.boolean().optional().default(false),
+  // Taxonomy — WHAT KIND of memory this is and WHICH HOST owns it. Both are
+  // optional: an older client omits them and the write path derives them from
+  // the `loop::<host>-lessons` tag via `inferKindHost` (tags.ts).
+  kind: MemoryKindSchema.optional(), host: z.string().max(64).optional(),
   // Provenance — where the memory was RECORDED FROM (vs `scope`, which says
   // where it applies). Every field is independently optional; the shared
   // `parseOrigin` validator (mcp-core / _shared/origin.ts) owns the shape rules.
@@ -135,6 +155,15 @@ export const ListMemoriesQuerySchema = z.object({
   source_agent_mode: ScalarFilterModeSchema.optional().default('in'),
   trigger: ValueListSchema.optional(),
   trigger_mode: ScalarFilterModeSchema.optional().default('in'),
+  /**
+   * Taxonomy filters — the bucket KIND (`lesson`/`bus`/`signal`) and the owning
+   * HOST. Same comma-list + `*_mode` shape as the scalar filters above, so
+   * `?kind=lesson&host=reviewer` reads "reviewer's lessons".
+   */
+  kind: ValueListSchema.optional(),
+  kind_mode: ScalarFilterModeSchema.optional().default('in'),
+  host: ValueListSchema.optional(),
+  host_mode: ScalarFilterModeSchema.optional().default('in'),
   origin_repo: ValueListSchema.optional(),
   origin_repo_mode: ScalarFilterModeSchema.optional().default('in'),
   origin_branch: ValueListSchema.optional(),
@@ -448,6 +477,9 @@ export const MemoryEntrySchema = z.object({
   expires_at: z.string().datetime().nullable(), archived_at: z.string().datetime().nullable(),
   origin_repo: z.string().nullable().optional(), origin_branch: z.string().nullable().optional(),
   origin_commit: z.string().nullable().optional(), origin_pr: z.number().nullable().optional(),
+  // Taxonomy. Optional/nullable so a row written before 00056 (NULL kind/host)
+  // and an older client that reads neither are both unaffected.
+  kind: z.string().nullable().optional(), host: z.string().nullable().optional(),
   // Ownership / authorship. Optional so an older client (and the CLI's
   // RemoteStore, which reads none of them) is unaffected by the addition.
   org_id: z.string().uuid().nullable().optional(),
@@ -468,7 +500,7 @@ export type MemoryEntry = z.infer<typeof MemoryEntrySchema>;
  */
 export const MEMORY_SELECT =
   'id,scope,key,value,tags,source_agent,trigger,created_at,updated_at,expires_at,archived_at,'
-  + 'origin_repo,origin_branch,origin_commit,origin_pr,org_id,created_by,updated_by,orgs(id,name,slug)';
+  + 'origin_repo,origin_branch,origin_commit,origin_pr,kind,host,org_id,created_by,updated_by,orgs(id,name,slug)';
 
 /**
  * Collapse a selected row's `orgs` embed into the flat `org` field.

--- a/supabase/functions/_shared/schemas/tags.ts
+++ b/supabase/functions/_shared/schemas/tags.ts
@@ -48,6 +48,64 @@ export function parseTagsParam(raw: string | undefined | null): string[] {
 }
 
 /**
+ * Derive `{ kind, host }` from a memory's loop tags — the back-compat bridge
+ * for the taxonomy columns (migration 00056).
+ *
+ * A loop bucket has always encoded its kind and host in a `loop::…` tag. When a
+ * write does not carry explicit `kind`/`host`, the write path calls this to
+ * recover them from the tags so a memory written by an older client is still
+ * attributable. Pure and total: an absent, unrecognised, or malformed tag set
+ * yields `{}` rather than throwing — the two columns simply stay NULL.
+ *
+ * The mapping (authoritative reference: agent-skills'
+ * `agents/shared/rules/memory-buckets.md`):
+ *   `loop::<host>-lessons`             → { kind: 'lesson', host: '<host>' }
+ *   `loop::review-outcomes`            → { kind: 'bus',    host: 'review' }
+ *   `loop::reviewer-comment-relevance` → { kind: 'signal', host: 'reviewer' }
+ *
+ * First recognised tag wins, so a stray extra `loop::` tag cannot flip the
+ * classification of a bucket that already matched.
+ */
+export function inferKindHost(
+  tags: readonly unknown[] | undefined | null,
+): { kind?: 'lesson' | 'bus' | 'signal'; host?: string } {
+  for (const tag of normalizeTagList(tags as readonly unknown[] | undefined | null)) {
+    if (tag === 'loop::review-outcomes') return { kind: 'bus', host: 'review' };
+    if (tag === 'loop::reviewer-comment-relevance') return { kind: 'signal', host: 'reviewer' };
+    const m = /^loop::(.+)-lessons$/.exec(tag);
+    if (m && m[1]) return { kind: 'lesson', host: m[1] };
+  }
+  return {};
+}
+
+/**
+ * Resolve the effective `{ kind, host }` for a write: an explicit, valid value
+ * wins; otherwise fall back to what {@link inferKindHost} recovers from the
+ * loop tags; otherwise `null`.
+ *
+ * Shared by every write surface (Node server, edge MCP, and the usage-tracking
+ * recorder) so the family/owner STORED on the memory and the family/owner
+ * TRACKED in usage_events are classified identically — a write that omits
+ * `kind` but carries `loop::reviewer-lessons` is a `lesson`/`reviewer` in both
+ * the row and the analytics event. An explicit `kind` outside the closed
+ * vocabulary is ignored (falls through to inference) rather than stored.
+ */
+export function resolveKindHost(params: {
+  kind?: unknown;
+  host?: unknown;
+  tags?: readonly unknown[] | null;
+}): { kind: 'lesson' | 'bus' | 'signal' | null; host: string | null } {
+  const inferred = inferKindHost(params.tags ?? null);
+  const kind =
+    params.kind === 'lesson' || params.kind === 'bus' || params.kind === 'signal'
+      ? params.kind
+      : (inferred.kind ?? null);
+  const host =
+    typeof params.host === 'string' && params.host ? params.host : (inferred.host ?? null);
+  return { kind, host };
+}
+
+/**
  * Build a PostgreSQL array literal (`{"a","b,c"}`) from a label list.
  *
  * postgrest-js's `.contains(column, string[])` / `.overlaps(column, string[])`

--- a/supabase/functions/_shared/schemas/tags.ts
+++ b/supabase/functions/_shared/schemas/tags.ts
@@ -65,6 +65,11 @@ export function parseTagsParam(raw: string | undefined | null): string[] {
  *
  * First recognised tag wins, so a stray extra `loop::` tag cannot flip the
  * classification of a bucket that already matched.
+ *
+ * A host longer than the `memories.host` column bound (64) is skipped, not
+ * returned: inferring an over-long host would turn a write that previously
+ * succeeded into a CHECK-constraint error, and inference must stay
+ * non-destructive. Such a tag simply leaves the columns NULL.
  */
 export function inferKindHost(
   tags: readonly unknown[] | undefined | null,
@@ -73,7 +78,7 @@ export function inferKindHost(
     if (tag === 'loop::review-outcomes') return { kind: 'bus', host: 'review' };
     if (tag === 'loop::reviewer-comment-relevance') return { kind: 'signal', host: 'reviewer' };
     const m = /^loop::(.+)-lessons$/.exec(tag);
-    if (m && m[1]) return { kind: 'lesson', host: m[1] };
+    if (m && m[1] && m[1].length <= 64) return { kind: 'lesson', host: m[1] };
   }
   return {};
 }

--- a/supabase/functions/_shared/schemas/tool-catalog.ts
+++ b/supabase/functions/_shared/schemas/tool-catalog.ts
@@ -53,6 +53,8 @@ export interface JsonSchemaProperty {
   readonly minimum?: number;
   readonly maximum?: number;
   readonly default?: string | number | boolean;
+  /** Closed value vocabulary, e.g. `kind: ['lesson','bus','signal']`. */
+  readonly enum?: readonly string[];
 }
 
 export interface JsonSchemaObject {
@@ -105,6 +107,17 @@ export const MCP_TOOLS: readonly McpToolDoc[] = [
         tags: { type: 'array', items: { type: 'string' }, description: 'Free-form labels, e.g. `["skill::aw", "source::stuck-loop"]`.' },
         source_agent: { type: 'string', description: 'Name of the agent writing this lesson.' },
         trigger: { type: 'string', description: 'What triggered the write: `stuck-loop`, `pr-webhook`, `manual`.' },
+        kind: {
+          type: 'string',
+          enum: ['lesson', 'bus', 'signal'],
+          description:
+            'The bucket kind: `lesson` (procedural, read every run), `bus` (transient outcome event, read at promotion time), or `signal` (durable per-repo filter, read every run). Omit to have it inferred from a `loop::<host>-lessons` tag.',
+        },
+        host: {
+          type: 'string',
+          description:
+            'The owning skill or agent (e.g. `reviewer`, `aw`, `ci-auto-fix`). Omit to have it inferred from a `loop::<host>-lessons` tag.',
+        },
         created_at: {
           type: 'string',
           format: 'date-time',

--- a/supabase/functions/_shared/usage.ts
+++ b/supabase/functions/_shared/usage.ts
@@ -40,6 +40,15 @@ export interface UsageEventParams {
    * dashboard's own reads out of the "Memories read" metric.
    */
   client?: string | null;
+  /**
+   * Memory TAXONOMY — the bucket kind (`lesson`/`bus`/`signal`) and owning host
+   * — so usage can be grouped by family and owner, not just tool name. Resolved
+   * by `resolveKindHost` (schemas/tags) so it matches what the write STORED.
+   * Null on non-write tools and on writes that carry neither an explicit value
+   * nor a `loop::…` tag to infer from.
+   */
+  kind?: string | null;
+  host?: string | null;
 }
 
 /**

--- a/supabase/functions/mcp/mcp-handler.ts
+++ b/supabase/functions/mcp/mcp-handler.ts
@@ -29,6 +29,7 @@ import { LimitError, recordUsageEvent, getUserPlanName } from './limits.ts';
 import { toolRequires } from './permissions.ts';
 import { wireTools } from '../_shared/schemas/tool-catalog.ts';
 import { countRecords, parseCorrelationId, parseUsageClient, usageToolKind } from '../_shared/usage-stats.ts';
+import { resolveKindHost } from '../_shared/schemas/tags.ts';
 
 /**
  * Request header carrying a client-supplied grouping key (PR / session / job),
@@ -261,6 +262,10 @@ export async function handleMcp(req: Request, auth: AuthContext, span: Span, ada
     const correlationId = parseCorrelationId(req.headers.get(CORRELATION_HEADER));
     // Calling surface (same header and same fail-safe posture as the REST side).
     const client = parseUsageClient(req.headers.get(CLIENT_HEADER));
+    // Memory taxonomy for analytics — resolved the SAME way the write stores it
+    // (explicit kind/host, else inferred from the loop tag). Null for non-write
+    // tools, which carry neither. Groups usage by family + owner.
+    const { kind: usageKind, host: usageHost } = resolveKindHost(toolArgs);
 
     const toolStartMs = Date.now();
 
@@ -300,6 +305,8 @@ export async function handleMcp(req: Request, auth: AuthContext, span: Span, ada
           resultCount,
           correlationId,
           client,
+          kind: usageKind,
+          host: usageHost,
         });
       }
 
@@ -338,6 +345,8 @@ export async function handleMcp(req: Request, auth: AuthContext, span: Span, ada
           durationMs,
           correlationId,
           client,
+          kind: usageKind,
+          host: usageHost,
         });
       }
 

--- a/supabase/functions/mcp/mcp-handler.ts
+++ b/supabase/functions/mcp/mcp-handler.ts
@@ -263,8 +263,10 @@ export async function handleMcp(req: Request, auth: AuthContext, span: Span, ada
     // Calling surface (same header and same fail-safe posture as the REST side).
     const client = parseUsageClient(req.headers.get(CLIENT_HEADER));
     // Memory taxonomy for analytics — resolved the SAME way the write stores it
-    // (explicit kind/host, else inferred from the loop tag). Null for non-write
-    // tools, which carry neither. Groups usage by family + owner.
+    // (explicit kind/host, else inferred from the loop tag). A read that carries
+    // a loop tag (memory.list / memory.search filtered by it) is attributed too;
+    // it is null only when the args carry neither an explicit value nor a
+    // loop tag. Groups usage by family + owner.
     const { kind: usageKind, host: usageHost } = resolveKindHost(toolArgs);
 
     const toolStartMs = Date.now();

--- a/supabase/functions/mcp/tools.ts
+++ b/supabase/functions/mcp/tools.ts
@@ -22,6 +22,7 @@ import { parseTtl } from './ttl.ts';
 import { parseOrigin } from '../_shared/origin.ts';
 import { recordAudit } from '../_shared/audit.ts';
 import { applyTenantScope } from './tenant-scope.ts';
+import { inferKindHost } from '../_shared/schemas/tags.ts';
 
 export const MAX_VALUE_BYTES = 65_536;
 export const PURGE_RETENTION_DAYS_DEFAULT = 30;
@@ -68,7 +69,7 @@ export async function toolWrite(
   userId: string | null,
   span: Span,
 ) {
-  const { scope: rawScope, key, value, tags = [], source_agent, trigger, created_at, org, ttl_days, ttl_minutes, ttl_seconds, clear_ttl = false, origin_repo, origin_branch, origin_commit, origin_pr } = params;
+  const { scope: rawScope, key, value, tags = [], source_agent, trigger, created_at, org, ttl_days, ttl_minutes, ttl_seconds, clear_ttl = false, origin_repo, origin_branch, origin_commit, origin_pr, kind, host } = params;
   if (!rawScope || !key || !value) throw new Error('scope, key, and value are required');
   if (value.length > MAX_VALUE_BYTES) throw new Error(`value exceeds ${MAX_VALUE_BYTES} bytes`);
   const scope = validateScope(rawScope);
@@ -80,6 +81,13 @@ export async function toolWrite(
   // Every field is independently optional; the RPC keeps the last KNOWN value
   // per field, so omitting one never erases what an earlier write recorded.
   const origin = parseOrigin({ origin_repo, origin_branch, origin_commit, origin_pr });
+  // Taxonomy: explicit kind/host win; otherwise recover them from the loop tag.
+  // An unknown explicit kind falls through to inference rather than being stored.
+  const inferred = inferKindHost(tags);
+  const resolvedKind =
+    (kind === 'lesson' || kind === 'bus' || kind === 'signal' ? kind : undefined) ??
+    inferred.kind ?? null;
+  const resolvedHost = (typeof host === 'string' && host ? host : undefined) ?? inferred.host ?? null;
 
   span.setAttributes({
     'lorekit.scope': scope,
@@ -96,6 +104,8 @@ export async function toolWrite(
     ...(origin.branch ? { 'lorekit.origin.branch': origin.branch } : {}),
     ...(origin.commit ? { 'lorekit.origin.commit': origin.commit } : {}),
     ...(origin.pr !== null ? { 'lorekit.origin.pr': origin.pr } : {}),
+    ...(resolvedKind ? { 'lorekit.kind': resolvedKind } : {}),
+    ...(resolvedHost ? { 'lorekit.host': resolvedHost } : {}),
   });
 
   // 00003 replaced the plain unique constraint with PARTIAL indexes
@@ -120,6 +130,8 @@ export async function toolWrite(
       p_origin_branch: origin.branch,
       p_origin_commit: origin.commit,
       p_origin_pr: origin.pr,
+      p_kind: resolvedKind,
+      p_host: resolvedHost,
     })
     .single();
   if (error) {

--- a/supabase/functions/mcp/tools.ts
+++ b/supabase/functions/mcp/tools.ts
@@ -22,7 +22,7 @@ import { parseTtl } from './ttl.ts';
 import { parseOrigin } from '../_shared/origin.ts';
 import { recordAudit } from '../_shared/audit.ts';
 import { applyTenantScope } from './tenant-scope.ts';
-import { inferKindHost } from '../_shared/schemas/tags.ts';
+import { resolveKindHost } from '../_shared/schemas/tags.ts';
 
 export const MAX_VALUE_BYTES = 65_536;
 export const PURGE_RETENTION_DAYS_DEFAULT = 30;
@@ -82,12 +82,9 @@ export async function toolWrite(
   // per field, so omitting one never erases what an earlier write recorded.
   const origin = parseOrigin({ origin_repo, origin_branch, origin_commit, origin_pr });
   // Taxonomy: explicit kind/host win; otherwise recover them from the loop tag.
-  // An unknown explicit kind falls through to inference rather than being stored.
-  const inferred = inferKindHost(tags);
-  const resolvedKind =
-    (kind === 'lesson' || kind === 'bus' || kind === 'signal' ? kind : undefined) ??
-    inferred.kind ?? null;
-  const resolvedHost = (typeof host === 'string' && host ? host : undefined) ?? inferred.host ?? null;
+  // The shared resolver is the one place the closed-vocabulary check and the
+  // host-length clamp live, so storage and usage tracking classify identically.
+  const { kind: resolvedKind, host: resolvedHost } = resolveKindHost({ kind, host, tags });
 
   span.setAttributes({
     'lorekit.scope': scope,

--- a/supabase/functions/memories/handlers/create.ts
+++ b/supabase/functions/memories/handlers/create.ts
@@ -9,6 +9,7 @@ import { CreateMemoryBodySchema } from '../../_shared/schemas/memory.ts';
 import { translateDbError } from '../../_shared/api/errors.ts';
 import { parseCreatedAt, CreatedAtError } from '../../_shared/created-at.ts';
 import { parseOrigin, OriginError } from '../../_shared/origin.ts';
+import { resolveKindHost } from '../../_shared/schemas/tags.ts';
 import { recordAudit } from '../../_shared/audit.ts';
 import type { DbClient } from '../../_shared/api/auth.ts';
 import type { Database } from '../../_shared/database.types.ts';
@@ -39,6 +40,13 @@ export async function handleCreate(
     throw err;
   }
   if (createdAtOverride) span.setAttributes({ 'lorekit.created_at': createdAtOverride });
+
+  // Taxonomy: explicit kind/host from the body, else inferred from the loop
+  // tag — the same resolution the MCP surface applies, so REST and MCP writes
+  // classify a bucket identically.
+  const { kind, host } = resolveKindHost(body);
+  if (kind) span.setAttributes({ 'lorekit.kind': kind });
+  if (host) span.setAttributes({ 'lorekit.host': host });
 
   // Optional provenance (repo / branch / commit / PR the write came from).
   // Same posture as created_at: the schema only types the fields, the SEMANTIC
@@ -94,6 +102,8 @@ export async function handleCreate(
     p_origin_branch: origin.branch,
     p_origin_commit: origin.commit,
     p_origin_pr: origin.pr,
+    p_kind: kind,
+    p_host: host,
     // `.single()` because memory_write RETURNS TABLE — without it the traced
     // client resolves an array and the `row?.id` guard below always throws.
   }).single();
@@ -115,7 +125,7 @@ export async function handleCreate(
   }
   const { data: entry, error: fetchErr } = await createTracedClient(db, span)
     .from('memories')
-    .select('id,scope,key,value,tags,source_agent,trigger,created_at,updated_at,expires_at,archived_at,origin_repo,origin_branch,origin_commit,origin_pr')
+    .select('id,scope,key,value,tags,source_agent,trigger,created_at,updated_at,expires_at,archived_at,origin_repo,origin_branch,origin_commit,origin_pr,kind,host')
     .eq('id', row.id)
     .single();
 

--- a/supabase/functions/memories/handlers/list.ts
+++ b/supabase/functions/memories/handlers/list.ts
@@ -110,6 +110,10 @@ export async function handleList(
   // by one rule.
   q = applyScalarFilter(q, 'source_agent', parseTagsParam(params.source_agent), params.source_agent_mode);
   q = applyScalarFilter(q, 'trigger', parseTagsParam(params.trigger), params.trigger_mode);
+  // Taxonomy dimensions — `?kind=lesson&host=reviewer` reads "reviewer's
+  // lessons". Same conjunct-of-disjunction shape as the provenance filters.
+  q = applyScalarFilter(q, 'kind', parseTagsParam(params.kind), params.kind_mode);
+  q = applyScalarFilter(q, 'host', parseTagsParam(params.host), params.host_mode);
   q = applyScalarFilter(q, 'origin_repo', parseTagsParam(params.origin_repo), params.origin_repo_mode);
   q = applyScalarFilter(q, 'origin_branch', parseTagsParam(params.origin_branch), params.origin_branch_mode);
   // `origin_pr` is an integer column. A non-numeric entry is dropped rather

--- a/supabase/migrations/00056_memory_kind_host.sql
+++ b/supabase/migrations/00056_memory_kind_host.sql
@@ -1,0 +1,304 @@
+-- ═════════════════════════════════════════════════════════════════════════
+-- memories.kind + memories.host — the bucket TAXONOMY as first-class columns,
+-- and the same two dimensions on usage_events so operations are attributable
+-- to a family and an owner.
+--
+-- WHY: a loop's memory bucket has always encoded two facts in its tag string —
+-- WHAT KIND of memory it is (a procedural `lesson`, a transient outcome `bus`,
+-- or a durable per-repo `signal`) and WHICH HOST owns it (`reviewer`, `aw`, …).
+-- Reading either meant parsing `loop::<host>-lessons` on the client. Promoting
+-- them to columns lets a caller filter (`?kind=lesson`), lets usage analytics
+-- group by kind/host, and lets the dashboard show the three families instead of
+-- implying them. The authoritative vocabulary lives in agent-skills'
+-- `agents/shared/rules/memory-buckets.md`.
+--
+-- kind is a closed 3-value vocabulary; host is open (a new host is a new agent,
+-- not a migration). Following 00054's `client` precedent, neither is pinned by a
+-- CHECK enumerating members — the Zod `MemoryWriteSchema` is the authoritative
+-- gate for kind, and a length backstop bounds cardinality/storage without
+-- turning "add a host" into a migration.
+--
+-- Forward-only and additive: both columns are nullable, and each RPC is DROPped
+-- and recreated with its new params appended-and-defaulted, so every existing
+-- row and every caller that omits them is unaffected. A memory written before
+-- this migration has NULL kind/host; the app derives them from the legacy tag
+-- (see tags.ts `inferKindHost`) so no data backfill is required.
+-- ═════════════════════════════════════════════════════════════════════════
+
+-- ── columns on memories ──────────────────────────────────────────────────────
+alter table memories add column if not exists kind text;
+alter table memories add column if not exists host text;
+
+-- Length backstops (not the primary gate — see 00054). kind's closed vocabulary
+-- is enforced by MemoryWriteSchema; host is open free-text like source_agent.
+alter table memories drop constraint if exists memories_kind_len;
+alter table memories add constraint memories_kind_len
+  check (kind is null or (char_length(kind) between 1 and 32));
+alter table memories drop constraint if exists memories_host_len;
+alter table memories add constraint memories_host_len
+  check (host is null or (char_length(host) between 1 and 64));
+
+-- Index the family/owner read: "lessons for host reviewer", newest first.
+create index if not exists memories_kind_host_idx
+  on memories (kind, host)
+  where kind is not null;
+
+-- ── writer: memory_write gains p_kind + p_host ──────────────────────────────
+-- DROP first (not CREATE OR REPLACE): adding params changes the signature, and a
+-- bare CREATE would leave the 00048 15-arg overload behind and make calls
+-- ambiguous. Body is 00048's verbatim plus the two columns in every branch.
+-- kind/host use the origin_* "last KNOWN value wins" merge on update so a write
+-- that does not know them (an older client) keeps the previously recorded value
+-- rather than erasing it.
+drop function if exists memory_write(uuid, text, text, text, text[], text, text, timestamptz, text, integer, boolean, text, text, text, integer);
+
+create or replace function memory_write(
+  p_user_id       uuid,
+  p_scope         text,
+  p_key           text,
+  p_value         text,
+  p_tags          text[]      default '{}',
+  p_source_agent  text        default null,
+  p_trigger       text        default null,
+  p_created_at    timestamptz default null,
+  p_org_slug      text        default null,
+  p_ttl_seconds   integer     default null,
+  p_clear_ttl     boolean     default false,
+  p_origin_repo   text        default null,
+  p_origin_branch text        default null,
+  p_origin_commit text        default null,
+  p_origin_pr     integer     default null,
+  p_kind          text        default null,
+  p_host          text        default null
+)
+returns table (
+  id               uuid,
+  created_at       timestamptz,
+  inserted         boolean,
+  org_routed       boolean,
+  binding_org_slug text,
+  expires_at       timestamptz
+)
+language plpgsql
+set search_path = public
+as $$
+declare
+  v_org_id       uuid;
+  v_binding_org  uuid;
+  v_binding_slug text;
+  v_expires_at   timestamptz;
+  v_ttl_action   text := 'keep';
+begin
+  if p_clear_ttl then
+    v_ttl_action := 'clear';
+  elsif p_ttl_seconds is not null then
+    if p_ttl_seconds < 1 or p_ttl_seconds > 31536000 then
+      raise exception using errcode = 'P0001',
+        message = format('ttl_seconds must be between 1 and 31536000, got %s', p_ttl_seconds);
+    end if;
+    v_expires_at  := now() + (p_ttl_seconds * interval '1 second');
+    v_ttl_action  := 'set';
+  end if;
+
+  if p_org_slug is not null then
+    select o.id into v_org_id from orgs o where o.slug = p_org_slug and o.deleted_at is null;
+    if v_org_id is null then
+      raise exception using errcode = 'P0001', message = format('unknown_org: %s', p_org_slug);
+    end if;
+    if not lorekit_org_can(p_user_id, v_org_id, 'write') then
+      raise exception using errcode = 'LK002', message = format('org_permission_denied: org=%s', p_org_slug);
+    end if;
+  else
+    select b.org_id, o.slug into v_binding_org, v_binding_slug
+    from org_scope_bindings b
+    join orgs o on o.id = b.org_id
+    where b.scope = p_scope and o.deleted_at is null;
+
+    if v_binding_org is not null
+       and p_user_id is not null
+       and lorekit_org_can(p_user_id, v_binding_org, 'write') then
+      v_org_id := v_binding_org;
+    end if;
+  end if;
+
+  if v_org_id is not null then
+    return query
+    insert into memories (
+      user_id, org_id, scope, key, value, tags, source_agent, trigger,
+      created_at, updated_at, created_by, updated_by, expires_at,
+      origin_repo, origin_branch, origin_commit, origin_pr, kind, host
+    )
+    values (
+      null, v_org_id, p_scope, p_key, p_value, p_tags, p_source_agent, p_trigger,
+      coalesce(p_created_at, now()), coalesce(p_created_at, now()),
+      p_user_id, p_user_id, v_expires_at,
+      p_origin_repo, p_origin_branch, p_origin_commit, p_origin_pr, p_kind, p_host
+    )
+    on conflict (org_id, scope, key) where org_id is not null and archived_at is null
+    do update set
+      value         = excluded.value,
+      tags          = excluded.tags,
+      source_agent  = excluded.source_agent,
+      trigger       = excluded.trigger,
+      updated_at    = now(),
+      updated_by    = p_user_id,
+      origin_repo   = coalesce(excluded.origin_repo,   memories.origin_repo),
+      origin_branch = coalesce(excluded.origin_branch, memories.origin_branch),
+      origin_commit = coalesce(excluded.origin_commit, memories.origin_commit),
+      origin_pr     = coalesce(excluded.origin_pr,     memories.origin_pr),
+      kind          = coalesce(excluded.kind,          memories.kind),
+      host          = coalesce(excluded.host,          memories.host),
+      expires_at    = case v_ttl_action
+                        when 'clear' then null
+                        when 'set'   then v_expires_at
+                        else memories.expires_at
+                      end
+    returning
+      memories.id, memories.created_at, (xmax::text = '0') as inserted,
+      true as org_routed, v_binding_slug as binding_org_slug, memories.expires_at;
+
+  elsif p_user_id is null then
+    return query
+    insert into memories (
+      user_id, scope, key, value, tags, source_agent, trigger,
+      created_at, updated_at, created_by, updated_by, expires_at,
+      origin_repo, origin_branch, origin_commit, origin_pr, kind, host
+    )
+    values (
+      null, p_scope, p_key, p_value, p_tags, p_source_agent, p_trigger,
+      coalesce(p_created_at, now()), coalesce(p_created_at, now()),
+      null, null, v_expires_at,
+      p_origin_repo, p_origin_branch, p_origin_commit, p_origin_pr, p_kind, p_host
+    )
+    on conflict (scope, key) where org_id is null and user_id is null and archived_at is null
+    do update set
+      value         = excluded.value,
+      tags          = excluded.tags,
+      source_agent  = excluded.source_agent,
+      trigger       = excluded.trigger,
+      updated_at    = now(),
+      origin_repo   = coalesce(excluded.origin_repo,   memories.origin_repo),
+      origin_branch = coalesce(excluded.origin_branch, memories.origin_branch),
+      origin_commit = coalesce(excluded.origin_commit, memories.origin_commit),
+      origin_pr     = coalesce(excluded.origin_pr,     memories.origin_pr),
+      kind          = coalesce(excluded.kind,          memories.kind),
+      host          = coalesce(excluded.host,          memories.host),
+      expires_at    = case v_ttl_action
+                        when 'clear' then null
+                        when 'set'   then v_expires_at
+                        else memories.expires_at
+                      end
+    returning
+      memories.id, memories.created_at, (xmax::text = '0') as inserted,
+      false as org_routed, v_binding_slug as binding_org_slug, memories.expires_at;
+
+  else
+    return query
+    insert into memories (
+      user_id, scope, key, value, tags, source_agent, trigger,
+      created_at, updated_at, created_by, updated_by, expires_at,
+      origin_repo, origin_branch, origin_commit, origin_pr, kind, host
+    )
+    values (
+      p_user_id, p_scope, p_key, p_value, p_tags, p_source_agent, p_trigger,
+      coalesce(p_created_at, now()), coalesce(p_created_at, now()),
+      p_user_id, p_user_id, v_expires_at,
+      p_origin_repo, p_origin_branch, p_origin_commit, p_origin_pr, p_kind, p_host
+    )
+    on conflict (user_id, scope, key) where org_id is null and user_id is not null and archived_at is null
+    do update set
+      value         = excluded.value,
+      tags          = excluded.tags,
+      source_agent  = excluded.source_agent,
+      trigger       = excluded.trigger,
+      updated_at    = now(),
+      updated_by    = p_user_id,
+      origin_repo   = coalesce(excluded.origin_repo,   memories.origin_repo),
+      origin_branch = coalesce(excluded.origin_branch, memories.origin_branch),
+      origin_commit = coalesce(excluded.origin_commit, memories.origin_commit),
+      origin_pr     = coalesce(excluded.origin_pr,     memories.origin_pr),
+      kind          = coalesce(excluded.kind,          memories.kind),
+      host          = coalesce(excluded.host,          memories.host),
+      expires_at    = case v_ttl_action
+                        when 'clear' then null
+                        when 'set'   then v_expires_at
+                        else memories.expires_at
+                      end
+    returning
+      memories.id, memories.created_at, (xmax::text = '0') as inserted,
+      false as org_routed, v_binding_slug as binding_org_slug, memories.expires_at;
+  end if;
+end;
+$$;
+
+grant execute on function memory_write(uuid, text, text, text, text[], text, text, timestamptz, text, integer, boolean, text, text, text, integer, text, text)
+  to anon, authenticated, service_role;
+
+-- ── usage_events: kind + host as tracked dimensions ─────────────────────────
+alter table usage_events add column if not exists kind text;
+alter table usage_events add column if not exists host text;
+
+alter table usage_events drop constraint if exists usage_events_kind_len;
+alter table usage_events add constraint usage_events_kind_len
+  check (kind is null or (char_length(kind) between 1 and 32));
+alter table usage_events drop constraint if exists usage_events_host_len;
+alter table usage_events add constraint usage_events_host_len
+  check (host is null or (char_length(host) between 1 and 64));
+
+-- Index the family/owner analytics roll-up: "my events for kind X", newest first.
+create index if not exists usage_events_user_kind_idx
+  on usage_events (user_id, kind, created_at desc)
+  where kind is not null;
+
+-- ── writer: record_usage_event gains p_kind + p_host ────────────────────────
+-- DROP first — adding params changes the signature (00054's 12-arg overload
+-- would otherwise remain and make calls ambiguous). Body is 00054's verbatim
+-- plus the two columns.
+drop function if exists lorekit_record_usage_event(uuid, uuid, text, text, text, text, text, integer, integer, integer, text, text);
+
+create or replace function lorekit_record_usage_event(
+  p_user_id        uuid    default null,
+  p_org_id         uuid    default null,
+  p_plan_name      text    default null,
+  p_tool_name      text    default null,
+  p_scope_type     text    default null,
+  p_auth_type      text    default null,
+  p_outcome        text    default null,
+  p_duration_ms    integer default null,
+  p_memory_count   integer default null,
+  p_result_count   integer default null,
+  p_correlation_id text    default null,
+  p_client         text    default null,
+  p_kind           text    default null,
+  p_host           text    default null
+)
+returns uuid
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_id uuid;
+begin
+  insert into usage_events (
+    user_id, org_id, plan_name,
+    tool_name, scope_type, auth_type,
+    outcome, duration_ms, memory_count,
+    result_count, correlation_id, client, kind, host
+  ) values (
+    p_user_id, p_org_id, p_plan_name,
+    p_tool_name, p_scope_type, p_auth_type,
+    p_outcome, p_duration_ms, p_memory_count,
+    p_result_count, p_correlation_id, p_client, p_kind, p_host
+  )
+  returning id into v_id;
+  return v_id;
+exception
+  when others then
+    -- Never let telemetry writes break the primary operation.
+    return null;
+end;
+$$;
+
+grant execute on function lorekit_record_usage_event(uuid, uuid, text, text, text, text, text, integer, integer, integer, text, text, text, text)
+  to anon, authenticated, service_role;

--- a/supabase/tests/migrations.test.sql
+++ b/supabase/tests/migrations.test.sql
@@ -3397,11 +3397,12 @@ begin
 end;
 $$;
 
--- ── 65. origin: grant surface — the widened 15-arg memory_write signature is
--- granted to the same three roles the 11-arg form was (00038) ───────────────
+-- ── 65. origin: grant surface — the widened memory_write signature is granted
+-- to the same three roles the 11-arg form was (00038); 00056 further widened it
+-- with p_kind + p_host (17 args) ────────────────────────────────────────────
 do $$
 declare
-  v_sig text := 'memory_write(uuid, text, text, text, text[], text, text, timestamp with time zone, text, integer, boolean, text, text, text, integer)';
+  v_sig text := 'memory_write(uuid, text, text, text, text[], text, text, timestamp with time zone, text, integer, boolean, text, text, text, integer, text, text)';
 begin
   assert has_function_privilege('anon', v_sig, 'EXECUTE'),
     'origin: anon must have EXECUTE on the widened memory_write';


### PR DESCRIPTION
## What

Promotes the bucket taxonomy that a self-improvement loop encodes in its tag string — **what kind** of memory it is (`lesson` | `bus` | `signal`) and **which host** owns it — to **first-class columns**, so callers can filter and usage analytics can group by family and owner instead of parsing `loop::<host>-lessons` on the client.

Authoritative vocabulary: agent-skills `agents/shared/rules/memory-buckets.md`.

## Changes

- **Migration `00056`** — `memories.kind` + `memories.host`; `memory_write` RPC gains `p_kind`/`p_host` (last-known-wins merge, like `origin_*`); `usage_events.kind` + `host`; `lorekit_record_usage_event` gains `p_kind`/`p_host` so operations are attributable to a family + owner.
- **Schema (`packages/schemas`)** — `MemoryKindSchema` enum; `kind`/`host` on the write schema, entry schema, `MEMORY_SELECT` projection, and list filter; MCP tool-catalog advertises both. New pure helpers `inferKindHost` (tag back-compat) and `resolveKindHost` (explicit → inferred → null), shared by every write surface so the value **stored** and the value **tracked** always agree.
- **Write paths** (Node + edge MCP + REST) resolve and persist `kind`/`host` and emit them as OTel span attributes.
- **Usage tracking** — the MCP handler records `kind`/`host` on every event.
- **Read** — `GET /memories?kind=lesson&host=reviewer` filters by taxonomy.
- **CLI** — `write --kind/--host`, `list --kind/--host`, and a taxonomy badge in the listing.
- **Back-compat** — both columns nullable; a pre-`00056` row (or an older client) has its `kind`/`host` inferred from the loop tag — no backfill.

## Verified

- `nx test schemas` (incl. new `inferKindHost`/`resolveKindHost` tests), `nx test cli` (646/646), mcp-core parity specs (`edge-schema-parity`, `edge-parity`, `tool-catalog-parity`, `edge-bare-specifier` — 89/89), typecheck + lint on schemas/mcp-core/cli.

## Deployer follow-up

Not run in the authoring environment (no live Supabase): run `nx db:push` then `nx db:types` against the target project to apply `00056` and regenerate `database.types.ts` (the `.rpc()` clients are untyped, so types don't gate the build; regenerating keeps them accurate). Live-DB integration + migration-SQL tests need a running Supabase.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_0148V8aAvfouycsjksiVQvjx)_