### PR TITLE
feat(explorer): mobile filter menu focus + per-group selection count

### DIFF
--- a/packages/web/src/components/lore/FilterMenu.test.stories.tsx
+++ b/packages/web/src/components/lore/FilterMenu.test.stories.tsx
@@ -375,6 +375,76 @@ export const PillOperatorEscapeDismissesWithoutLeaking: Story = {
 };
 
 /**
+ * The dimension list has to say which groups are already doing the filtering.
+ *
+ * As you apply filters the results list shrinks — which is the point — but the
+ * dimension list itself gave no sign of WHERE that narrowing came from, so you
+ * could not tell a filtered-on group from an untouched one without opening each.
+ * A per-group count badge, folded into the row's accessible name, closes that.
+ */
+export const DimensionListShowsPerGroupSelectionCount: Story = {
+  args: {
+    initialFilters: [
+      { field: 'label', operator: 'all', values: ['performance', 'auth'] },
+      { field: 'agent', operator: 'in', values: ['claude'] },
+    ],
+  },
+  play: async ({ canvasElement, step }) => {
+    // The trigger's name changes once a filter is applied ("Add or edit a
+    // filter"), so `openMenu`'s /add filter/ query would miss it.
+    await userEvent.click(
+      await within(canvasElement).findByRole('button', { name: /add or edit a filter/i }),
+    );
+    const canvas = within(document.body);
+    await canvas.findByRole('dialog', { name: /^filter$/i });
+
+    await step('each filtered group announces its selection count', async () => {
+      await expect(
+        canvas.getByRole('option', { name: /label, 2 selected/i }),
+      ).toBeInTheDocument();
+      await expect(
+        canvas.getByRole('option', { name: /agent, 1 selected/i }),
+      ).toBeInTheDocument();
+    });
+
+    await step('an untouched group is still just its name — no phantom count', async () => {
+      await expect(canvas.getByRole('option', { name: /^trigger$/i })).toBeInTheDocument();
+      await expect(
+        canvas.queryByRole('option', { name: /trigger,.*selected/i }),
+      ).not.toBeInTheDocument();
+    });
+  },
+};
+
+/**
+ * Regression: the mobile sheet must not steal focus when you drill in.
+ *
+ * On a phone, focusing the search box raises the on-screen keyboard, which
+ * scrolls the sheet up and off the very values the user just opened. The sheet
+ * deliberately never auto-focuses — on open OR on drilling into a dimension —
+ * so the keyboard only appears when the user taps the field. (The popover keeps
+ * its focus, which is what its keyboard model needs.)
+ */
+export const MobileSheetDoesNotAutofocusOnDrillIn: StoryObj<typeof MobileHarness> = {
+  render: () => <MobileHarness />,
+  play: async ({ canvasElement, step }) => {
+    const screen = within(document.body);
+    await userEvent.click(within(canvasElement).getByRole('button', { name: /add filter/i }));
+
+    await step('opening the sheet does not focus the search box', async () => {
+      const input = await screen.findByRole('combobox', { name: /search filters/i });
+      await expect(input).not.toHaveFocus();
+    });
+
+    await step('drilling into a dimension still does not focus it', async () => {
+      await userEvent.click(await screen.findByRole('option', { name: /^agent/i }));
+      const input = await screen.findByRole('combobox', { name: /search agent values/i });
+      await expect(input).not.toHaveFocus();
+    });
+  },
+};
+
+/**
  * Regression: the popover must escape its ancestors' overflow.
  *
  * In the Explorer the trigger sits inside `overflow-hidden` panels and a

--- a/packages/web/src/components/lore/FilterMenu.tsx
+++ b/packages/web/src/components/lore/FilterMenu.tsx
@@ -318,7 +318,12 @@ export function FilterMenu({
     // dimension is meaningless against its values.
     setQuery('');
     setActiveIndex(0);
-    inputRef.current?.focus();
+    // Popover only, for the same reason the open effect does not auto-focus in
+    // the sheet: on a phone, focusing the search box raises the on-screen
+    // keyboard, which scrolls the sheet up and off the values the user just
+    // drilled into — the keyboard covers exactly the content they came to see.
+    // They tap the field when they actually want to type.
+    if (!useSheet) inputRef.current?.focus();
   }
 
   /** Back one level, or close when already at the level the menu opened on. */
@@ -330,7 +335,8 @@ export function FilterMenu({
     setField(null);
     setQuery('');
     setActiveIndex(0);
-    inputRef.current?.focus();
+    // Popover only — see `pushField` for why the sheet must not grab focus here.
+    if (!useSheet) inputRef.current?.focus();
   }
 
   function commitRootRow(index: number) {
@@ -529,6 +535,14 @@ export function FilterMenu({
           const rowField = requireField(row.field);
           const Icon = FIELD_ICONS[row.field];
           const isValueRow = row.kind === 'value';
+          // How many values this dimension already has committed. The count
+          // badge is what tells the user, WITHOUT drilling in, which groups the
+          // narrowed list is being filtered by — the list shrinks as filters
+          // apply, but nothing on the dimension list said where that came from.
+          // A value row is a whole condition, not a group, so it has no count.
+          const selectedCount = isValueRow
+            ? 0
+            : selectedValues(filters, row.field).length;
           return (
             <button
               key={isValueRow ? `${row.field}:${row.value}` : row.field}
@@ -536,6 +550,13 @@ export function FilterMenu({
               type="button"
               role="option"
               aria-selected={i === activeIndex}
+              // A count badge is aria-hidden decoration; fold it into the name so
+              // a screen-reader user hears "Label, 2 selected", not just "Label".
+              aria-label={
+                !isValueRow && selectedCount > 0
+                  ? `${rowField.label}, ${selectedCount} selected`
+                  : undefined
+              }
               onClick={() => commitRootRow(i)}
               onMouseEnter={() => setActiveIndex(i)}
               className={[
@@ -560,7 +581,24 @@ export function FilterMenu({
                 </>
               ) : (
                 <>
-                  <span className="flex-1 truncate">{rowField.label}</span>
+                  <span
+                    className={[
+                      'flex-1 truncate',
+                      selectedCount > 0
+                        ? 'font-medium text-[var(--color-content-primary)]'
+                        : '',
+                    ].join(' ')}
+                  >
+                    {rowField.label}
+                  </span>
+                  {selectedCount > 0 && (
+                    <span
+                      aria-hidden
+                      className="flex min-h-4 min-w-4 items-center justify-center rounded-full bg-[var(--color-accent-subtle)] px-1 text-[10px] font-semibold tabular-nums text-[var(--color-accent)]"
+                    >
+                      {selectedCount}
+                    </span>
+                  )}
                   <ChevronRight
                     className="size-3.5 shrink-0 text-[var(--color-content-tertiary)]"
                     aria-hidden


### PR DESCRIPTION
Two mobile UX fixes to the Lore Explorer's FilterMenu.

1. Drilling into a dimension in the bottom sheet no longer grabs focus.
   `pushField`/`popLevel` called `inputRef.focus()` unconditionally, so on a
   phone tapping a dimension raised the on-screen keyboard, which scrolled the
   sheet up and off the values just opened — the keyboard covered the content.
   The calls are now popover-only (`if (!useSheet)`), matching the open effect's
   existing decision to never auto-focus in the sheet. The keyboard appears only
   when the user taps the search field.

2. The dimension list now shows which groups have a selection, and how many.
   Applying a filter narrows the results but the dimension list gave no sign of
   where that came from. Each filtered group now renders an accent count badge
   and an emphasised label, folded into the option's accessible name
   ("Label, 2 selected") for screen readers.

Adds two interaction tests (per-group count, mobile no-autofocus-on-drill-in).
No user-facing docs apply — behavioural/visual polish of an existing surface,
no new capability, config, or contract.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ACKTU8p4SV5We4yLnhg28R