### PR TITLE
fix(cli): flush stdout before exit so a large mcp frame is not truncated

### DIFF
--- a/packages/cli/bin/lorekit.mjs
+++ b/packages/cli/bin/lorekit.mjs
@@ -718,8 +718,38 @@ async function main() {
 }
 
 main()
-  .then((code) => process.exit(code ?? 0))
+  .then((code) => flushThenExit(code ?? 0))
   .catch((e) => {
     err(`${c.red('Error:')} ${e && e.stack ? e.stack : e}`);
-    process.exit(1);
+    flushThenExit(1);
   });
+
+// Exit only after stdout/stderr have drained.
+//
+// `process.exit()` truncates any output still buffered for a PIPE (the shape a
+// spawned child's stdout has), because pipe writes are asynchronous. `lorekit
+// mcp` streams newline-delimited JSON-RPC frames to stdout, and a large frame —
+// e.g. a `memory.list` result for a big scope — overflows the pipe buffer, so
+// exiting the instant `main()` resolves drops the tail of that write and the
+// client sees a silent "no response" (this reproduced deterministically once a
+// scope's payload crossed ~½ MB). Flushing first makes the final frame whole.
+// The unref'd safety timer guarantees the process still exits if a stream never
+// drains, so this can never turn a finished command into a hang.
+function flushThenExit(code) {
+  let pending = 2;
+  const done = () => {
+    pending -= 1;
+    if (pending === 0) process.exit(code);
+  };
+  const safety = setTimeout(() => process.exit(code), 2000);
+  safety.unref?.();
+  for (const stream of [process.stdout, process.stderr]) {
+    try {
+      // An empty write's callback fires only after every previously-queued write
+      // has flushed to the fd, so it is a reliable drain barrier.
+      stream.write('', done);
+    } catch {
+      done();
+    }
+  }
+}

--- a/packages/cli/test/mcp-server.test.mjs
+++ b/packages/cli/test/mcp-server.test.mjs
@@ -102,6 +102,42 @@ test('initialize → tools/list → write/read/list round-trip over stdio', asyn
   assert.ok(fs.existsSync(path.join(home, 'global')));
 });
 
+test('a large memory.list frame survives exit (big-scope stdout is not truncated)', async () => {
+  // Regression: `process.exit()` truncates stdout still buffered for a pipe, so
+  // the FINAL and largest frame — a `memory.list` over a big scope — was
+  // silently dropped and the client saw "no response". It reproduced
+  // deterministically once the response crossed ~½ MB; production's `global`
+  // scope had grown past that and rolled back two deploys before the exit path
+  // learned to flush first. Write enough large memories that the list response
+  // is several MB, then assert the frame comes back whole.
+  const store = tmpDir();
+  const BIG = 'x'.repeat(50 * 1024); // 50 KB per value
+  const COUNT = 50; // → ~2.5 MB list response, well past the truncation threshold
+  const writes = Array.from({ length: COUNT }, (_, i) => ({
+    jsonrpc: '2.0',
+    id: 100 + i,
+    method: 'tools/call',
+    params: { name: 'memory.write', arguments: { scope: 'global', key: `big-${i}`, value: BIG } },
+  }));
+
+  const { messages } = await serve(
+    [
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: {} },
+      ...writes,
+      { jsonrpc: '2.0', id: 999, method: 'tools/call', params: { name: 'memory.list', arguments: { scope: 'global' } } },
+    ],
+    { store },
+  );
+
+  const listMsg = byId(messages).get(999);
+  assert.ok(listMsg, 'memory.list produced no response — the final frame was truncated on exit');
+  const listed = JSON.parse(listMsg.result.content[0].text);
+  assert.equal(listed.ok, true);
+  assert.equal(listed.entries.length, COUNT);
+  // Every value came through whole, not clipped mid-frame.
+  assert.ok(listed.entries.every((e) => e.value.length === BIG.length));
+});
+
 test('unknown method returns a JSON-RPC method-not-found error', async () => {
   const store = tmpDir();
   const { messages } = await serve([{ jsonrpc: '2.0', id: 1, method: 'does/not/exist', params: {} }], { store });


### PR DESCRIPTION
## The actual root cause of the production deploy rollbacks

Deploys #375 and #377 (and my re-run of #377) all failed at one step — `smoke-mcp-stdio.mjs` → `memory.list errored: no response`, in ~1s, every time. This is **deterministic, not transient** — my earlier "transient" read was wrong, and the smoke-retry hardening in #379 would have retried it three times and still rolled back.

### Mechanism

`lorekit mcp` streams newline-delimited JSON-RPC frames to stdout. `bin/lorekit.mjs` then calls **`process.exit(0)` the instant `main()` resolves**. `process.exit()` **truncates output still buffered for a pipe** (documented Node behaviour — a spawned child's stdout is a pipe, and pipe writes are async). A `memory.list` frame for a large scope overflows the pipe buffer, so the final and largest frame is silently dropped — the client sees "no response". The tiny `initialize` / `tools/list` frames always arrived; only the big one vanished.

Production's `global` scope grew past the buffer threshold (LoreKit's own self-improvement loops write lessons constantly), which is why it began failing on 2026-08-05 and now fails every run.

### Reproduced

Spawning the real binary against a mock backend, varying the `memory.list` payload:

| payload | id:3 (memory.list) dropped |
|---|---|
| ~100 KB | 0/4 |
| ~½ MB | 3/4 |
| ≥2 MB | **4/4 (deterministic)** |

With the fix: **0/N at every size, verified up to 5 MB+.**

## The fix

Flush stdout/stderr before exiting. `flushThenExit` writes an empty chunk to each stream — its callback fires only after every queued write has flushed to the fd — and exits once both drain, with an unref'd 2s safety timer so a stream that never drains can't turn a finished command into a hang. Applied at the **single** process-exit site, so it protects every command, not just `mcp`.

## Regression test

`packages/cli/test/mcp-server.test.mjs` — writes ~2.5 MB of memories, lists them over stdio via the real spawned binary, and asserts the frame comes back whole with all values intact. **Verified it fails without the fix** (`not ok … the final frame was truncated`) and passes with it. Full CLI mcp suite: 52/52 green.

## Relationship to #379

#379 (smoke retry + failure diagnostics) is complementary and worth keeping — it tolerates genuine transients and, on a real failure, now dumps the child's raw stdout/stderr. But it does **not** fix this: a deterministic truncation retried three times still fails. **This PR is what unblocks the deploy pipeline.**

## Scope / docs

Internal CLI exit-path bugfix; no user-facing capability, config, or contract change. `deploy.yml` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ACKTU8p4SV5We4yLnhg28R)_