### PR TITLE
ci(deploy): add manual deploy_target override to deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,16 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      deploy_target:
+        description: 'What to deploy (overrides the change-detection step for a manual run)'
+        type: choice
+        default: auto
+        options:
+          - auto        # Use the change-detection step (same as a push to main)
+          - all         # Force BOTH halves — API + web
+          - api         # API only (Supabase edge functions + migrations)
+          - web         # Web only (Next.js dashboard on Vercel)
 
 permissions: {}
 
@@ -74,6 +84,11 @@ jobs:
   #    a change to this pipeline exercises the whole thing. Skipping the unchanged
   #    half is safe for the FE↔API lockstep — lockstep only matters when both
   #    change, and then both halves run and flip together.
+  #
+  #    A MANUAL run (workflow_dispatch) can override the detection with the
+  #    `deploy_target` input: `all` forces both halves, `api`/`web` force exactly
+  #    one, and `auto` (the default) falls back to the path filter — so a maintainer
+  #    can redeploy an unchanged half from the Actions UI without a no-op commit.
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
@@ -92,7 +107,27 @@ jobs:
         id: filter
         env:
           BEFORE: ${{ github.event.before }}
+          DEPLOY_TARGET: ${{ inputs.deploy_target }}
         run: |
+          # Manual override: a workflow_dispatch run can force what deploys,
+          # bypassing the path filter entirely. `auto` (and any push, where the
+          # input is empty) falls through to the change detection below.
+          case "$DEPLOY_TARGET" in
+            all) API=true;  WEB=true  ;;
+            api) API=true;  WEB=false ;;
+            web) API=false; WEB=true  ;;
+            *)   API=skip;  WEB=skip  ;;  # auto / empty → detect below
+          esac
+          if [ "$API" != skip ]; then
+            echo "Manual deploy target '$DEPLOY_TARGET' → api=$API web=$WEB"
+            echo "api=$API" >> "$GITHUB_OUTPUT"
+            echo "web=$WEB" >> "$GITHUB_OUTPUT"
+            echo "### Deploy scope (manual override: \`$DEPLOY_TARGET\`)" >> "$GITHUB_STEP_SUMMARY"
+            echo "- API (Supabase): $API" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Web (Vercel): $WEB" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
           BASE="$BEFORE"
           # Fall back to the parent commit for a first push, a missing base SHA,
           # or workflow_dispatch (no event.before) → compare against HEAD~1.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -88,6 +88,30 @@ any job fails ─▶ notify-failure   Discord webhook (see below)
 
 Production is never touched until preview has been deployed and smoke-tested.
 
+#### Which halves run (change detection + manual override)
+
+A `changes` job diffs the merge and gates the two halves independently: the API
+chain (`deploy-preview` → `smoke-preview` → `deploy-production`) runs only when
+API paths changed, and the web chain (`deploy-web-preview` / `stage-web-production`
+→ `promote-web-production`) only when web paths changed. A docs-only merge deploys
+neither. `packages/schemas/`, the workspace files, and `deploy.yml` itself map to
+**both**.
+
+A **manual run** can override the detection. From **Actions ▸ Deploy ▸ Run
+workflow** (or `gh workflow run deploy.yml`), pick a `deploy_target`:
+
+| `deploy_target` | Deploys |
+|-----------------|---------|
+| `auto` (default) | Whatever the change-detection step finds — same as a push to `main`. |
+| `all` | Both halves — API **and** web — regardless of what changed. |
+| `api` | API only (Supabase migrations + edge functions). |
+| `web` | Web only (Next.js dashboard on Vercel). |
+
+This is the way to redeploy an unchanged half — e.g. re-ship the dashboard after a
+Vercel env-var change, or re-apply functions — without an empty no-op commit. The
+override only decides **which** halves run; each still goes through the full
+preview → smoke → production promotion with its own gates and rollback.
+
 ### FE ↔ API deploy in lockstep (no availability skew)
 
 The whole point of moving the web deploy into `deploy.yml` is that the frontend


### PR DESCRIPTION
Add a workflow_dispatch `deploy_target` choice input (auto | all | api |
web) that overrides the change-detection step for a manual run, so a
maintainer can redeploy the API alone, the web alone, or both from the
Actions UI without a no-op commit. `auto` (and every push) falls through
to the existing path filter unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VSXpQ15Uqpuw1StRT3ybpt