### PR TITLE
ci: manual deploy_target override + observable smoke telemetry (tagged test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,22 @@ jobs:
     if: needs.changes.outputs.api == 'true'
     permissions:
       contents: read
+    env:
+      # ── Smoke telemetry (job-wide) ────────────────────────────────────────────
+      # Same knobs as deploy.yml / preview.yml so the tagging is uniform: every
+      # smoke request carries `X-LoreKit-Deployment-Environment: test` (via the
+      # CLI's `restFetch`, the REST/MCP smoke specs, and the tools/list curl
+      # below) and the CLI reports `deployment.environment.name=test`.
+      #
+      # NOTE: this job runs against a THROWAWAY LOCAL Supabase, which has no OTLP
+      # endpoint, so the edge exports NOTHING here regardless — the value is
+      # uniform tagging + exercising the new edge/CLI code path on the same stack
+      # the merge gate uses; real export only happens in preview.yml/deploy.yml
+      # against a project that has OTLP configured. The token is set for symmetry
+      # (no traced CLI command runs in this job, so it is inert here).
+      LOREKIT_TELEMETRY_TOKEN: ${{ secrets.LOREKIT_TELEMETRY_TOKEN }}
+      DEPLOYMENT_ENVIRONMENT: test
+      LOREKIT_CORRELATION_ID: ci-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
@@ -369,6 +385,7 @@ jobs:
               -H "Authorization: Bearer ${TOKEN}" \
               -H "Content-Type: application/json" \
               -H "Accept: application/json, text/event-stream" \
+              -H "x-lorekit-deployment-environment: ${DEPLOYMENT_ENVIRONMENT}" \
               -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' || echo 000)
             if [ "$CODE" = "200" ]; then
               echo "MCP stack healthy (migrations applied, functions serving, auth OK, tools/list → 200)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -468,6 +468,24 @@ jobs:
       # here so a step `if:` can read it — a step `if:` cannot reference secrets
       # via env of the same step. Unset → the suite self-skips (announced).
       HAVE_ORG_SMOKE_CREDS: ${{ secrets.LOREKIT_SMOKE_EMAIL != '' && secrets.LOREKIT_SMOKE_PASSWORD != '' && secrets.SUPABASE_ANON_KEY != '' }}
+      # ── Smoke telemetry (job-wide, inherited by every step) ───────────────────
+      # Make the smoke run OBSERVABLE in Dash0 so a failure is diagnosable from
+      # the telemetry, not just the CI log. Three knobs, all read by the code
+      # the smokes already run:
+      #   • LOREKIT_TELEMETRY_TOKEN — turns ON CLI OTLP export (off by default in
+      #     a source checkout: the baked-in token is injected only at npm publish),
+      #     so `install` / `doctor --deep` emit their `cli` spans + metrics.
+      #   • DEPLOYMENT_ENVIRONMENT=test — stamps `deployment.environment.name=test`
+      #     on the CLI's own spans AND, via the `X-LoreKit-Deployment-Environment`
+      #     header the CLI/`restFetch` + the REST/MCP smoke specs forward, on the
+      #     edge (`api`) spans for every smoke request — so ALL synthetic smoke
+      #     telemetry (cli + api + mcp) filters apart from real traffic. The edge
+      #     honours only `test` (supabase/functions/_shared/otel.ts).
+      #   • LOREKIT_CORRELATION_ID — a per-run key on every REST call's
+      #     `usage_events.correlation_id`, so one run's calls are greppable.
+      LOREKIT_TELEMETRY_TOKEN: ${{ secrets.LOREKIT_TELEMETRY_TOKEN }}
+      DEPLOYMENT_ENVIRONMENT: test
+      LOREKIT_CORRELATION_ID: smoke-preview-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
@@ -758,6 +776,15 @@ jobs:
     environment: production
     permissions:
       contents: read
+    env:
+      # Smoke telemetry — same three knobs as smoke-preview (see the comment
+      # there). DEPLOYMENT_ENVIRONMENT=test stamps ALL of this run's smoke spans
+      # (cli + api + mcp) with `deployment.environment.name=test` so they filter
+      # apart from real PRODUCTION traffic, even though they run against the
+      # production deployment; the edge honours only the synthetic `test` value.
+      LOREKIT_TELEMETRY_TOKEN: ${{ secrets.LOREKIT_TELEMETRY_TOKEN }}
+      DEPLOYMENT_ENVIRONMENT: test
+      LOREKIT_CORRELATION_ID: smoke-production-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
@@ -777,7 +804,9 @@ jobs:
       - name: Verify health endpoint
         run: |
           URL="https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co/functions/v1/health"
-          STATUS=$(curl -sf "$URL" | jq -r '.status // "unknown"')
+          # Tag this smoke request so its edge span reports env=test (job-wide
+          # DEPLOYMENT_ENVIRONMENT); the edge honours only the synthetic `test`.
+          STATUS=$(curl -sf -H "x-lorekit-deployment-environment: $DEPLOYMENT_ENVIRONMENT" "$URL" | jq -r '.status // "unknown"')
           echo "### Production deploy" >> "$GITHUB_STEP_SUMMARY"
           echo "- Commit: \`${{ github.sha }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Health endpoint status: **${STATUS}**" >> "$GITHUB_STEP_SUMMARY"
@@ -793,6 +822,7 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.LOREKIT_SMOKE_TOKEN }}" \
             -H "Content-Type: application/json" \
             -H "Accept: application/json, text/event-stream" \
+            -H "x-lorekit-deployment-environment: $DEPLOYMENT_ENVIRONMENT" \
             -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}')
           echo "- MCP tools/list HTTP: **${CODE}**" >> "$GITHUB_STEP_SUMMARY"
           if [ "$CODE" != "200" ]; then

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -267,6 +267,18 @@ jobs:
       # here so a step `if:` can read it — a step `if:` cannot reference secrets
       # via env of the same step. Unset → the suite self-skips (announced).
       HAVE_ORG_SMOKE_CREDS: ${{ secrets.LOREKIT_SMOKE_EMAIL != '' && secrets.LOREKIT_SMOKE_PASSWORD != '' && secrets.SUPABASE_ANON_KEY != '' }}
+      # ── Smoke telemetry (job-wide) ────────────────────────────────────────────
+      # Same as deploy.yml's smoke jobs: make the /preview smoke observable in
+      # Dash0, tagged apart from real traffic. LOREKIT_TELEMETRY_TOKEN turns ON
+      # CLI OTLP export (off by default in a source checkout); DEPLOYMENT_ENVIRONMENT=test
+      # stamps `deployment.environment.name=test` on the CLI's own spans AND —
+      # via the `X-LoreKit-Deployment-Environment` header the CLI/`restFetch` and
+      # the REST/MCP smoke specs forward — on the edge (`api`) spans for every
+      # smoke request; LOREKIT_CORRELATION_ID keys the run in `usage_events`. The
+      # preview project has OTLP configured, so cli + api + mcp telemetry all flow.
+      LOREKIT_TELEMETRY_TOKEN: ${{ secrets.LOREKIT_TELEMETRY_TOKEN }}
+      DEPLOYMENT_ENVIRONMENT: test
+      LOREKIT_CORRELATION_ID: preview-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,15 @@ jobs:
         run: node scripts/inject-telemetry-token.mjs --require
 
       - name: Verify the injected token can ingest (doctor --telemetry)
+        # This probe emits ONE real span to Dash0 (it is the only live-emitting
+        # step in the release). Tag it `deployment.environment.name=test` — same
+        # convention as the deploy/preview/ci smoke jobs — so this synthetic
+        # release-verification span filters apart from real CLI usage. (It hits
+        # the OTLP endpoint, not the LoreKit API, so no request header applies —
+        # the CLI resource attribute is enough.) The probe already carries
+        # `lorekit.telemetry.probe=true`; env=test is the second axis.
+        env:
+          DEPLOYMENT_ENVIRONMENT: test
         run: node packages/cli/bin/lorekit.mjs doctor --telemetry --dir "$RUNNER_TEMP"
 
       # No NODE_AUTH_TOKEN: npm authenticates via the Actions OIDC trusted

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -315,6 +315,29 @@ dashboard as the database safety net. The web rollback stays out only when the
 API deploy failed before the web was ever promoted — in that case the web was
 never touched, so reverting it would regress a healthy deployment.
 
+### Smoke telemetry (observable in Dash0, tagged `test`)
+
+The smoke jobs are instrumented so a failure is diagnosable from telemetry, not
+only the CI log. Each smoke job (`deploy.yml` smoke-preview/smoke-production,
+`preview.yml` smoke, `ci.yml` integration) sets three job-wide env vars:
+
+- `LOREKIT_TELEMETRY_TOKEN` — turns on CLI OTLP export, which is off in a source
+  checkout (the token is injected only at npm publish), so `install` /
+  `doctor --deep` emit their `cli` spans.
+- `DEPLOYMENT_ENVIRONMENT=test` — stamps **all** of the run's smoke telemetry
+  (CLI, plus the edge `api` spans for every REST/MCP request the smokes make)
+  with `deployment.environment.name=test`, so synthetic smoke traffic filters
+  apart from real usage — including the production smoke, which runs against the
+  production deployment. The mechanism (a forwarded `X-LoreKit-Deployment-Environment`
+  header the edge honours only for the value `test`) is documented in
+  [docs/otel.md](./otel.md) → "Smoke / test runs are tagged".
+- `LOREKIT_CORRELATION_ID` — a per-run key on every REST call's
+  `usage_events.correlation_id`, so one run's calls are greppable.
+
+`ci.yml`'s integration job runs against a throwaway **local** Supabase with no
+OTLP endpoint, so nothing exports there — the vars only keep the tagging uniform
+and exercise the code path; real export happens in the preview/production jobs.
+
 ### Smoke-test data hygiene
 
 The smoke suites write to **real projects** — the preview/staging project in

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -446,7 +446,33 @@ All signals carry these resource attributes:
 | `service.namespace` | `lorekit` |
 | `service.name` | `api` (Edge Functions), `web` (Next.js), `mcp` (Node MCP server), or `cli` (CLI) |
 | `service.version` | Git SHA (`VERCEL_GIT_COMMIT_SHA`) or `unknown`; the package version for the CLI |
-| `deployment.environment.name` | `production` / `preview` / `development` / `local`; the CLI omits it unless overridden. An explicit `DEPLOYMENT_ENVIRONMENT` env var overrides the ambient value on every component (used by `scripts/emit-correlated-trace.mts` to stamp `test`). |
+| `deployment.environment.name` | `production` / `preview` / `development` / `local`; the CLI omits it unless overridden. An explicit `DEPLOYMENT_ENVIRONMENT` env var overrides the ambient value on every component (used by `scripts/emit-correlated-trace.mts` and the smoke jobs to stamp `test` — see below). |
+
+### Smoke / test runs are tagged `deployment.environment.name=test`
+
+Every smoke suite in the pipelines (`deploy.yml` smoke-preview/smoke-production,
+`preview.yml` smoke, `ci.yml` integration) sets `DEPLOYMENT_ENVIRONMENT=test`, so
+all synthetic smoke telemetry filters apart from real traffic in Dash0 — even the
+production smoke, which runs against the production deployment. It reaches all
+three emitters through one knob:
+
+- **CLI** (`install`, `doctor --deep`): `resolveDeploymentEnvironment` reads
+  `DEPLOYMENT_ENVIRONMENT` and stamps the CLI's own resource.
+- **Edge** (`api` — every REST/MCP request a smoke makes): the client forwards
+  the value as the `X-LoreKit-Deployment-Environment` request header — the CLI's
+  `restFetch` does it automatically from the same env var, and the REST/MCP smoke
+  specs send it via `testRunHeaders` (`packages/mcp-server/src/smoke-telemetry.ts`).
+  `traceRequest` applies it to that request's span batch as
+  `deployment.environment.name`. The edge's own `deployment.environment.name` is a
+  per-deployment resource attribute it cannot change per request, so the header is
+  the seam that lets a smoke request against a production isolate still report
+  `test`.
+
+The edge honours **only** the synthetic value `test` from the header (an
+allowlist in `resolveEnvironmentOverride`): a caller can mark its own traffic as
+synthetic but can never relabel itself `production`/`preview`, and no auth,
+tenancy, limit, or behaviour depends on the tag — it is observability only.
+`release.yml`'s `doctor --telemetry` ingest probe is tagged `test` the same way.
 
 ---
 

--- a/packages/cli/src/mcp.mjs
+++ b/packages/cli/src/mcp.mjs
@@ -138,6 +138,26 @@ export function normalizeCorrelationId(raw) {
   return /^[A-Za-z0-9_\-./:#@]+$/.test(t) ? t : null;
 }
 
+/**
+ * Normalise a deployment-environment marker restFetch attaches as
+ * X-LoreKit-Deployment-Environment when DEPLOYMENT_ENVIRONMENT (or
+ * OTEL_DEPLOYMENT_ENVIRONMENT) is set. It lets a smoke/test run tell the edge to
+ * report `deployment.environment.name` for that request — the edge honours only
+ * the synthetic `test` value, so real traffic (no env set) is never tagged and a
+ * caller can never relabel itself as another real environment. This is the SAME
+ * value `resolveDeploymentEnvironment` (packages/cli/src/telemetry.mjs) puts on
+ * the CLI's own resource, so one `DEPLOYMENT_ENVIRONMENT=test` marks both the CLI
+ * span and its downstream edge spans. Bounded + charset-restricted (fail-safe: a
+ * bad value is not sent). Zero-dep, so the small regex is duplicated
+ * intentionally, like `normalizeCorrelationId`.
+ */
+export function normalizeRunEnvironment(raw) {
+  if (typeof raw !== 'string') return null;
+  const t = raw.trim();
+  if (!t || t.length > 64) return null;
+  return /^[A-Za-z0-9_.\-:]+$/.test(t) ? t : null;
+}
+
 export async function restFetch(baseUrl, token, path, { method = 'GET', body, timeoutMs = 10000, traceparent } = {}) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
@@ -148,12 +168,21 @@ export async function restFetch(baseUrl, token, path, { method = 'GET', body, ti
     // /memories/usage?correlation_id=… can report "usage for this PR". Absent env
     // ⇒ no header ⇒ existing behaviour unchanged.
     const correlationId = normalizeCorrelationId(process.env.LOREKIT_CORRELATION_ID);
+    // Opt-in test-run marker: when DEPLOYMENT_ENVIRONMENT is set (a deploy/CI
+    // smoke sets it to `test`), tell the edge to report that
+    // `deployment.environment.name` for this request so Dash0 can filter synthetic
+    // smoke traffic apart from real usage. Absent env ⇒ no header ⇒ existing
+    // behaviour unchanged. The edge honours only `test` (see otel.ts).
+    const runEnv = normalizeRunEnvironment(
+      process.env.DEPLOYMENT_ENVIRONMENT ?? process.env.OTEL_DEPLOYMENT_ENVIRONMENT,
+    );
     const headers = {
       accept: 'application/json',
       ...(body !== undefined ? { 'content-type': 'application/json' } : {}),
       ...(token ? { authorization: `Bearer ${token}` } : {}),
       ...(traceparent ? { traceparent } : {}),
       ...(correlationId ? { 'x-lorekit-correlation-id': correlationId } : {}),
+      ...(runEnv ? { 'x-lorekit-deployment-environment': runEnv } : {}),
       // Name the calling surface so usage analytics can tell a CLI read from a
       // dashboard one. Not cosmetic: `GET /memories/read-activity` EXCLUDES the
       // `dashboard` client (a human browsing lore is not consuming it), so a

--- a/packages/cli/test/run-environment.test.mjs
+++ b/packages/cli/test/run-environment.test.mjs
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeRunEnvironment } from '../src/mcp.mjs';
+
+// The deployment-environment marker restFetch attaches as
+// X-LoreKit-Deployment-Environment when DEPLOYMENT_ENVIRONMENT (or
+// OTEL_DEPLOYMENT_ENVIRONMENT) is set — the edge reports it as
+// `deployment.environment.name` (honouring only the synthetic `test`), so a
+// smoke run's downstream spans filter apart from real traffic. Bounds mirror the
+// edge's `resolveEnvironmentOverride` charset (supabase/functions/_shared/otel.ts)
+// and `testRunHeaders` (packages/mcp-server/src/smoke-telemetry.ts).
+
+test('normalizeRunEnvironment accepts bounded environment names, trimmed', () => {
+  assert.equal(normalizeRunEnvironment('test'), 'test');
+  assert.equal(normalizeRunEnvironment('  test  '), 'test');
+  assert.equal(normalizeRunEnvironment('preview'), 'preview');
+  assert.equal(normalizeRunEnvironment('staging-2'), 'staging-2');
+});
+
+test('normalizeRunEnvironment rejects empty, over-long, out-of-charset, non-string', () => {
+  assert.equal(normalizeRunEnvironment(''), null);
+  assert.equal(normalizeRunEnvironment('   '), null);
+  assert.equal(normalizeRunEnvironment('a'.repeat(65)), null);
+  assert.equal(normalizeRunEnvironment('has spaces'), null);
+  assert.equal(normalizeRunEnvironment('semi;colon'), null);
+  assert.equal(normalizeRunEnvironment(undefined), null);
+  assert.equal(normalizeRunEnvironment(null), null);
+  assert.equal(normalizeRunEnvironment(42), null);
+});

--- a/packages/mcp-server/src/byod-smoke.integration.spec.ts
+++ b/packages/mcp-server/src/byod-smoke.integration.spec.ts
@@ -26,6 +26,7 @@ import {
   runBestEffortCleanup,
   sweepSmokeArtefacts,
 } from './smoke-cleanup.js';
+import { testRunHeaders } from './smoke-telemetry.js';
 
 const BASE_URL = (process.env['LOREKIT_BYOD_URL'] ?? '').replace(/\/$/, '');
 const TOKEN    = process.env['LOREKIT_BYOD_TOKEN'];
@@ -69,6 +70,7 @@ async function mcpCall<T = unknown>(tool: string, args: Record<string, unknown>)
       'Content-Type': 'application/json',
       Accept: 'application/json, text/event-stream',
       Authorization: `Bearer ${TOKEN}`,
+      ...testRunHeaders(),
     },
     body: JSON.stringify({
       jsonrpc: '2.0',

--- a/packages/mcp-server/src/memories-api.integration.spec.ts
+++ b/packages/mcp-server/src/memories-api.integration.spec.ts
@@ -23,6 +23,7 @@ import {
   sweepSmokeArtefacts,
   type SmokeNamespace,
 } from './smoke-cleanup.js';
+import { testRunHeaders } from './smoke-telemetry.js';
 
 const BASE = (process.env['LOREKIT_REST_BASE_URL'] ?? 'http://localhost:54321/functions/v1').replace(/\/$/, '');
 const TOKEN = process.env['LOREKIT_SMOKE_TOKEN'];
@@ -63,6 +64,7 @@ async function api(method: string, path: string, body?: unknown): Promise<{ stat
     headers: {
       Authorization: `Bearer ${TOKEN}`,
       'Content-Type': 'application/json',
+      ...testRunHeaders(),
     },
     ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
   });

--- a/packages/mcp-server/src/orgs-api.integration.spec.ts
+++ b/packages/mcp-server/src/orgs-api.integration.spec.ts
@@ -30,6 +30,7 @@
 
 import { describe, it, expect, afterAll, beforeAll } from 'vitest';
 import { createSmokeNamespace, runBestEffortCleanup } from './smoke-cleanup.js';
+import { testRunHeaders } from './smoke-telemetry.js';
 
 const BASE = (process.env['LOREKIT_REST_BASE_URL'] ?? 'http://localhost:54321/functions/v1').replace(/\/$/, '');
 const JWT = process.env['LOREKIT_SMOKE_JWT'];
@@ -79,7 +80,7 @@ async function restFetch(
   body?: unknown,
   token: string | null | undefined = JWT,
 ): Promise<{ status: number; data: unknown }> {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const headers: Record<string, string> = { 'Content-Type': 'application/json', ...testRunHeaders() };
   if (token) headers['Authorization'] = `Bearer ${token}`;
   const res = await fetch(`${BASE}/orgs${path}`, {
     method,

--- a/packages/mcp-server/src/smoke-telemetry.ts
+++ b/packages/mcp-server/src/smoke-telemetry.ts
@@ -1,0 +1,45 @@
+/**
+ * Test-run telemetry headers for the live smoke suites.
+ *
+ * The smoke specs are HTTP CLIENTS of the live edge functions (the `api`
+ * service), so the server already emits a span for every call they make. What
+ * was missing is a way to tell a deploy-pipeline smoke request apart from real
+ * traffic in Dash0. These headers supply that:
+ *
+ *   • `X-LoreKit-Deployment-Environment` → the edge reports this request's
+ *     `deployment.environment.name` (it honours only the synthetic `test`
+ *     value; supabase/functions/_shared/otel.ts), so a whole smoke run's server
+ *     spans sit under env=test alongside the CLI's own test-tagged spans.
+ *   • `X-LoreKit-Correlation-Id`         → recorded on `usage_events.correlation_id`
+ *     by the router, so ONE run's calls share a key.
+ *
+ * Both are read from the environment the deploy job sets (`DEPLOYMENT_ENVIRONMENT`,
+ * `LOREKIT_CORRELATION_ID`) — the SAME vars the CLI's `restFetch` forwards — so
+ * every smoke surface (CLI, REST, MCP) tags identically. Both are fail-safe:
+ * unset/invalid ⇒ the header is omitted, so a local `vitest` run without the env
+ * behaves exactly as before.
+ *
+ * Bounds mirror `normalizeRunEnvironment` / `normalizeCorrelationId` in the
+ * zero-dep CLI (packages/cli/src/mcp.mjs); keep them in step.
+ */
+export function testRunHeaders(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+  const headers: Record<string, string> = {};
+
+  const rawEnv = env['DEPLOYMENT_ENVIRONMENT'] ?? env['OTEL_DEPLOYMENT_ENVIRONMENT'];
+  if (typeof rawEnv === 'string') {
+    const value = rawEnv.trim();
+    if (value && value.length <= 64 && /^[A-Za-z0-9_.\-:]+$/.test(value)) {
+      headers['X-LoreKit-Deployment-Environment'] = value;
+    }
+  }
+
+  const rawCorrelation = env['LOREKIT_CORRELATION_ID'];
+  if (typeof rawCorrelation === 'string') {
+    const correlation = rawCorrelation.trim();
+    if (correlation && correlation.length <= 200 && /^[A-Za-z0-9_\-./:#@]+$/.test(correlation)) {
+      headers['X-LoreKit-Correlation-Id'] = correlation;
+    }
+  }
+
+  return headers;
+}

--- a/packages/mcp-server/src/smoke.integration.spec.ts
+++ b/packages/mcp-server/src/smoke.integration.spec.ts
@@ -23,6 +23,7 @@ import {
   runBestEffortCleanup,
   sweepSmokeArtefacts,
 } from './smoke-cleanup.js';
+import { testRunHeaders } from './smoke-telemetry.js';
 
 const BASE_URL = (process.env['LOREKIT_SMOKE_URL'] ?? 'http://localhost:3000/mcp').replace(/\/$/, '');
 const TOKEN = process.env['LOREKIT_SMOKE_TOKEN'];
@@ -61,6 +62,7 @@ async function mcpCallInner<T = unknown>(tool: string, args: Record<string, unkn
       'Content-Type': 'application/json',
       Accept: 'application/json, text/event-stream',
       Authorization: `Bearer ${TOKEN}`,
+      ...testRunHeaders(),
     },
     body: JSON.stringify({
       jsonrpc: '2.0',

--- a/supabase/functions/_shared/otel.ts
+++ b/supabase/functions/_shared/otel.ts
@@ -214,7 +214,10 @@ function resolveDeploymentEnv(): string {
   return 'local';
 }
 
-export function buildOtlpPayload(spans: SpanPayload[]): unknown {
+export function buildOtlpPayload(
+  spans: SpanPayload[],
+  opts: { environmentOverride?: string } = {},
+): unknown {
   // Build vcs.* resource attributes once per payload (they are constant for
   // the lifetime of the isolate — resolved from Supabase secrets at startup).
   const vcsAttrs = getVcsResourceAttributes();
@@ -240,7 +243,10 @@ export function buildOtlpPayload(spans: SpanPayload[]): unknown {
     { key: 'service.name', value: { stringValue: serviceName } },
     { key: 'service.namespace', value: { stringValue: 'lorekit' } },
     { key: 'service.version', value: { stringValue: serviceVersion } },
-    { key: 'deployment.environment.name', value: { stringValue: resolveDeploymentEnv() } },
+    // A caller-supplied override (a smoke run's `test`) wins over the isolate's
+    // ambient environment, so synthetic traffic against a production deployment
+    // still reports `test`. Validated to the allowlist before it reaches here.
+    { key: 'deployment.environment.name', value: { stringValue: opts.environmentOverride ?? resolveDeploymentEnv() } },
     ...Object.entries(vcsAttrs).map(([key, value]) => ({
       key,
       value: { stringValue: value },
@@ -277,6 +283,12 @@ export function buildOtlpPayload(spans: SpanPayload[]): unknown {
 
 export class ExportBatch {
   private spans: SpanPayload[] = [];
+  /**
+   * Optional per-request `deployment.environment.name` override (a smoke run's
+   * `test`). Set by `traceRequest` from a validated header; applied at flush so
+   * a request against a production deployment can still report synthetic env.
+   */
+  environmentOverride?: string;
 
   add(span: SpanPayload): void { this.spans.push(span); }
 
@@ -298,7 +310,7 @@ export class ExportBatch {
     const cfg = getOtlpConfig();
     if (!cfg) return;
 
-    const payload = buildOtlpPayload([...this.spans]);
+    const payload = buildOtlpPayload([...this.spans], { environmentOverride: this.environmentOverride });
     this.spans = [];
 
     const p = fetch(`${cfg.endpoint}/v1/traces`, {
@@ -413,6 +425,34 @@ function faasNameFrom(operationName: string): string {
 }
 
 /**
+ * Values the `X-LoreKit-Deployment-Environment` request header is allowed to set
+ * `deployment.environment.name` to. Restricted to the single SYNTHETIC value
+ * `test` on purpose: LoreKit's own smoke suites send it (the CLI forwards
+ * `DEPLOYMENT_ENVIRONMENT`, the REST/MCP smoke specs send it directly) so a
+ * deploy-pipeline run's server spans are tagged `test` and filter apart from
+ * real traffic in Dash0. A caller can therefore only mark its own traffic as
+ * synthetic — never relabel itself as `production`/`preview` — so the header can
+ * hide a caller's own spans from an env=production view but can never forge a
+ * different real environment. It changes only an observability tag: no auth,
+ * tenancy, limit, or behaviour depends on it.
+ */
+const HEADER_ENV_ALLOWLIST = new Set(['test']);
+
+/**
+ * Resolve a caller-supplied `deployment.environment.name` override from the
+ * `X-LoreKit-Deployment-Environment` header, or `undefined` when absent or not
+ * in the allowlist. Unlike a resource attribute the isolate fixes at boot, this
+ * is applied per request batch (each request flushes its own ExportBatch), which
+ * is what lets a smoke request against a production deployment report `test`.
+ */
+function resolveEnvironmentOverride(req: Request): string | undefined {
+  const raw = req.headers.get('x-lorekit-deployment-environment');
+  if (!raw) return undefined;
+  const t = raw.trim().toLowerCase();
+  return HEADER_ENV_ALLOWLIST.has(t) ? t : undefined;
+}
+
+/**
  * Return a Response carrying the server span's `traceparent`, so a browser or
  * CLI can correlate its request with the server-side trace.
  *
@@ -461,6 +501,10 @@ export async function traceRequest<T extends Response>(
   fn: (span: Span) => Promise<T>,
 ): Promise<T> {
   const batch = new ExportBatch();
+  // A smoke/test run may ask (via header) to report `deployment.environment.name
+  // = test` so its spans filter apart from real traffic; applied to this
+  // request's whole span batch at flush.
+  batch.environmentOverride = resolveEnvironmentOverride(req);
   const ctx = extractTraceContext(req);
   const span = new Span(operationName, ctx, batch, SPAN_KIND_SERVER);
 


### PR DESCRIPTION
## Summary

Two deploy-pipeline improvements:

### 1. Manual `deploy_target` override (`deploy.yml`)
A `workflow_dispatch` dropdown lets a maintainer force what deploys, bypassing change detection — so an unchanged half can be redeployed from the Actions UI without a no-op commit:

| `deploy_target` | Deploys |
|-----------------|---------|
| `auto` (default) | Whatever change detection finds — same as a push to `main` |
| `all` | Both halves — API **and** web |
| `api` | API only (Supabase migrations + edge functions) |
| `web` | Web only (Next.js dashboard on Vercel) |

The override lives in the existing `changes` job and short-circuits the git-diff detection; every downstream job already gates on `needs.changes.outputs.api/web`, so nothing else changed. A push (empty input) and `auto` fall through to the unchanged detection.

### 2. Observable smoke telemetry, tagged `deployment.environment.name=test`
The smoke suites emitted **no CLI telemetry** (export is gated off in a source checkout — the Dash0 token is injected only at npm publish), and the edge server spans they produced were indistinguishable from real traffic, so a smoke failure was undiagnosable from telemetry.

Now every smoke surface (**cli + api + mcp**) is observable and filtered apart from real traffic, via one knob — `DEPLOYMENT_ENVIRONMENT=test` — reusing the existing `deployment.environment.name` convention:

- **CLI** (`install`, `doctor --deep`): `LOREKIT_TELEMETRY_TOKEN` turns on OTLP export; `resolveDeploymentEnvironment` already stamps the CLI resource. `restFetch` now also forwards the value as the `X-LoreKit-Deployment-Environment` header (`normalizeRunEnvironment`, mirroring the correlation-id path).
- **Edge** (`api` — every REST/MCP request a smoke makes): `traceRequest` applies a per-request `deployment.environment.name` override from that header, **allowlisted to the synthetic value `test` only**. So a smoke request against the production deployment still reports `test`, and a caller can never relabel itself as another real environment. Observability only — no auth / tenancy / limit / behaviour depends on it.
- **REST/MCP smoke specs** send the header via a shared `testRunHeaders()` helper (`packages/mcp-server/src/smoke-telemetry.ts`); the raw production curls send it via `-H`.
- **Workflows**: `deploy.yml` (smoke-preview/-production), `preview.yml` (smoke), and `ci.yml` (integration) set `LOREKIT_TELEMETRY_TOKEN`, `DEPLOYMENT_ENVIRONMENT=test`, and a per-run `LOREKIT_CORRELATION_ID`. `release.yml`'s `doctor --telemetry` ingest probe is tagged `test` the same way.

`ci.yml`'s integration job runs against a throwaway local Supabase with no OTLP endpoint, so nothing exports there — the vars keep the tagging uniform and exercise the new code path; real export happens in the preview/production jobs.

## Why
The production deploy in [run 31034068257](https://github.com/mthines/lorekit/actions/runs/31034068257) rolled back on a smoke failure that emitted no telemetry, making it undiagnosable from the data. This makes the next such failure readable in Dash0 (filter `deployment.environment.name = test`).

## Testing
- CLI unit tests pass (`normalizeRunEnvironment` added, mirroring the correlation-id tests; existing `restFetch`/remote-store header assertions still green).
- `mcp-server` typecheck passes.
- All four workflow YAMLs validated.
- Remaining gates run in CI.

## Docs
- `docs/otel.md` → "Smoke / test runs are tagged `deployment.environment.name=test`"
- `docs/deployment.md` → "Smoke telemetry" + manual-override table

`llms.txt` / public docs are intentionally untouched: the `X-LoreKit-Deployment-Environment` header and `DEPLOYMENT_ENVIRONMENT` marker are internal observability plumbing for LoreKit's own smoke suites, not a user-facing product capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSXpQ15Uqpuw1StRT3ybpt)_