### PR TITLE
ci: export local edge telemetry from CI + address #386 review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,11 @@ jobs:
       # file is only ever created on the runner, never committed. Fork PRs have
       # no secret → skip → the edge stays dark (unchanged behaviour), never a
       # broken start. Must run BEFORE `supabase start` so the runtime picks it up.
+      # The GITHUB_* lines give the edge its `service.version` + `vcs.*` resource
+      # attrs (`_shared/otel.ts` reads GITHUB_SHA/REPOSITORY/REF_NAME); the edge
+      # isolate does not inherit the runner env — that is the same reason the
+      # OTLP endpoint has to be written here — so without them these spans land
+      # unattributed (`service.version=unknown`, no `vcs.*`).
       - name: Configure local edge OTLP export (Dash0)
         env:
           LOREKIT_TELEMETRY_TOKEN: ${{ secrets.LOREKIT_TELEMETRY_TOKEN }}
@@ -375,8 +380,11 @@ jobs:
             echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer ${LOREKIT_TELEMETRY_TOKEN}"
             echo "DASH0_DATASET=default"
             echo "DEPLOYMENT_ENVIRONMENT=test"
+            echo "GITHUB_SHA=${GITHUB_SHA}"
+            echo "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}"
+            echo "GITHUB_REF_NAME=${GITHUB_REF_NAME}"
           } > supabase/functions/.env
-          echo "Wrote supabase/functions/.env — local edge will export to Dash0 as deployment.environment.name=test."
+          echo "Wrote supabase/functions/.env — local edge will export to Dash0 as deployment.environment.name=test, attributed to ${GITHUB_REPOSITORY}@${GITHUB_SHA}."
 
       - name: Start local Supabase (applies migrations, serves functions)
         run: supabase start

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,17 +318,16 @@ jobs:
       contents: read
     env:
       # ── Smoke telemetry (job-wide) ────────────────────────────────────────────
-      # Same knobs as deploy.yml / preview.yml so the tagging is uniform: every
-      # smoke request carries `X-LoreKit-Deployment-Environment: test` (via the
-      # CLI's `restFetch`, the REST/MCP smoke specs, and the tools/list curl
-      # below) and the CLI reports `deployment.environment.name=test`.
-      #
-      # NOTE: this job runs against a THROWAWAY LOCAL Supabase, which has no OTLP
-      # endpoint, so the edge exports NOTHING here regardless — the value is
-      # uniform tagging + exercising the new edge/CLI code path on the same stack
-      # the merge gate uses; real export only happens in preview.yml/deploy.yml
-      # against a project that has OTLP configured. The token is set for symmetry
-      # (no traced CLI command runs in this job, so it is inert here).
+      # Same knobs as deploy.yml / preview.yml so the tagging is uniform, AND —
+      # unlike a plain `supabase start` — the local edge is given an OTLP endpoint
+      # (the "Configure local edge OTLP export" step below) so its smoke spans
+      # actually export to Dash0, tagged `deployment.environment.name=test`. Every
+      # smoke request also carries `X-LoreKit-Deployment-Environment: test` (via
+      # the CLI's `restFetch`, the REST/MCP smoke specs, and the tools/list curl).
+      # LOREKIT_TELEMETRY_TOKEN is the Dash0 ingest-only token, used both to write
+      # that edge .env and (were a traced CLI command to run here) for CLI export.
+      # Fork PRs get no secret → the edge .env step self-skips → graceful
+      # no-export, exactly as before.
       LOREKIT_TELEMETRY_TOKEN: ${{ secrets.LOREKIT_TELEMETRY_TOKEN }}
       DEPLOYMENT_ENVIRONMENT: test
       LOREKIT_CORRELATION_ID: ci-${{ github.run_id }}-${{ github.run_attempt }}
@@ -352,6 +351,32 @@ jobs:
         uses: supabase/setup-cli@v3
         with:
           version: latest
+
+      # Give the LOCAL edge runtime an OTLP endpoint so its smoke spans actually
+      # export to Dash0 (tagged `deployment.environment.name=test`), instead of
+      # being dark as they are under a plain `supabase start`. The CLI loads
+      # `supabase/functions/.env` into the edge runtime at `supabase start`, so
+      # write it there from the ingest-only token secret. The endpoint is the
+      # same public Dash0 ingress the CLI bakes in as its default; the token is
+      # ingest-only (POST spans, no read/manage). `.env` is gitignored, and the
+      # file is only ever created on the runner, never committed. Fork PRs have
+      # no secret → skip → the edge stays dark (unchanged behaviour), never a
+      # broken start. Must run BEFORE `supabase start` so the runtime picks it up.
+      - name: Configure local edge OTLP export (Dash0)
+        env:
+          LOREKIT_TELEMETRY_TOKEN: ${{ secrets.LOREKIT_TELEMETRY_TOKEN }}
+        run: |
+          if [ -z "$LOREKIT_TELEMETRY_TOKEN" ]; then
+            echo "::warning::LOREKIT_TELEMETRY_TOKEN unavailable (fork PR?) — local edge telemetry export is disabled for this run."
+            exit 0
+          fi
+          {
+            echo "OTEL_EXPORTER_OTLP_ENDPOINT=https://ingress.europe-west4.gcp.dash0-dev.com"
+            echo "OTEL_EXPORTER_OTLP_HEADERS=Authorization=Bearer ${LOREKIT_TELEMETRY_TOKEN}"
+            echo "DASH0_DATASET=default"
+            echo "DEPLOYMENT_ENVIRONMENT=test"
+          } > supabase/functions/.env
+          echo "Wrote supabase/functions/.env — local edge will export to Dash0 as deployment.environment.name=test."
 
       - name: Start local Supabase (applies migrations, serves functions)
         run: supabase start

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,8 +231,10 @@ external-bot feedback loop (which is Step 4). Do **not** pass `--no-feedback` (t
 `--no-quality`. Undrafting is the last, human step, after the flow reaches ready-to-review.
 
 > **The one review agent on the PR is the `dash0-dev` bot — never run a second `pr-reviewer` locally.**
-> `/polish` (Step 1) runs the reviewer BEFORE the PR exists (a local pre-flight, no GitHub write), so
-> it does not double-post; `review-loop` runs it ON the open PR, which does, so it is excluded here.
+> `/polish` (Step 1) runs pre-PR, where its reviewer pass (Pass A) is **skipped** — `pr-reviewer` has no
+> PR-less mode — so Step 1 only runs the `simplify` pass and never posts to GitHub; `review-loop` runs
+> `pr-reviewer` ON the open PR, where it posts a `COMMENT` review, so it is excluded here to avoid
+> duplicating the `dash0-dev` review.
 
 ### Step 3 — The `dash0-dev` bot reviews (the ONE review agent on the PR)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,67 +218,60 @@ are surfaced for awareness but do not block the workflow — they require a huma
 
 Skip this step only if the branch diff is non-code only (docs, lockfiles, generated artefacts).
 
-### Step 2 — Open / push the PR
+### Step 2 — Open the PR (as a draft)
 
-Create the PR (or push a new commit to an existing branch). It may start as a draft.
-The Dash0 bot picks up the event automatically and starts its review — **you do not trigger it manually**.
+Open the PR **as a draft** (`gh pr create --draft`). The draft state is what lets `pr-reviewer`
+(Step 3) and the `dash0-dev` bot (Step 4) post inline comments while the branch converges — undrafting
+is the last, human step, after the flow below reaches ready-to-review. The `dash0-dev` bot picks up the
+event automatically and starts its review — **you do not trigger it manually**.
 
-### Step 3 — Await the Dash0 bot review report
+### Step 3 — Converge the PR locally with `/review-loop`
 
-After the PR is opened or marked ready-for-review, **wait for the `dash0-dev` bot to post its review**.
-The bot runs `PR Ready for Review — Polish + Review` automatically; a comment from `dash0-dev` with
-the review results will appear on the PR. Do not proceed until that comment is present.
+After the draft PR is open, run the bounded review-apply-simplify convergence loop — the same
+orchestrator `/create-pr` (post-draft) and `autonomous-workflow` Phase 6/7 use:
 
-**The bot re-reviews automatically on every new commit (a `synchronize` push) — you do NOT need a
-human `@dash0 review` to re-trigger it.** After you push fixes, it re-runs against the new SHA and
-posts fresh inline comments, marking addressed findings **"Superseded / Resolving."** So the loop is:
-push fix → the bot re-reviews the new commit → it resolves what you fixed. Two consequences worth
-remembering: (1) a review verdict is pinned to a specific `commit_id` — the gate summary (e.g. a ❌
-"Code review") can be **stale on an older SHA** while the findings are already resolved on `HEAD`, so
-always check which commit a verdict/comment targets before treating it as open; and (2) there is a
-**race window** — if you push while an in-flight review is mid-run, its next comments can be anchored
-to your new SHA but still describe the *pre-fix* content. Re-verify against `HEAD` (`git show
-HEAD:<file>`) rather than trusting a just-arrived comment. The `@dash0 resolve`-doesn't-fire caveat in
-Step 4 is about **comments**, not pushes — a push is what re-triggers the review.
-
-```bash
-# Poll until the dash0-dev review appears (count should reach ≥ 1)
-while [ "$(gh pr view <pr-number> --repo mthines/lorekit --json reviews \
-  --jq '.reviews | map(select(.author.login == "dash0-dev")) | length')" -lt 1 ]; do
-  sleep 10
-done
+```
+Skill("review-loop", "<pr-url>")
 ```
 
-### Step 4 — Implement review suggestions on a WATCH LOOP (max 5 iterations)
+`review-loop` owns no rules of its own; each iteration it sequences `pr-reviewer` (find — read-only,
+posts one `COMMENT` review) → `implement-suggestion` (apply — **single-shot, NOT `--watch`**) →
+`Skill("polish", "simplify")` (Class-M mechanical refactors), then pushes. It **drives its own
+re-review**, so it never waits on an external bot. `implement-suggestion` makes **one commit per
+comment**, each gated by `/critical` then `/confidence` — that is the per-comment behaviour. The loop
+**early-exits** the instant `pr-reviewer` returns PASS with no blocking findings, and is **bounded to 3
+iterations** (`--cap N` to change; `--critical` for an adversarial pre-mortem each round). It **never
+undrafts** the PR. If it reaches the cap still failing, it surfaces the remaining blockers — fix them
+or reply why not.
 
-The `dash0-dev` bot re-reviews on **every** new commit (Step 3), so addressing findings is a LOOP, not
-a one-shot: each push of fixes triggers a fresh review that may surface new findings. **Immediately
-after the PR is created** (Step 2), dispatch `/implement-suggestion --watch` as a **background
-sub-agent** (`run_in_background: true`, subagent_type: general) — the same way `/create-pr` Step 6.5
-does — and continue to Step 5 in the main thread in parallel; do NOT block on it:
+### Step 4 — Absorb EXTERNAL-bot feedback with `/implement-suggestion --watch`
+
+Separately from the local loop, the `dash0-dev` bot reviews **automatically on every commit** (a
+`synchronize` push) — it runs the same `pr-reviewer` agent server-side and posts a `COMMENT` review
+(marking addressed findings "Superseded / Resolving"); CodeRabbit and human reviewers may comment too.
+After `review-loop` has converged, dispatch a **background** sub-agent (`run_in_background: true`,
+subagent_type: general) to absorb that external feedback without blocking the CI work in Step 5 — the
+same thing `/create-pr` does after its review-loop:
 
 > Invoke: Skill('implement-suggestion', '<pr-url> --watch')
-> Drive the reviewer-feedback loop for PR <pr-url> to completion. It never opens a new PR and never
-> undrafts this one. Return its final per-iteration watch report verbatim.
+> Absorb EXTERNAL review feedback to completion — only comments from external parties, NOT the
+> review-loop's own. It never opens a new PR and never undrafts this one. Return its watch report.
 
-`/implement-suggestion --watch` waits for each `dash0-dev` review, fetches all open review comments
-(human + AI), validates **each comment** through `/critical` then `/confidence`, applies each approved
-change as its **own commit** (one commit per comment), pushes, and resolves the addressed threads —
-then waits for the NEXT review that push triggers and repeats. It only ever processes comments newer
-than the last round, so it never re-applies the same one.
+`--watch` waits for each external review, applies the actionable comments (one commit per comment,
+`/critical`+`/confidence` gated), pushes, and repeats — **scoped to comments posted after
+`review-loop`'s last push**, so it never re-applies the loop's own findings. It is **bounded to 5
+iterations** (`--max-iters` default; hard cap 10) and **never undrafts**. Two facts about the external
+bot: a verdict is pinned to a `commit_id`, so a gate summary can be **stale on an older SHA** while
+already resolved on `HEAD` — check which commit a comment targets before treating it as open; and a
+push mid-review can anchor the next comments to your new SHA while still describing *pre-fix* content,
+so re-verify against `HEAD` (`git show HEAD:<file>`). Do **not** post `@dash0 resolve` — agent-posted
+comments don't trigger the webhook; the skill resolves threads via the API directly.
 
-**The loop is bounded to 5 iterations** (the skill's `--max-iters` default; hard cap 10). It stops
-early when a round is clean or reviewers go quiet, and stops at the cap otherwise — so it can never run
-away. Two hard rules to know: it **never undrafts** the PR (readiness is a human decision — see Step 5),
-and it **never** posts `@dash0 resolve` (agent-posted comments don't trigger the webhook; the skill
-resolves threads via the API directly). If findings still remain when the cap is hit, the watch report
-lists them as *surfaced* for a human.
+### Step 5 — Drive CI green (in parallel); ready-to-review = clean + green
 
-### Step 5 — Drive CI green (in parallel), reach a ready-to-review state
-
-CI is a **separate, parallel** concern from the review loop — run it in the main thread while the Step 4
-watch sub-agent runs in the background (both push to the same branch; each skill pull-rebases
-internally, so no manual serialisation). Whenever checks are red, run:
+CI is a separate concern, run in the main thread in parallel with the Step 4 background watch (both
+push to the same branch; each skill pull-rebases internally, so no manual serialisation). Whenever
+checks are red, run:
 
 ```
 /ci-auto-fix
@@ -287,12 +280,13 @@ internally, so no manual serialisation). Whenever checks are red, run:
 This uses the `ci-auto-fix` skill (wired in during Prerequisites), diagnoses any failing GitHub
 Actions checks, applies a minimal targeted fix, and iterates until all checks are green. The skill
 is confidence-gated (>=90 auto-apply, 80-89 ask, <80 escalate) and will never disable or weaken a
-check. Skip only when CI is already fully green. Note a `/ci-auto-fix` push is itself a new commit, so
-it triggers another bot review that the Step 4 watch loop then absorbs — the two loops converge.
+check. Skip only when CI is already fully green. A `/ci-auto-fix` push is itself a new commit, so it
+re-triggers the external bot review that Step 4 then absorbs — the loops converge.
 
-**Definition of ready-to-review:** no open actionable findings **and** every CI check green. That is
-the *content* state this flow drives to; per the watch-mode contract the agent does **not** flip the
-draft flag — undrafting (or opening non-draft in the first place) stays a human/explicit decision.
+**Definition of ready-to-review:** `review-loop` converged (PASS, no blockers) **and** external-bot
+feedback absorbed **and** every CI check green. That is the *content* state this flow drives to; per
+both skills' hard rule the agent does **not** flip the draft flag — undrafting stays a human/explicit
+decision.
 
 ### Summary table
 
@@ -301,10 +295,10 @@ draft flag — undrafting (or opening non-draft in the first place) stays a huma
 | 0 | Clone agent-skills + run sync-symlinks.sh (once per sandbox) | Agent |
 | 0.5 | Update user-facing docs + regenerate `llms.txt` (or state why none applied) | Agent |
 | 1 | Run `/polish` — review + simplify, auto-fix all findings, commit each pass | Agent |
-| 2 | Open / push the PR (draft or ready) | Agent |
-| 3 | Bot reviews automatically — and RE-reviews on every commit | Automatic (Dash0 bot) |
-| 4 | Right after Step 2, dispatch `/implement-suggestion --watch` as a **background** sub-agent — one commit per comment, **5 iterations max**, never undrafts | Agent (background) |
-| 5 | In parallel, run `/ci-auto-fix` until green. Ready-to-review = no open findings AND green CI (agent does not undraft) | Agent |
+| 2 | Open the PR **as a draft** (so `pr-reviewer` can post inline comments) | Agent |
+| 3 | `Skill("review-loop", "<pr>")` — local `pr-reviewer`→`implement-suggestion`→`polish simplify`, one commit per comment, ≤**3** iters, early-exit on PASS, never undrafts | Agent |
+| 4 | `/implement-suggestion --watch` as a **background** sub-agent — absorb EXTERNAL-bot (`dash0-dev`/CodeRabbit/human) feedback, one commit per comment, ≤**5** iters, never undrafts | Agent (background) |
+| 5 | In parallel, `/ci-auto-fix` until green. Ready-to-review = review-loop converged AND external feedback absorbed AND green CI (agent does not undraft) | Agent |
 
 ## Scope format (canonical — `::` separator only)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,60 +218,54 @@ are surfaced for awareness but do not block the workflow — they require a huma
 
 Skip this step only if the branch diff is non-code only (docs, lockfiles, generated artefacts).
 
-### Step 2 — Open the PR (as a draft)
+### Step 2 — Open the PR with `/create-pr --no-review` (as a draft)
 
-Open the PR **as a draft** (`gh pr create --draft`). The draft state is what lets `pr-reviewer`
-(Step 3) and the `dash0-dev` bot (Step 4) post inline comments while the branch converges — undrafting
-is the last, human step, after the flow below reaches ready-to-review. The `dash0-dev` bot picks up the
-event automatically and starts its review — **you do not trigger it manually**.
+Open the PR with `/create-pr` (it opens as a **draft** — the draft state is what lets the `dash0-dev`
+bot post inline comments while the branch converges).
 
-### Step 3 — Converge the PR locally with `/review-loop`
+**Always pass `--no-review`.** This repo has the `dash0-dev` bot, which runs the `pr-reviewer` agent on
+the PR automatically (Step 3), so `/create-pr`'s built-in `review-loop` would run a **second**
+`pr-reviewer` on the same PR — a duplicate review by the same agent, for no gain. `--no-review` drops
+that local reviewer pass while **keeping** `create-pr`'s `polish simplify` and, crucially, its
+external-bot feedback loop (which is Step 4). Do **not** pass `--no-feedback` (that skips Step 4) or
+`--no-quality`. Undrafting is the last, human step, after the flow reaches ready-to-review.
 
-After the draft PR is open, run the bounded review-apply-simplify convergence loop — the same
-orchestrator `/create-pr` (post-draft) and `autonomous-workflow` Phase 6/7 use:
+> **The one review agent on the PR is the `dash0-dev` bot — never run a second `pr-reviewer` locally.**
+> `/polish` (Step 1) runs the reviewer BEFORE the PR exists (a local pre-flight, no GitHub write), so
+> it does not double-post; `review-loop` runs it ON the open PR, which does, so it is excluded here.
 
-```
-Skill("review-loop", "<pr-url>")
-```
+### Step 3 — The `dash0-dev` bot reviews (the ONE review agent on the PR)
 
-`review-loop` owns no rules of its own; each iteration it sequences `pr-reviewer` (find — read-only,
-posts one `COMMENT` review) → `implement-suggestion` (apply — **single-shot, NOT `--watch`**) →
-`Skill("polish", "simplify")` (Class-M mechanical refactors), then pushes. It **drives its own
-re-review**, so it never waits on an external bot. `implement-suggestion` makes **one commit per
-comment**, each gated by `/critical` then `/confidence` — that is the per-comment behaviour. The loop
-**early-exits** the instant `pr-reviewer` returns PASS with no blocking findings, and is **bounded to 3
-iterations** (`--cap N` to change; `--critical` for an adversarial pre-mortem each round). It **never
-undrafts** the PR. If it reaches the cap still failing, it surfaces the remaining blockers — fix them
-or reply why not.
+The `dash0-dev` bot runs `pr-reviewer` server-side and posts a `COMMENT` review automatically — **and
+re-reviews on every new commit** (a `synchronize` push), marking addressed findings "Superseded /
+Resolving." You do NOT trigger it manually, and you do NOT run a second reviewer against the PR. Two
+facts to remember: a verdict is pinned to a `commit_id`, so a gate summary can be **stale on an older
+SHA** while already resolved on `HEAD` — check which commit a comment targets before treating it as
+open; and a push mid-review can anchor the next comments to your new SHA while still describing
+*pre-fix* content, so re-verify against `HEAD` (`git show HEAD:<file>`) rather than trusting a
+just-arrived comment.
 
-### Step 4 — Absorb EXTERNAL-bot feedback with `/implement-suggestion --watch`
+### Step 4 — Absorb the bot's feedback with `/implement-suggestion --watch`
 
-Separately from the local loop, the `dash0-dev` bot reviews **automatically on every commit** (a
-`synchronize` push) — it runs the same `pr-reviewer` agent server-side and posts a `COMMENT` review
-(marking addressed findings "Superseded / Resolving"); CodeRabbit and human reviewers may comment too.
-After `review-loop` has converged, dispatch a **background** sub-agent (`run_in_background: true`,
-subagent_type: general) to absorb that external feedback without blocking the CI work in Step 5 — the
-same thing `/create-pr` does after its review-loop:
+`/create-pr` dispatches this automatically after opening the PR (its external-bot feedback step) as a
+**background** sub-agent — so if you opened the PR with `/create-pr` (Step 2) it is already running. If
+you pushed a follow-up commit by hand, or need to drive it yourself, dispatch a background sub-agent
+(`run_in_background: true`, subagent_type: general):
 
 > Invoke: Skill('implement-suggestion', '<pr-url> --watch')
-> Absorb EXTERNAL review feedback to completion — only comments from external parties, NOT the
-> review-loop's own. It never opens a new PR and never undrafts this one. Return its watch report.
+> Absorb the `dash0-dev` (and any CodeRabbit / human) review feedback to completion. It never opens a
+> new PR and never undrafts this one. Return its per-iteration watch report.
 
-`--watch` waits for each external review, applies the actionable comments (one commit per comment,
-`/critical`+`/confidence` gated), pushes, and repeats — **scoped to comments posted after
-`review-loop`'s last push**, so it never re-applies the loop's own findings. It is **bounded to 5
-iterations** (`--max-iters` default; hard cap 10) and **never undrafts**. Two facts about the external
-bot: a verdict is pinned to a `commit_id`, so a gate summary can be **stale on an older SHA** while
-already resolved on `HEAD` — check which commit a comment targets before treating it as open; and a
-push mid-review can anchor the next comments to your new SHA while still describing *pre-fix* content,
-so re-verify against `HEAD` (`git show HEAD:<file>`). Do **not** post `@dash0 resolve` — agent-posted
+`--watch` waits for each `dash0-dev` review, applies the actionable comments (**one commit per
+comment**, each gated by `/critical` then `/confidence`), pushes, and repeats — **bounded to 5
+iterations** (`--max-iters` default; hard cap 10), processing only comments newer than the last round
+so it never re-applies one. It **never undrafts**. Do **not** post `@dash0 resolve` — agent-posted
 comments don't trigger the webhook; the skill resolves threads via the API directly.
 
-### Step 5 — Drive CI green (in parallel); ready-to-review = clean + green
+### Step 5 — Drive CI green; ready-to-review = bot PASS + green CI
 
-CI is a separate concern, run in the main thread in parallel with the Step 4 background watch (both
-push to the same branch; each skill pull-rebases internally, so no manual serialisation). Whenever
-checks are red, run:
+`/create-pr` watches CI and delegates mechanical failures to `/ci-auto-fix` for you. For any red check
+on a hand-pushed commit, run it yourself:
 
 ```
 /ci-auto-fix
@@ -281,12 +275,11 @@ This uses the `ci-auto-fix` skill (wired in during Prerequisites), diagnoses any
 Actions checks, applies a minimal targeted fix, and iterates until all checks are green. The skill
 is confidence-gated (>=90 auto-apply, 80-89 ask, <80 escalate) and will never disable or weaken a
 check. Skip only when CI is already fully green. A `/ci-auto-fix` push is itself a new commit, so it
-re-triggers the external bot review that Step 4 then absorbs — the loops converge.
+re-triggers the `dash0-dev` review that Step 4 then absorbs — the loops converge.
 
-**Definition of ready-to-review:** `review-loop` converged (PASS, no blockers) **and** external-bot
-feedback absorbed **and** every CI check green. That is the *content* state this flow drives to; per
-both skills' hard rule the agent does **not** flip the draft flag — undrafting stays a human/explicit
-decision.
+**Definition of ready-to-review:** the `dash0-dev` review is PASS with no open actionable findings
+**and** every CI check is green. That is the *content* state this flow drives to; the agent does
+**not** flip the draft flag — undrafting stays a human/explicit decision.
 
 ### Summary table
 
@@ -295,10 +288,10 @@ decision.
 | 0 | Clone agent-skills + run sync-symlinks.sh (once per sandbox) | Agent |
 | 0.5 | Update user-facing docs + regenerate `llms.txt` (or state why none applied) | Agent |
 | 1 | Run `/polish` — review + simplify, auto-fix all findings, commit each pass | Agent |
-| 2 | Open the PR **as a draft** (so `pr-reviewer` can post inline comments) | Agent |
-| 3 | `Skill("review-loop", "<pr>")` — local `pr-reviewer`→`implement-suggestion`→`polish simplify`, one commit per comment, ≤**3** iters, early-exit on PASS, never undrafts | Agent |
-| 4 | `/implement-suggestion --watch` as a **background** sub-agent — absorb EXTERNAL-bot (`dash0-dev`/CodeRabbit/human) feedback, one commit per comment, ≤**5** iters, never undrafts | Agent (background) |
-| 5 | In parallel, `/ci-auto-fix` until green. Ready-to-review = review-loop converged AND external feedback absorbed AND green CI (agent does not undraft) | Agent |
+| 2 | `/create-pr --no-review` — open draft PR; NO duplicate local reviewer (keeps `polish simplify` + the feedback loop) | Agent |
+| 3 | `dash0-dev` bot reviews automatically — the ONE review agent, re-reviews on every commit | Automatic (bot) |
+| 4 | `/implement-suggestion --watch` (background) — absorb the `dash0-dev`/CodeRabbit/human feedback, one commit per comment, ≤**5** iters, never undrafts | Agent (background) |
+| 5 | `/ci-auto-fix` until green. Ready-to-review = `dash0-dev` PASS AND green CI (agent does not undraft) | Agent |
 
 ## Scope format (canonical — `::` separator only)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,7 +476,7 @@ All `lorekit.*` spans carry:
 - `lorekit.scope.type` — bounded: `global|project|repo|branch`
 - `lorekit.key` — lesson key
 - `service.namespace` — always `lorekit`
-- `deployment.environment.name` — `production|preview|development|local` (from `VERCEL_ENV`)
+- `deployment.environment.name` — `production|preview|development|local` (from `VERCEL_ENV`), plus the synthetic `test` stamped on smoke/CI runs (the pipelines set `DEPLOYMENT_ENVIRONMENT=test`; the edge also honours it per-request via the `X-LoreKit-Deployment-Environment` header, allowlisted to `test`) — see [docs/otel.md](./docs/otel.md) → "Smoke / test runs are tagged"
 
 Metric: `lorekit.tool.duration` histogram (unit `s`) with `lorekit.tool.name` + `lorekit.scope.type`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,26 +249,34 @@ while [ "$(gh pr view <pr-number> --repo mthines/lorekit --json reviews \
 done
 ```
 
-### Step 4 — Implement review suggestions
+### Step 4 — Implement review suggestions on a WATCH LOOP (max 5 iterations)
 
-Once the Dash0 bot review is posted, dispatch a sub-agent (subagent_type: general):
+The `dash0-dev` bot re-reviews on **every** new commit (Step 3), so addressing findings is a LOOP, not
+a one-shot: each push of fixes triggers a fresh review that may surface new findings. **Start the watch
+immediately after the PR is created** (Step 2) — do not wait for the first review by hand; the watch
+handles the first review and every subsequent one. Dispatch a sub-agent (subagent_type: general):
 
-> Read /tmp/workspace/agent-skills/skills/workflow/implement-suggestion/SKILL.md and follow it exactly.
+> Read /tmp/workspace/agent-skills/skills/workflow/implement-suggestion/SKILL.md and follow it exactly,
+> in `--watch` mode.
 > TARGET_PR=<full PR URL>, OWNER=<owner>, REPO=<repo>, NUMBER=<pr number>
 
-The skill fetches all open review comments from human and AI reviewers, validates each through
-`/critical` then `/confidence`, applies approved changes as individual commits, pushes to
-the existing branch, and resolves addressed threads. Do NOT open a new PR. Do NOT skip the two-gate
-validation. Wait for the sub-agent to finish before proceeding to Step 5.
+`/implement-suggestion --watch` waits for each `dash0-dev` review, fetches all open review comments
+(human + AI), validates each through `/critical` then `/confidence`, applies approved changes as
+individual commits, pushes to the existing branch, and resolves addressed threads — then waits for the
+NEXT review that push triggers and repeats. Do NOT open a new PR. Do NOT skip the two-gate validation.
+
+**Bound the loop to 5 iterations maximum.** Stop early when a review round produces no actionable
+findings (all gates clean), or when the only comments left are ones you've validated as won't-fix
+(reply on the thread with the reason instead of looping). If findings still remain after 5 iterations,
+STOP and summarise what's outstanding for a human — never loop indefinitely.
 
 **Note:** Do NOT post `@dash0 resolve` as a PR comment — agent-posted comments do not trigger
 the webhook. Run the skill directly as described above.
 
-If the review report contained no actionable suggestions (all gates passed clean), skip this step.
+### Step 5 — Drive CI green, leave the PR ready-to-review
 
-### Step 5 — Fix CI with `/ci-auto-fix`
-
-After the implement-suggestion sub-agent finishes (or if there were no suggestions to implement), run:
+The PR is DONE only when the review loop has settled **and** every CI check is green. Whenever checks
+go red during or after the watch loop (a pushed fix can itself break CI), run:
 
 ```
 /ci-auto-fix
@@ -277,7 +285,10 @@ After the implement-suggestion sub-agent finishes (or if there were no suggestio
 This uses the `ci-auto-fix` skill (wired in during Prerequisites), diagnoses any failing GitHub
 Actions checks, applies a minimal targeted fix, and iterates until all checks are green. The skill
 is confidence-gated (>=90 auto-apply, 80-89 ask, <80 escalate) and will never disable or weaken a
-check. Skip if CI is already fully green.
+check. A `/ci-auto-fix` push re-triggers the bot review, so it folds back into the Step 4 loop — keep
+both settling together, within the same 5-iteration budget, until the end state holds: **no open
+actionable findings AND green CI**, i.e. the PR is genuinely ready for human review. Skip only when CI
+is already fully green.
 
 ### Summary table
 
@@ -287,9 +298,9 @@ check. Skip if CI is already fully green.
 | 0.5 | Update user-facing docs + regenerate `llms.txt` (or state why none applied) | Agent |
 | 1 | Run `/polish` — review + simplify, auto-fix all findings, commit each pass | Agent |
 | 2 | Open / push the PR (draft or ready) | Agent |
-| 3 | Wait for `dash0-dev` bot review comment | Automatic (Dash0 bot) |
-| 4 | Run implement-suggestion skill (or skip if review is clean) | Agent |
-| 5 | Run `/ci-auto-fix` until all checks pass (or skip if green) | Agent |
+| 3 | Bot reviews automatically — and RE-reviews on every commit | Automatic (Dash0 bot) |
+| 4 | Start `/implement-suggestion --watch` right after Step 2; fix findings each review round, **5 iterations max** | Agent |
+| 5 | Run `/ci-auto-fix` until green; end state = no open findings AND green CI (ready to review) | Agent |
 
 ## Scope format (canonical — `::` separator only)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,31 +252,33 @@ done
 ### Step 4 — Implement review suggestions on a WATCH LOOP (max 5 iterations)
 
 The `dash0-dev` bot re-reviews on **every** new commit (Step 3), so addressing findings is a LOOP, not
-a one-shot: each push of fixes triggers a fresh review that may surface new findings. **Start the watch
-immediately after the PR is created** (Step 2) — do not wait for the first review by hand; the watch
-handles the first review and every subsequent one. Dispatch a sub-agent (subagent_type: general):
+a one-shot: each push of fixes triggers a fresh review that may surface new findings. **Immediately
+after the PR is created** (Step 2), dispatch `/implement-suggestion --watch` as a **background
+sub-agent** (`run_in_background: true`, subagent_type: general) — the same way `/create-pr` Step 6.5
+does — and continue to Step 5 in the main thread in parallel; do NOT block on it:
 
-> Read /tmp/workspace/agent-skills/skills/workflow/implement-suggestion/SKILL.md and follow it exactly,
-> in `--watch` mode.
-> TARGET_PR=<full PR URL>, OWNER=<owner>, REPO=<repo>, NUMBER=<pr number>
+> Invoke: Skill('implement-suggestion', '<pr-url> --watch')
+> Drive the reviewer-feedback loop for PR <pr-url> to completion. It never opens a new PR and never
+> undrafts this one. Return its final per-iteration watch report verbatim.
 
 `/implement-suggestion --watch` waits for each `dash0-dev` review, fetches all open review comments
-(human + AI), validates each through `/critical` then `/confidence`, applies approved changes as
-individual commits, pushes to the existing branch, and resolves addressed threads — then waits for the
-NEXT review that push triggers and repeats. Do NOT open a new PR. Do NOT skip the two-gate validation.
+(human + AI), validates **each comment** through `/critical` then `/confidence`, applies each approved
+change as its **own commit** (one commit per comment), pushes, and resolves the addressed threads —
+then waits for the NEXT review that push triggers and repeats. It only ever processes comments newer
+than the last round, so it never re-applies the same one.
 
-**Bound the loop to 5 iterations maximum.** Stop early when a review round produces no actionable
-findings (all gates clean), or when the only comments left are ones you've validated as won't-fix
-(reply on the thread with the reason instead of looping). If findings still remain after 5 iterations,
-STOP and summarise what's outstanding for a human — never loop indefinitely.
+**The loop is bounded to 5 iterations** (the skill's `--max-iters` default; hard cap 10). It stops
+early when a round is clean or reviewers go quiet, and stops at the cap otherwise — so it can never run
+away. Two hard rules to know: it **never undrafts** the PR (readiness is a human decision — see Step 5),
+and it **never** posts `@dash0 resolve` (agent-posted comments don't trigger the webhook; the skill
+resolves threads via the API directly). If findings still remain when the cap is hit, the watch report
+lists them as *surfaced* for a human.
 
-**Note:** Do NOT post `@dash0 resolve` as a PR comment — agent-posted comments do not trigger
-the webhook. Run the skill directly as described above.
+### Step 5 — Drive CI green (in parallel), reach a ready-to-review state
 
-### Step 5 — Drive CI green, leave the PR ready-to-review
-
-The PR is DONE only when the review loop has settled **and** every CI check is green. Whenever checks
-go red during or after the watch loop (a pushed fix can itself break CI), run:
+CI is a **separate, parallel** concern from the review loop — run it in the main thread while the Step 4
+watch sub-agent runs in the background (both push to the same branch; each skill pull-rebases
+internally, so no manual serialisation). Whenever checks are red, run:
 
 ```
 /ci-auto-fix
@@ -285,10 +287,12 @@ go red during or after the watch loop (a pushed fix can itself break CI), run:
 This uses the `ci-auto-fix` skill (wired in during Prerequisites), diagnoses any failing GitHub
 Actions checks, applies a minimal targeted fix, and iterates until all checks are green. The skill
 is confidence-gated (>=90 auto-apply, 80-89 ask, <80 escalate) and will never disable or weaken a
-check. A `/ci-auto-fix` push re-triggers the bot review, so it folds back into the Step 4 loop — keep
-both settling together, within the same 5-iteration budget, until the end state holds: **no open
-actionable findings AND green CI**, i.e. the PR is genuinely ready for human review. Skip only when CI
-is already fully green.
+check. Skip only when CI is already fully green. Note a `/ci-auto-fix` push is itself a new commit, so
+it triggers another bot review that the Step 4 watch loop then absorbs — the two loops converge.
+
+**Definition of ready-to-review:** no open actionable findings **and** every CI check green. That is
+the *content* state this flow drives to; per the watch-mode contract the agent does **not** flip the
+draft flag — undrafting (or opening non-draft in the first place) stays a human/explicit decision.
 
 ### Summary table
 
@@ -299,8 +303,8 @@ is already fully green.
 | 1 | Run `/polish` — review + simplify, auto-fix all findings, commit each pass | Agent |
 | 2 | Open / push the PR (draft or ready) | Agent |
 | 3 | Bot reviews automatically — and RE-reviews on every commit | Automatic (Dash0 bot) |
-| 4 | Start `/implement-suggestion --watch` right after Step 2; fix findings each review round, **5 iterations max** | Agent |
-| 5 | Run `/ci-auto-fix` until green; end state = no open findings AND green CI (ready to review) | Agent |
+| 4 | Right after Step 2, dispatch `/implement-suggestion --watch` as a **background** sub-agent — one commit per comment, **5 iterations max**, never undrafts | Agent (background) |
+| 5 | In parallel, run `/ci-auto-fix` until green. Ready-to-review = no open findings AND green CI (agent does not undraft) | Agent |
 
 ## Scope format (canonical — `::` separator only)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -122,6 +122,7 @@ pnpm nx test mcp-core                            # needs supabase start
 | `VERCEL_TOKEN` | Vercel access token (Account Settings → Tokens) — lets `deploy.yml` build + promote the web dashboard |
 | `VERCEL_ORG_ID` | From `.vercel/project.json` after `vercel link` (or Vercel project settings) |
 | `VERCEL_PROJECT_ID` | From `.vercel/project.json` after `vercel link` |
+| `LOREKIT_TELEMETRY_TOKEN` | Dash0 ingest-only token — the smoke/CI jobs pass it so their edge telemetry exports (tagged `deployment.environment.name=test`); also injected into the CLI tarball at publish by `release.yml`. Fork PRs without it skip telemetry gracefully. |
 
 Optional repo **variables** (Settings → Secrets and variables → Actions →
 Variables):

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,4 +239,4 @@ See [otel.md](./otel.md) for the full setup. Every layer emits telemetry to Dash
 | Next.js server | HTTP server spans via `@vercel/otel` |
 | Browser (RUM) | Page loads, navigation, fetch traces, errors via `@dash0/sdk-web` |
 
-All signals carry `service.namespace=lorekit` and `deployment.environment.name` (`production` / `preview` / `local`).
+All signals carry `service.namespace=lorekit` and `deployment.environment.name` (`production` / `preview` / `development` / `local`, plus the synthetic `test` stamped on smoke/CI runs).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -403,9 +403,13 @@ only the CI log. Each smoke job (`deploy.yml` smoke-preview/smoke-production,
 - `LOREKIT_CORRELATION_ID` — a per-run key on every REST call's
   `usage_events.correlation_id`, so one run's calls are greppable.
 
-`ci.yml`'s integration job runs against a throwaway **local** Supabase with no
-OTLP endpoint, so nothing exports there — the vars only keep the tagging uniform
-and exercise the code path; real export happens in the preview/production jobs.
+`ci.yml`'s integration job runs against a throwaway **local** Supabase. A plain
+`supabase start` gives the edge no OTLP endpoint, so it would be dark — the
+"Configure local edge OTLP export" step therefore writes `supabase/functions/.env`
+(the file the CLI loads into the local edge runtime) with the Dash0 ingress
+endpoint + ingest token, so the local `api` spans **do** export, tagged `test`.
+Fork PRs have no secret, so that step self-skips and the edge stays dark — a
+graceful no-export, never a broken start.
 
 ### Smoke-test data hygiene
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -573,7 +573,10 @@ below.
 Repo-level secrets (not environment-scoped): `SUPABASE_ACCESS_TOKEN` (a Supabase
 personal access token); the three **Vercel** secrets the web jobs use —
 `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` (the same set `preview.yml`
-already relies on); and — optionally — `DISCORD_WEBHOOK_URL` for
+already relies on); `LOREKIT_TELEMETRY_TOKEN` (the Dash0 ingest-only token — the
+smoke jobs pass it so their telemetry exports; see [Smoke telemetry](#smoke-telemetry-observable-in-dash0-tagged-test),
+and it is also injected into the CLI tarball at publish by `release.yml`); and —
+optionally — `DISCORD_WEBHOOK_URL` for
 [failure notifications](#failure-notifications-discord). Add a **required
 reviewer** on the `production` environment for a manual approval gate before prod
 is touched — it now gates the web promote (`promote-web-production`) as well as

--- a/packages/mcp-core/src/otel-conventions.spec.ts
+++ b/packages/mcp-core/src/otel-conventions.spec.ts
@@ -254,8 +254,13 @@ describe('smoke test-run marker — the deployment-environment charset/bound sta
 
   it.each(sites)('%s uses the shared charset and a 64-char bound', (_label, rel) => {
     const src = read(rel);
-    expect(src, `${rel} must use the shared charset ${CHARSET}`).toContain(CHARSET);
-    expect(src, `${rel} must bound the value at 64 chars`).toMatch(/(?:<=|>)\s*64/);
+    // Match the executable regex literal and the `.length` bound, not a bare
+    // charset mention a comment could satisfy — sibling smoke-cleanup.spec.ts
+    // pins the executable line for exactly this reason.
+    expect(src, `${rel} must test with the shared charset regex /^${CHARSET}+$/`).toMatch(
+      /\/\^\[A-Za-z0-9_\.\\-:\]\+\$\//,
+    );
+    expect(src, `${rel} must bound the value length at 64 chars`).toMatch(/\.length\s*(?:<=|>)\s*64/);
   });
 
   it('the edge honours exactly the synthetic value `test`, which the charset admits', () => {

--- a/packages/mcp-core/src/otel-conventions.spec.ts
+++ b/packages/mcp-core/src/otel-conventions.spec.ts
@@ -238,3 +238,29 @@ describe('lorekit.tool.duration histogram accessor', () => {
     ).not.toThrow();
   });
 });
+
+describe('smoke test-run marker — the deployment-environment charset/bound stay in step', () => {
+  // `X-LoreKit-Deployment-Environment` is normalised by three independent
+  // low-/zero-dep copies (the CLI cannot import mcp-core; the sweeper runs from
+  // a bare checkout), so the shared charset + bound is otherwise only
+  // prose-coupled ("keep them in step"). Pin it the way edge-bare-specifier.spec
+  // pins its own invariant, so a drift in one copy fails the build.
+  const CHARSET = '[A-Za-z0-9_.\\-:]';
+  const sites: Array<[string, string]> = [
+    ['CLI restFetch (normalizeRunEnvironment)', 'packages/cli/src/mcp.mjs'],
+    ['REST/MCP smoke specs (testRunHeaders)', 'packages/mcp-server/src/smoke-telemetry.ts'],
+    ['orphan sweeper (runEnvHeaders)', 'scripts/smoke-cleanup.mjs'],
+  ];
+
+  it.each(sites)('%s uses the shared charset and a 64-char bound', (_label, rel) => {
+    const src = read(rel);
+    expect(src, `${rel} must use the shared charset ${CHARSET}`).toContain(CHARSET);
+    expect(src, `${rel} must bound the value at 64 chars`).toMatch(/(?:<=|>)\s*64/);
+  });
+
+  it('the edge honours exactly the synthetic value `test`, which the charset admits', () => {
+    const otel = read('supabase/functions/_shared/otel.ts');
+    expect(otel).toMatch(/HEADER_ENV_ALLOWLIST\s*=\s*new Set\(\['test'\]\)/);
+    expect('test').toMatch(new RegExp(`^${CHARSET}+$`));
+  });
+});

--- a/packages/mcp-core/src/otel-conventions.spec.ts
+++ b/packages/mcp-core/src/otel-conventions.spec.ts
@@ -266,6 +266,5 @@ describe('smoke test-run marker — the deployment-environment charset/bound sta
   it('the edge honours exactly the synthetic value `test`, which the charset admits', () => {
     const otel = read('supabase/functions/_shared/otel.ts');
     expect(otel).toMatch(/HEADER_ENV_ALLOWLIST\s*=\s*new Set\(\['test'\]\)/);
-    expect('test').toMatch(new RegExp(`^${CHARSET}+$`));
   });
 });

--- a/packages/mcp-server/src/smoke-cleanup.spec.ts
+++ b/packages/mcp-server/src/smoke-cleanup.spec.ts
@@ -261,6 +261,15 @@ describe('mirror parity with scripts/smoke-cleanup.mjs', () => {
     expect(m?.[1]).toBe(SMOKE_ARTEFACT_PATTERN.toString());
   });
 
+  it('forwards the run-environment header from req(), not just declaring it', () => {
+    // The executable spread inside req() and the charset regex `.test()`, not a
+    // charset mention a comment could satisfy — declaring runEnvHeaders() but
+    // never spreading it would leave every sweep request untagged.
+    expect(sweeperSource).toContain('...runEnvHeaders(),');
+    expect(sweeperSource).toMatch(/function runEnvHeaders\(\)/);
+    expect(sweeperSource).toMatch(/\/\^\[A-Za-z0-9_\.\\-:\]\+\$\/\.test\(/);
+  });
+
   /**
    * Both strings below also appear in the sweeper's PROSE, so a bare
    * `toContain` stays green even if the real call loses them — the guard would

--- a/scripts/smoke-cleanup.mjs
+++ b/scripts/smoke-cleanup.mjs
@@ -194,6 +194,18 @@ function isServiceRoleKey(token) {
 
 // ── HTTP helpers ──────────────────────────────────────────────────────────────
 
+// Tag the sweeper's edge requests as a test run, so its /memories spans report
+// deployment.environment.name=test like the rest of the smoke suite (see
+// docs/otel.md → "Smoke / test runs are tagged"). Read from the env the smoke
+// jobs set; the edge honours only the synthetic `test`. Zero-dep + fail-safe:
+// unset/invalid ⇒ header omitted. Bounds mirror the CLI's normalizeRunEnvironment.
+function runEnvHeaders() {
+  const v = String(process.env.DEPLOYMENT_ENVIRONMENT ?? '').trim();
+  return v && v.length <= 64 && /^[A-Za-z0-9_.\-:]+$/.test(v)
+    ? { 'X-LoreKit-Deployment-Environment': v }
+    : {};
+}
+
 async function req(url, { method = 'GET', token, apikey, body, headers = {} } = {}) {
   const res = await fetch(url, {
     method,
@@ -202,6 +214,7 @@ async function req(url, { method = 'GET', token, apikey, body, headers = {} } = 
       ...(apikey ? { apikey } : {}),
       ...(body !== undefined ? { 'Content-Type': 'application/json' } : {}),
       Accept: 'application/json',
+      ...runEnvHeaders(),
       ...headers,
     },
     ...(body !== undefined ? { body: JSON.stringify(body) } : {}),


### PR DESCRIPTION
Follow-up to #386 (merged). Two things #386 didn't carry:

## 1. Actually export telemetry from `ci.yml`'s integration job
#386 tagged the ci.yml integration smoke with `deployment.environment.name=test`, but that job runs against a **local** Supabase which a plain `supabase start` gives no OTLP endpoint — so its edge spans were still dark.

This adds a **"Configure local edge OTLP export"** step (before `supabase start`) that writes `supabase/functions/.env` — the file the CLI loads into the local edge runtime — with the Dash0 ingress endpoint + the ingest-only token, so the local `api` spans **do** export, tagged `test`. Fork PRs have no secret → the step self-skips → the edge stays dark (graceful, never a broken start). `.env` is gitignored and only written on the runner.

> ⚠️ One assumption I couldn't verify locally: that this pinned Supabase CLI loads `supabase/functions/.env` into the edge runtime under `supabase start` (it's the documented local-secrets file). This PR's own `integration` job exercises it — if the spans don't appear in Dash0, it's a one-line path fix.

## 2. Address the `dash0-dev` review on #386 (all non-blocking)
- **Sweeper not tagged** → `scripts/smoke-cleanup.mjs`'s `req()` now forwards `X-LoreKit-Deployment-Environment`, so the orphan sweeper's `/memories` edge spans report `env=test` too — closing the "not quite every REST request a smoke makes" gap.
- **Doc drift** → `CLAUDE.md`'s `deployment.environment.name` enumeration now includes the synthetic `test` value (was `production|preview|development|local` only).
- **Missing secret in fork setup docs** → `LOREKIT_TELEMETRY_TOKEN` added to the repo-level secrets list in `docs/deployment.md`.
- **Prose-only invariant** → a drift guard in `otel-conventions.spec.ts` now pins the shared charset + 64-char bound across the three low-/zero-dep copies (CLI `normalizeRunEnvironment`, `testRunHeaders`, sweeper `runEnvHeaders`) and the edge's `test` allowlist — replacing "keep them in step".

## Testing
- `otel-conventions.spec.ts` — 40 pass (incl. the new drift guard).
- `smoke-cleanup.spec.ts` — 45 pass (mirror-parity guard still green after the `req()` change).
- CLI unit tests (`normalizeRunEnvironment`, correlation, source-hygiene) pass.
- Workflow YAML validated. The integration job runs here (editing `ci.yml` flips the api change-filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VSXpQ15Uqpuw1StRT3ybpt)_