### PR TITLE
docs(readme): offer global CLI install alongside npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ npx @lorekit/cli doctor
 # → connectivity, token permission, and detected scopes, all green
 ```
 
+**Run the CLI often?** Read commands like `list`, `search`, and `tree` are
+nicer without the `npx` prefix. Install the binary globally once:
+
+```bash
+npm install -g @lorekit/cli
+```
+
+Then drop `npx @lorekit/cli` and call `lorekit` directly:
+
+```bash
+lorekit doctor
+```
+
 ### 3. That's it
 
 Your agent now remembers. Its lessons survive every session, reach every machine


### PR DESCRIPTION
Add a note in Get started → step 2 pointing users who run the CLI often
(list/search/tree) at `npm install -g @lorekit/cli`, so they can drop the
`npx @lorekit/cli` prefix and call `lorekit` directly. Presented as two
separate copy-and-run code blocks (install, then use). The `npx` one-liner
stays the headline onboarding path.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ERAoRZUTdkHCynXG6CiLwG