### PR TITLE
fix(web): mobile skeleton layouts match mobile content shape

### DIFF
--- a/packages/web/src/app/(dashboard)/overview/loading.tsx
+++ b/packages/web/src/app/(dashboard)/overview/loading.tsx
@@ -31,9 +31,6 @@ export default function OverviewLoading() {
         </div>
       </div>
 
-      {/* Sparkline skeleton */}
-      <div className="h-36 animate-pulse rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)]" />
-
       {/* Scope health grid */}
       <div>
         <div className="mb-3 h-3 w-48 animate-pulse rounded bg-[var(--color-bg-elevated)]" />

--- a/packages/web/src/app/(dashboard)/overview/loading.tsx
+++ b/packages/web/src/app/(dashboard)/overview/loading.tsx
@@ -15,13 +15,20 @@ export default function OverviewLoading() {
       {/* Onboarding checklist skeleton */}
       <div className="h-14 animate-pulse rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)]" />
 
-      {/* Summary stats — same responsive grid + card height as the real
-          DashboardStats (`grid-cols-1 sm:grid-cols-3`, `h-40`) so the mobile
-          placeholder resolves to the same single-column shape and does not jump. */}
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-        {[0, 1, 2].map((i) => (
-          <div key={i} className="h-40 animate-pulse rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)]" />
-        ))}
+      {/* Summary stats — mirrors DashboardStatsSkeleton: a label + range-select
+          row above the grid (so the stats block doesn't shift down when the real
+          component mounts), then the same responsive grid + card height
+          (`grid-cols-1 sm:grid-cols-3`, `h-40`) as the real DashboardStats. */}
+      <div>
+        <div className="mb-3 flex items-center justify-between gap-2">
+          <div className="h-3 w-16 animate-pulse rounded bg-[var(--color-bg-elevated)]" />
+          <div className="h-6 w-28 animate-pulse rounded-md bg-[var(--color-bg-elevated)]" />
+        </div>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="h-40 animate-pulse rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)]" />
+          ))}
+        </div>
       </div>
 
       {/* Sparkline skeleton */}

--- a/packages/web/src/app/(dashboard)/overview/loading.tsx
+++ b/packages/web/src/app/(dashboard)/overview/loading.tsx
@@ -15,10 +15,12 @@ export default function OverviewLoading() {
       {/* Onboarding checklist skeleton */}
       <div className="h-14 animate-pulse rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)]" />
 
-      {/* Summary stats */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+      {/* Summary stats — same responsive grid + card height as the real
+          DashboardStats (`grid-cols-1 sm:grid-cols-3`, `h-40`) so the mobile
+          placeholder resolves to the same single-column shape and does not jump. */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
         {[0, 1, 2].map((i) => (
-          <div key={i} className="h-24 animate-pulse rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)]" />
+          <div key={i} className="h-40 animate-pulse rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)]" />
         ))}
       </div>
 

--- a/packages/web/src/components/lore/LoreExplorerSkeleton.tsx
+++ b/packages/web/src/components/lore/LoreExplorerSkeleton.tsx
@@ -54,12 +54,15 @@ export function LoreExplorerSkeleton() {
           <div className="h-5 w-40 animate-pulse rounded bg-[var(--color-bg-elevated)]" />
         </div>
 
-        {/* Control row: search input + filter / date / archived toggles */}
+        {/* Control row: search input + filter trigger + date pill + archived
+            toggle. The middle placeholder is a wider pill, not a square: the
+            real DateRangePicker renders a text pill ("All time"), so a square
+            here would let the row shift on load. */}
         <div className="flex items-center gap-2">
           <div className="h-9 flex-1 animate-pulse rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-raised)]" />
-          {[0, 1, 2].map((i) => (
-            <div key={i} className="size-9 shrink-0 animate-pulse rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)]" />
-          ))}
+          <div className="size-9 shrink-0 animate-pulse rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)]" />
+          <div className="h-9 w-20 shrink-0 animate-pulse rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)]" />
+          <div className="size-9 shrink-0 animate-pulse rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)]" />
         </div>
 
         {/* Card list */}

--- a/packages/web/src/components/lore/LoreExplorerSkeleton.tsx
+++ b/packages/web/src/components/lore/LoreExplorerSkeleton.tsx
@@ -1,37 +1,73 @@
 // Skeleton for the data-only part of the Lore Explorer.
 // Used by lore/page.tsx inline (so the title stays visible while data loads)
 // and by lore/loading.tsx (route-level fallback on first navigation).
+//
+// The shape is breakpoint-split the same way LoreExplorer itself is: the
+// desktop skeleton mirrors the `hidden md:flex` side-by-side panels (scope
+// sidebar + list), and the mobile skeleton mirrors the `flex md:hidden` stacked
+// layout (collapsed scope header + control row + card list). The split is CSS
+// only (`hidden md:flex` / `flex md:hidden`) — matching the real component — so
+// the loading placeholder always resolves to the same shape the data will, and
+// there is no layout jump when the query settles on either breakpoint.
 export function LoreExplorerSkeleton() {
   return (
-    <div
-      className="flex overflow-hidden rounded-xl border border-[var(--color-border)]"
-      style={{ height: 'calc(100vh - 11rem)' }}
-    >
-      {/* Scope tree skeleton */}
-      <div className="flex w-56 shrink-0 flex-col border-r border-[var(--color-border)] bg-[var(--color-bg-raised)] p-3 gap-1.5">
-        <div className="mb-2 h-3 w-16 animate-pulse rounded bg-[var(--color-bg-elevated)]" />
-        {[60, 75, 90, 70, 85, 65, 80, 60].map((w, i) => (
-          <div
-            key={i}
-            className="h-7 animate-pulse rounded-md bg-[var(--color-bg-elevated)]"
-            style={{ width: `${w}%` }}
-          />
-        ))}
+    <>
+      {/* Desktop: side-by-side panels (mirrors LoreExplorer's `hidden md:flex`) */}
+      <div
+        className="hidden overflow-hidden rounded-xl border border-[var(--color-border)] md:flex"
+        style={{ height: 'calc(100vh - 11rem)' }}
+      >
+        {/* Scope tree skeleton */}
+        <div className="flex w-56 shrink-0 flex-col gap-1.5 border-r border-[var(--color-border)] bg-[var(--color-bg-raised)] p-3">
+          <div className="mb-2 h-3 w-16 animate-pulse rounded bg-[var(--color-bg-elevated)]" />
+          {[60, 75, 90, 70, 85, 65, 80, 60].map((w, i) => (
+            <div
+              key={i}
+              className="h-7 animate-pulse rounded-md bg-[var(--color-bg-elevated)]"
+              style={{ width: `${w}%` }}
+            />
+          ))}
+        </div>
+
+        {/* Lesson list skeleton */}
+        <div className="flex flex-1 flex-col gap-0 overflow-hidden">
+          {/* Search bar */}
+          <div className="border-b border-[var(--color-border)] p-3">
+            <div className="h-8 animate-pulse rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)]" />
+          </div>
+          {/* Cards */}
+          <div className="flex flex-col gap-2 overflow-hidden p-3">
+            {[0, 1, 2, 3, 4].map((i) => (
+              <div key={i} className="h-24 animate-pulse rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)]" />
+            ))}
+          </div>
+        </div>
       </div>
 
-      {/* Lesson list skeleton */}
-      <div className="flex flex-1 flex-col gap-0 overflow-hidden">
-        {/* Search bar */}
-        <div className="border-b border-[var(--color-border)] p-3">
-          <div className="h-8 animate-pulse rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)]" />
+      {/* Mobile: stacked layout (mirrors LoreExplorer's `flex md:hidden`) — a
+          collapsed scope header, the control row, then the card list. `pb-6`
+          matches the real layout so the last card clears the bottom edge. */}
+      <div className="flex flex-col gap-3 pb-6 md:hidden">
+        {/* Collapsed scope accordion header */}
+        <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)] px-4 py-2.5">
+          <div className="h-5 w-40 animate-pulse rounded bg-[var(--color-bg-elevated)]" />
         </div>
-        {/* Cards */}
-        <div className="flex flex-col gap-2 overflow-hidden p-3">
+
+        {/* Control row: search input + filter / date / archived toggles */}
+        <div className="flex items-center gap-2">
+          <div className="h-9 flex-1 animate-pulse rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-raised)]" />
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="size-9 shrink-0 animate-pulse rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-elevated)]" />
+          ))}
+        </div>
+
+        {/* Card list */}
+        <div className="flex flex-col gap-2">
           {[0, 1, 2, 3, 4].map((i) => (
             <div key={i} className="h-24 animate-pulse rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)]" />
           ))}
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/packages/web/src/components/lore/LoreExplorerSkeleton.tsx
+++ b/packages/web/src/components/lore/LoreExplorerSkeleton.tsx
@@ -7,8 +7,11 @@
 // sidebar + list), and the mobile skeleton mirrors the `flex md:hidden` stacked
 // layout (collapsed scope header + control row + card list). The split is CSS
 // only (`hidden md:flex` / `flex md:hidden`) — matching the real component — so
-// the loading placeholder always resolves to the same shape the data will, and
-// there is no layout jump when the query settles on either breakpoint.
+// the loading placeholder resolves to the same shape the data will on either
+// breakpoint. Scope note: this skeletons the data-only panels only. The heatmap
+// panel and the view-mode tablist LoreExplorer renders ABOVE these are not
+// skeletoned here, so the no-jump guarantee applies to the scope/list panels,
+// not to those regions.
 export function LoreExplorerSkeleton() {
   return (
     <>

--- a/packages/web/src/components/lore/LoreExplorerSkeleton.tsx
+++ b/packages/web/src/components/lore/LoreExplorerSkeleton.tsx
@@ -48,8 +48,9 @@ export function LoreExplorerSkeleton() {
           collapsed scope header, the control row, then the card list. `pb-6`
           matches the real layout so the last card clears the bottom edge. */}
       <div className="flex flex-col gap-3 pb-6 md:hidden">
-        {/* Collapsed scope accordion header */}
-        <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)] px-4 py-2.5">
+        {/* Collapsed scope accordion header — `min-h-11` matches the real
+            collapsed scope button (44px) so there is no residual height shift. */}
+        <div className="flex min-h-11 items-center rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)] px-4 py-2.5">
           <div className="h-5 w-40 animate-pulse rounded bg-[var(--color-bg-elevated)]" />
         </div>
 


### PR DESCRIPTION
## What

The skeleton loading states rendered the **desktop** layout on mobile, causing a layout jump once data loaded.

- **`LoreExplorerSkeleton.tsx`** — hard-coded a desktop two-column `flex` (a `w-56` scope sidebar next to the list). The real `LoreExplorer` uses a breakpoint split (`hidden md:flex` desktop / `flex md:hidden` mobile stacked), so on mobile the skeleton showed a cramped desktop shape. Now breakpoint-split to match: `hidden md:flex` keeps the desktop two-panel shell unchanged; a new `flex md:hidden` branch mirrors the mobile stack (collapsed scope header → control row → card list).
- **`overview/loading.tsx`** — stat grid aligned to the real `DashboardStats` (`grid-cols-1 sm:grid-cols-3`, `h-40`) so the mobile placeholder resolves to the same single-column shape.

CSS-only via Tailwind `md:` classes — no `useIsMobile()` needed, matching the repo pattern. Other skeletons (`DashboardStatsSkeleton`, `settings/*`, `onboarding`) were already responsive and left untouched.

### Follow-up review fixes (from `dash0-dev` review)

Refinements applied after the initial commit, each closing a residual layout shift the reviewer identified:

- **Overview stats** — added a label + range-select row above the stat grid so the block no longer shifts down when the real `DashboardStats` mounts.
- **Collapsed scope header** — added `min-h-11` (the real button's 44px height) to remove a residual 4px shift.
- **Mobile date picker** — the middle control-row placeholder is now a wider `w-20` pill (matching `DateRangePicker`'s "All time" text pill) instead of a square, so the control row no longer shifts on load.
- **Docblock** — scoped the "no layout jump" claim to the data-only scope/list panels this skeleton covers (the heatmap panel and view-mode tablist rendered above are not skeletoned).
- **Phantom sparkline** — removed the `h-36` sparkline placeholder from `overview/loading.tsx`; the real page renders no standalone sparkline, so it reserved ~144px the page never fills.

## Verification

- `pnpm nx typecheck web` — clean
- `pnpm exec vitest run --config vitest.config.ts` — 767/767 pass
- `pnpm nx lint web` — 0 errors

## Docs

N/A — internal loading placeholders; no MCP tool / route / CLI / config / dashboard-surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqsavZQng3q2sgbEhw4wZv)_