### PR TITLE
fix(cli): review follow-ups for install --mcp-json (#399)

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -178,7 +178,9 @@ Commit the generated `.mcp.json` and set `LOREKIT_TOKEN` as an environment
 secret in the web UI. Note that `.mcp.json` is usually git-ignored (the default
 install embeds a token) — un-ignore it before committing, and keep using
 `--mcp-json` in that repo so a later plain install never writes a token into the
-now-tracked file. The command warns when the file it wrote is still git-ignored.
+now-tracked file. The command warns when the file it wrote is still git-ignored,
+and again when a plain install is about to replace that committable entry with an
+embedded token.
 See the [Claude Code on the web guide](https://lorekit.io/docs/claude-code-web).
 
 For any other MCP-compatible agent, add the endpoint and Bearer token to the agent's MCP config directly:

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -103,7 +103,8 @@ from `.gitignore`, negate it with `!.mcp.json`, or `git add -f .mcp.json` once);
 `install --mcp-json` **warns when the file it wrote is still git-ignored**, so a
 fresh web clone silently missing the config is not a mystery. Once `.mcp.json` is
 tracked, only run `install --mcp-json` in that repo — a plain `install --project`
-would embed a live token in the now-committed file. See the
+would embed a live token in the now-committed file (and the command warns before
+it does). See the
 [Claude Code on the web guide](https://lorekit.io/docs/claude-code-web).
 
 In a TTY it prompts for the scope (and for `--endpoint` / `--token` if missing).

--- a/packages/cli/src/config.mjs
+++ b/packages/cli/src/config.mjs
@@ -591,7 +591,12 @@ export function tokenKind(token) {
 // avoid a circular import with mcp.mjs.
 //
 // A source that STORES a token wins outright (project beats global — closest
-// scope), but a TOKENLESS source must NOT shadow a later source that has one.
+// scope), and it brings its OWN endpoint: a token authenticates one endpoint,
+// so the two must travel together. A TOKENLESS source therefore never shadows a
+// later source that has a token — not its token AND not its endpoint; its
+// endpoint is only remembered as a fallback, used solely when NO source stores a
+// token. (So "closest-scope-first" governs which token wins; the endpoint simply
+// follows that token.)
 // That shadowing is exactly what `install --global --mcp-json` created: it
 // writes a committable, token-free project .mcp.json (auth via ${LOREKIT_TOKEN})
 // AND the real token into ~/.claude.json. Returning early on the project entry

--- a/packages/cli/src/install.mjs
+++ b/packages/cli/src/install.mjs
@@ -23,6 +23,8 @@ import {
   homeDir,
   mcpConfigPath,
   readJsonIfExists,
+  readLorekitServer,
+  isWebMcpServerEntry,
 } from './config.mjs';
 import { buildRemoteUrl, splitEndpoint } from './mcp.mjs';
 import { deriveScope } from './scope.mjs';
@@ -364,6 +366,21 @@ export async function install(args) {
   let file = null;
   let existed = false;
   if (!scopeWriteOwnedByWeb) {
+    // A plain project install embeds the token in .mcp.json. If that file
+    // currently holds the committable web form (written by an earlier
+    // `--mcp-json`), this write replaces it with an embedded secret — in the
+    // very file the docs tell you to commit. Warn before clobbering it;
+    // `isWebMcpServerEntry` recognises the shape we are about to overwrite.
+    if (scope === 'project' && token) {
+      const prior = readLorekitServer(root);
+      if (prior && isWebMcpServerEntry(prior.server)) {
+        status(
+          'warn',
+          '.mcp.json',
+          `replacing the committable web entry with an embedded token — do not commit this file, or re-run with --mcp-json to keep the \${${WEB_TOKEN_ENV_VAR}} form`,
+        );
+      }
+    }
     ({ file, existed } = upsertMcpServer(root, remoteUrl, scope));
   }
 

--- a/packages/cli/src/install.mjs
+++ b/packages/cli/src/install.mjs
@@ -527,7 +527,7 @@ export async function install(args) {
       'warn',
       'token',
       `not stored — the committable .mcp.json resolves \${${WEB_TOKEN_ENV_VAR}} at runtime; set it as an environment secret${
-        token ? ' (any --token you passed is not persisted)' : ''
+        plan.action === 'flag' ? ' (the token you supplied is not persisted)' : ''
       }`,
     );
   } else if (kind === 'none') {

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -396,6 +396,39 @@ test('resolveProjectConnection: a tokenless web .mcp.json does not shadow the gl
   }
 });
 
+test('resolveProjectConnection: the winning token brings its own endpoint, not the closer tokenless one', () => {
+  // A tokenless project source and a token-bearing global source with DISTINCT
+  // endpoints: the global token wins (project stored none) and MUST be paired
+  // with the global endpoint — a token authenticates one endpoint, so the closer
+  // tokenless project endpoint is not used when a later source carries a token.
+  const PROJECT_ENDPOINT = 'https://project.supabase.co/functions/v1/mcp';
+  const GLOBAL_ENDPOINT = 'https://global.supabase.co/functions/v1/mcp';
+  const home = tmpRoot();
+  const root = tmpRoot();
+  upsertWebMcpServer(root, PROJECT_ENDPOINT); // project: web form, no token
+  fs.writeFileSync(
+    path.join(home, '.claude.json'),
+    JSON.stringify({
+      mcpServers: { lorekit: { command: 'npx', args: ['-y', 'mcp-remote', `${GLOBAL_ENDPOINT}?token=lk_rw_global`] } },
+    }),
+  );
+
+  const prev = { HOME: process.env.HOME, USERPROFILE: process.env.USERPROFILE, TOK: process.env.LOREKIT_TOKEN };
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  delete process.env.LOREKIT_TOKEN;
+  try {
+    const conn = resolveProjectConnection(root, splitEndpoint);
+    assert.equal(conn.token, 'lk_rw_global', 'global token wins — project stored none');
+    assert.equal(conn.endpoint, GLOBAL_ENDPOINT, 'endpoint travels with the winning token, not the closer tokenless one');
+  } finally {
+    for (const [k, v] of [['HOME', prev.HOME], ['USERPROFILE', prev.USERPROFILE], ['LOREKIT_TOKEN', prev.TOK]]) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+});
+
 test('isWebMcpServerEntry recognises the committable web form only', () => {
   assert.equal(
     isWebMcpServerEntry({ args: ['-y', 'mcp-remote', WEB_ENDPOINT, '--header', 'Authorization:Bearer ${LOREKIT_TOKEN}'] }),

--- a/packages/cli/test/helpers.mjs
+++ b/packages/cli/test/helpers.mjs
@@ -1,0 +1,22 @@
+// Shared test helpers for the CLI suite. Not a test file (no `.test.mjs`), so
+// `node --test test/*.test.mjs` never runs it as a suite — it is imported.
+
+// Run `fn` with HOME and USERPROFILE pointed at `home`, then restore both to
+// exactly their prior state (including "was unset"). Async-safe: `fn` may return
+// a promise and the restore runs in a `.finally`, so it fires whether `fn`
+// resolves or rejects. Replaces the hand-rolled HOME save/restore blocks that
+// had been copy-pasted across install.test.mjs and uninstall.test.mjs.
+export function withHome(home, fn) {
+  const prevHome = process.env.HOME;
+  const prevProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevProfile;
+    });
+}

--- a/packages/cli/test/install.test.mjs
+++ b/packages/cli/test/install.test.mjs
@@ -215,6 +215,38 @@ test('install --mcp-json does NOT warn when .mcp.json is tracked', { skip: !gitA
   assert.doesNotMatch(out, /\.mcp\.json \(git\)/, 'no warning line when the file is not ignored');
 });
 
+test('install --project (plain) warns before replacing a committable web .mcp.json with an embedded token', async () => {
+  // A committable web .mcp.json (from an earlier --mcp-json) is meant to be
+  // committed; a later plain project install embeds the token into that same
+  // file. Warn before clobbering it. --force bypasses the already-installed
+  // short-circuit so the write step (and the warning) is reached.
+  const root = tmp('lk-webmcp-clobber-');
+  await install({ dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, project: true, 'mcp-json': true });
+  const before = fs.readFileSync(path.join(root, '.mcp.json'), 'utf8');
+  assert.ok(!before.includes(TOKEN), 'the web form embeds no token');
+
+  const out = await captureStdout(() =>
+    install({ dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, project: true, force: true }),
+  );
+  assert.match(
+    out,
+    /replacing the committable web entry with an embedded token/,
+    'install warns before overwriting the committable web form',
+  );
+  // The warning describes a real overwrite — the token is now embedded.
+  const after = JSON.parse(fs.readFileSync(path.join(root, '.mcp.json'), 'utf8'));
+  assert.ok(after.mcpServers.lorekit.args.some((a) => a.includes(TOKEN)), 'the plain install embedded the token');
+});
+
+test('install --mcp-json does NOT warn about clobbering when no web entry exists yet', async () => {
+  // A first-time plain project install has nothing to overwrite — no warning.
+  const root = tmp('lk-webmcp-noclobber-');
+  const out = await captureStdout(() =>
+    install({ dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, project: true }),
+  );
+  assert.doesNotMatch(out, /replacing the committable web entry/, 'no clobber warning on a fresh install');
+});
+
 test('install --mcp-json reaches the write step even on an already-complete install', async () => {
   // A fully-installed scope normally short-circuits to the "already installed"
   // summary; an explicit --mcp-json is an intent to write that file, so it must

--- a/packages/cli/test/install.test.mjs
+++ b/packages/cli/test/install.test.mjs
@@ -7,6 +7,7 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { install, defaultHookMode, HOOK_PROMPT_OPTIONS, tokenPlan, maskToken } from '../src/install.mjs';
 import { skillInstallDir, mcpConfigPath, homeDir, installedHookEvents, HOOK_MODES } from '../src/config.mjs';
+import { withHome } from './helpers.mjs';
 
 function tmp(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -84,11 +85,7 @@ test('install --global writes into ~/.claude and preserves existing user config'
     JSON.stringify({ theme: 'dark', mcpServers: { other: { command: 'x' } } }),
   );
 
-  const prevHome = process.env.HOME;
-  const prevProfile = process.env.USERPROFILE;
-  process.env.HOME = home;
-  process.env.USERPROFILE = home;
-  try {
+  await withHome(home, async () => {
     const code = await install({ dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, global: true });
     assert.equal(exitOf(code), 0);
 
@@ -100,12 +97,7 @@ test('install --global writes into ~/.claude and preserves existing user config'
     assert.equal(cfg.theme, 'dark', 'unrelated user settings preserved');
     assert.ok(cfg.mcpServers.other, 'other MCP server preserved');
     assert.ok(cfg.mcpServers.lorekit, 'lorekit server added to ~/.claude.json');
-  } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
-    if (prevProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = prevProfile;
-  }
+  });
 });
 
 // ── `--mcp-json`: committable, web-ready project .mcp.json ───────────────────
@@ -140,11 +132,7 @@ test('install --mcp-json writes a committable project .mcp.json referencing ${LO
 test('install --global --mcp-json writes BOTH ~/.claude.json and a committable project .mcp.json', async () => {
   const home = tmp('lk-webmcp-home-');
   const root = tmp('lk-webmcp-cwd-');
-  const prevHome = process.env.HOME;
-  const prevProfile = process.env.USERPROFILE;
-  process.env.HOME = home;
-  process.env.USERPROFILE = home;
-  try {
+  await withHome(home, async () => {
     const code = await install({ dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, global: true, 'mcp-json': true });
     assert.equal(exitOf(code), 0);
 
@@ -155,12 +143,7 @@ test('install --global --mcp-json writes BOTH ~/.claude.json and a committable p
     // AND the committable web file is written to the project root.
     const web = JSON.parse(fs.readFileSync(path.join(root, '.mcp.json'), 'utf8'));
     assertWebMcpShape(web);
-  } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
-    if (prevProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = prevProfile;
-  }
+  });
 });
 
 test('install --project --mcp-json does not embed a token (the web form owns .mcp.json)', async () => {
@@ -243,11 +226,7 @@ test('install --mcp-json reaches the write step even on an already-complete inst
   // process (they all read ~/.claude.json), breaking unrelated tests.
   const home = tmp('lk-webmcp-complete-home-');
   const root = tmp('lk-webmcp-complete-');
-  const prevHome = process.env.HOME;
-  const prevProfile = process.env.USERPROFILE;
-  process.env.HOME = home;
-  process.env.USERPROFILE = home;
-  try {
+  await withHome(home, async () => {
     const base = { dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, global: true };
     await install(base); // global install, no project .mcp.json yet
     assert.ok(!fs.existsSync(path.join(root, '.mcp.json')), 'no project .mcp.json after a plain global install');
@@ -255,12 +234,7 @@ test('install --mcp-json reaches the write step even on an already-complete inst
     const code = await install({ ...base, 'mcp-json': true });
     assert.equal(exitOf(code), 0);
     assert.ok(fs.existsSync(path.join(root, '.mcp.json')), 'the web .mcp.json is written despite the complete install');
-  } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
-    if (prevProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = prevProfile;
-  }
+  });
 });
 
 test('install wires the three lifecycle hooks into project settings.json', async () => {
@@ -320,21 +294,12 @@ test('install preserves existing settings.json content and non-lorekit hooks', a
 test('global install writes hooks into ~/.claude/settings.json', async () => {
   const home = tmp('lk-hooks-home-');
   const root = tmp('lk-hooks-cwd-');
-  const prevHome = process.env.HOME;
-  const prevProfile = process.env.USERPROFILE;
-  process.env.HOME = home;
-  process.env.USERPROFILE = home;
-  try {
+  await withHome(home, async () => {
     await install({ dir: root, endpoint: ENDPOINT, token: TOKEN, yes: true, global: true });
     const settings = JSON.parse(fs.readFileSync(path.join(home, '.claude', 'settings.json'), 'utf8'));
     assert.ok(settings.hooks.SessionStart[0].hooks[0].command.includes('hook --adapter claude'));
     assert.ok(!fs.existsSync(path.join(root, '.claude', 'settings.json')), 'project settings untouched for global install');
-  } finally {
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
-    if (prevProfile === undefined) delete process.env.USERPROFILE;
-    else process.env.USERPROFILE = prevProfile;
-  }
+  });
 });
 
 test('install reports already-installed and exits 0 without --force on a complete install', async () => {

--- a/packages/cli/test/uninstall.test.mjs
+++ b/packages/cli/test/uninstall.test.mjs
@@ -7,6 +7,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { install } from '../src/install.mjs';
 import { uninstall } from '../src/uninstall.mjs';
+import { withHome } from './helpers.mjs';
 
 function tmp(prefix) {
   return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -14,21 +15,6 @@ function tmp(prefix) {
 
 const ENDPOINT = 'https://ref.supabase.co/functions/v1/mcp';
 const TOKEN = 'lk_rw_test';
-
-function withHome(home, fn) {
-  const prevHome = process.env.HOME;
-  const prevProfile = process.env.USERPROFILE;
-  process.env.HOME = home;
-  process.env.USERPROFILE = home;
-  return Promise.resolve()
-    .then(fn)
-    .finally(() => {
-      if (prevHome === undefined) delete process.env.HOME;
-      else process.env.HOME = prevHome;
-      if (prevProfile === undefined) delete process.env.USERPROFILE;
-      else process.env.USERPROFILE = prevProfile;
-    });
-}
 
 test('uninstall --project removes skill, MCP entry, and hooks', async () => {
   const root = tmp('lk-uninst-proj-');

--- a/packages/web/src/content/docs/claude-code-web.mdx
+++ b/packages/web/src/content/docs/claude-code-web.mdx
@@ -56,7 +56,7 @@ It authenticates via a `${LOREKIT_TOKEN}` reference (an mcp-remote `--header`), 
 
 <TutorialCallout variant="warning">
 
-Once `.mcp.json` is tracked, only ever run `install` with `--mcp-json` in this repo. A *plain* `lorekit install --project` embeds a live token in that same file — now committed — and leaks it. `--mcp-json` keeps the file secret-free.
+Once `.mcp.json` is tracked, only ever run `install` with `--mcp-json` in this repo. A *plain* `lorekit install --project` embeds a live token in that same file — now committed — and leaks it. `--mcp-json` keeps the file secret-free. The install command **warns you when a plain install is about to replace a committable web `.mcp.json` with an embedded token**, so you catch the leak before it lands.
 
 </TutorialCallout>
 


### PR DESCRIPTION
Follow-up to #399 (`install --mcp-json`), which merged before this review round's fixes landed on the branch. These four commits address dash0-dev's non-blocking review comments on that PR; the shipped feature itself is unchanged.

## What's here

- **Warn before a plain install clobbers a committable web `.mcp.json`.** A later `lorekit install --project` embeds a live token into the file the docs tell you to commit. `install` now detects the committable web form (via the existing `isWebMcpServerEntry`) and warns before overwriting it, pointing at `--mcp-json`. Covered by two tests; the web guide, `docs/install.md`, and the CLI README note the new warning alongside the git-ignored one.
- **Only claim a token was dropped when one was actually supplied.** The `--project --mcp-json` "token not stored" line showed "(the token you supplied is not persisted)" whenever a token resolved — including one reused from config. Gated on `plan.action === 'flag'` so it only appears when `--token`/`LOREKIT_TOKEN` was passed this run.
- **Clarify the endpoint-precedence docblock + test it.** `resolveProjectConnection` returns the winning token's *own* endpoint (a token authenticates one endpoint), so a closer tokenless source is only an endpoint fallback. The docblock now says so, and a new test covers the distinct-endpoint case the existing same-endpoint test couldn't distinguish.
- **Hoist the duplicated HOME save/restore into a shared `withHome` test helper**, matching the one already in `uninstall.test.mjs` (test-only, no behavior change).

## Verification

`config` / `install` / `uninstall` CLI suites: 78 pass, 0 fail (with a clean `HOME`).

The corresponding threads on #399 were already replied-to and resolved; this PR is where the fixes actually reach `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)