### PR TITLE
ci: deploy Vercel web preview from CI, gated on web changes

### DIFF
--- a/.github/actions/vercel-preview-deploy/action.yml
+++ b/.github/actions/vercel-preview-deploy/action.yml
@@ -122,9 +122,11 @@ runs:
     # Rewrite the env file `vercel build` actually reads
     # (.vercel/.env.<environment>.local) — the only file whose values win over a
     # .env.local entry — so the build talks to the caller-named Supabase project.
-    # Skipped when no anon key is supplied: the pulled Vercel env values remain.
+    # Runs only when BOTH inputs are supplied (a partial pair can't form a valid
+    # URL); otherwise the pulled Vercel env values remain. "override ran" ⟺ both
+    # present, so the warn step below fires on exactly the incomplete cases.
     - name: Override Supabase config
-      if: ${{ inputs.supabase-anon-key != '' }}
+      if: ${{ inputs.supabase-anon-key != '' && inputs.supabase-project-ref != '' }}
       shell: bash
       env:
         PROJECT_REF: ${{ inputs.supabase-project-ref }}

--- a/.github/actions/vercel-preview-deploy/action.yml
+++ b/.github/actions/vercel-preview-deploy/action.yml
@@ -137,6 +137,17 @@ runs:
           echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${ANON_KEY}"
         } >> "$ENV_FILE"
 
+    # A caller that pins a Supabase project but whose anon key came back empty
+    # meant to override and could not — the Override step above self-skipped, so
+    # the build silently keeps Vercel's pulled env (production for a prod-pulled
+    # project). Flag it; deploy.yml emitted this same signal before the flow was
+    # shared. Only fires when an override was INTENDED (project-ref set), so the
+    # deliberate no-override caller (ci.yml, which passes neither) stays quiet.
+    - name: Warn on incomplete Supabase override
+      if: ${{ inputs.supabase-project-ref != '' && inputs.supabase-anon-key == '' }}
+      shell: bash
+      run: echo "::warning::supabase-project-ref set but supabase-anon-key is empty — the Supabase override was skipped and the preview build uses Vercel's pulled ${{ inputs.environment }} env, which may point at production Supabase."
+
     # A CLI build gets none of Vercel's auto-injected VERCEL_GIT_* system env
     # vars, so pass them through — instrumentation-client.ts bakes them into
     # NEXT_PUBLIC_VCS_* (OTel VCS resource attributes) and service.version.

--- a/.github/actions/vercel-preview-deploy/action.yml
+++ b/.github/actions/vercel-preview-deploy/action.yml
@@ -1,0 +1,174 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Composite action: build + deploy a Vercel PREVIEW deployment.
+#
+# The pull → (optional Supabase override) → build → deploy → parse-URL sequence
+# used to be copy-pasted across three jobs — ci.yml's `web-preview`, deploy.yml's
+# `deploy-web-preview`, and preview.yml's `deploy-web`. This is the single source
+# of truth for that flow; the callers supply only what differs (which env values
+# to pin, which git ref to attribute, and what to do with the resulting URL).
+#
+# The runner does the `next build` (`vercel build`) and uploads a prebuilt
+# deployment (`vercel deploy --prebuilt`), so Vercel spends no build minutes.
+#
+# The caller MUST check out the repo BEFORE invoking this action (a local
+# composite action needs its own files on disk, and `cache: pnpm` needs the
+# lockfile). The checkout ref differs per caller, so it stays in the caller.
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: Vercel preview deploy
+description: Build on the runner and deploy a prebuilt Vercel preview; returns the deployment URL.
+
+inputs:
+  vercel-token:
+    description: Vercel access token (repo secret VERCEL_TOKEN).
+    required: true
+  vercel-org-id:
+    description: Vercel org id (repo secret VERCEL_ORG_ID).
+    required: true
+  vercel-project-id:
+    description: Vercel project id (repo secret VERCEL_PROJECT_ID).
+    required: true
+  environment:
+    description: Vercel environment to pull/build against.
+    required: false
+    default: preview
+  vercel-cli-version:
+    description: Vercel CLI version to install (pinned so local and CI render on the same CLI).
+    required: false
+    default: '58'
+  supabase-project-ref:
+    description: >-
+      Supabase project ref to pin the FE at. When set together with
+      supabase-anon-key, the pulled NEXT_PUBLIC_SUPABASE_* vars are overwritten
+      so the build talks to this project. Leave empty to use Vercel's own pulled
+      environment values unchanged.
+    required: false
+    default: ''
+  supabase-anon-key:
+    description: Supabase anon key paired with supabase-project-ref. Empty ⇒ no override.
+    required: false
+    default: ''
+  git-repo-owner:
+    description: VERCEL_GIT_REPO_OWNER for the build (a CLI build gets no auto-injected VERCEL_GIT_* vars).
+    required: false
+    default: ''
+  git-repo-slug:
+    description: VERCEL_GIT_REPO_SLUG for the build.
+    required: false
+    default: ''
+  git-commit-ref:
+    description: VERCEL_GIT_COMMIT_REF for the build (branch name).
+    required: false
+    default: ''
+  git-commit-sha:
+    description: VERCEL_GIT_COMMIT_SHA for the build.
+    required: false
+    default: ''
+
+outputs:
+  url:
+    description: The deployed Vercel preview URL.
+    value: ${{ steps.deploy.outputs.url }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up pnpm
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+    - name: Set up Node.js
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+      with:
+        node-version: 20
+        cache: pnpm
+
+    - name: Verify Vercel secrets are set
+      shell: bash
+      env:
+        VERCEL_TOKEN: ${{ inputs.vercel-token }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+      run: |
+        missing=""
+        [ -z "$VERCEL_TOKEN" ] && missing="$missing VERCEL_TOKEN"
+        [ -z "$VERCEL_ORG_ID" ] && missing="$missing VERCEL_ORG_ID"
+        [ -z "$VERCEL_PROJECT_ID" ] && missing="$missing VERCEL_PROJECT_ID"
+        if [ -n "$missing" ]; then
+          echo "::error::Missing repo-level Vercel secrets:$missing. Add them under Settings ▸ Secrets and variables ▸ Actions."
+          exit 1
+        fi
+
+    - name: Install Vercel CLI
+      shell: bash
+      run: pnpm add -g vercel@${{ inputs.vercel-cli-version }}
+
+    - name: Pull Vercel environment
+      shell: bash
+      env:
+        VERCEL_TOKEN: ${{ inputs.vercel-token }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+      run: vercel pull --yes --environment="${{ inputs.environment }}" --token="$VERCEL_TOKEN"
+
+    # Rewrite the env file `vercel build` actually reads
+    # (.vercel/.env.<environment>.local) — the only file whose values win over a
+    # .env.local entry — so the build talks to the caller-named Supabase project.
+    # Skipped when no anon key is supplied: the pulled Vercel env values remain.
+    - name: Override Supabase config
+      if: ${{ inputs.supabase-anon-key != '' }}
+      shell: bash
+      env:
+        PROJECT_REF: ${{ inputs.supabase-project-ref }}
+        ANON_KEY: ${{ inputs.supabase-anon-key }}
+        ENVIRONMENT: ${{ inputs.environment }}
+      run: |
+        ENV_FILE=".vercel/.env.${ENVIRONMENT}.local"
+        if [ ! -f "$ENV_FILE" ]; then
+          echo "::error::$ENV_FILE not found — did 'vercel pull' run?"
+          exit 1
+        fi
+        # Drop any pulled Supabase vars so ours are the only definitions.
+        grep -vE '^(NEXT_PUBLIC_SUPABASE_URL|NEXT_PUBLIC_SUPABASE_ANON_KEY|NEXT_PUBLIC_SUPABASE_PROJECT_REF)=' \
+          "$ENV_FILE" > "$ENV_FILE.tmp" || true
+        mv "$ENV_FILE.tmp" "$ENV_FILE"
+        {
+          echo "NEXT_PUBLIC_SUPABASE_URL=https://${PROJECT_REF}.supabase.co"
+          echo "NEXT_PUBLIC_SUPABASE_PROJECT_REF=${PROJECT_REF}"
+          echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${ANON_KEY}"
+        } >> "$ENV_FILE"
+
+    # A CLI build gets none of Vercel's auto-injected VERCEL_GIT_* system env
+    # vars, so pass them through — instrumentation-client.ts bakes them into
+    # NEXT_PUBLIC_VCS_* (OTel VCS resource attributes) and service.version.
+    - name: Build
+      shell: bash
+      env:
+        VERCEL_TOKEN: ${{ inputs.vercel-token }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+        VERCEL_GIT_REPO_OWNER: ${{ inputs.git-repo-owner }}
+        VERCEL_GIT_REPO_SLUG: ${{ inputs.git-repo-slug }}
+        VERCEL_GIT_COMMIT_REF: ${{ inputs.git-commit-ref }}
+        VERCEL_GIT_COMMIT_SHA: ${{ inputs.git-commit-sha }}
+      run: vercel build --token="$VERCEL_TOKEN"
+
+    - name: Deploy (prebuilt)
+      id: deploy
+      shell: bash
+      env:
+        VERCEL_TOKEN: ${{ inputs.vercel-token }}
+        VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
+        VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+      run: |
+        set -euo pipefail
+        # Vercel prints the deployment URL to stdout and progress to stderr;
+        # keep them separate (no 2>&1) and grep the URL so a trailing stderr
+        # line can never be mistaken for the deployment URL.
+        out="$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")"
+        echo "$out"
+        URL="$(printf '%s\n' "$out" | grep -Eo 'https://[^[:space:]]+' | tail -1)"
+        if [ -z "$URL" ]; then
+          echo "::error::Could not parse Vercel preview deployment URL"
+          exit 1
+        fi
+        echo "url=$URL" >> "$GITHUB_OUTPUT"

--- a/.github/actions/vercel-preview-deploy/action.yml
+++ b/.github/actions/vercel-preview-deploy/action.yml
@@ -48,6 +48,15 @@ inputs:
     description: Supabase anon key paired with supabase-project-ref. Empty ⇒ no override.
     required: false
     default: ''
+  require-supabase-override:
+    description: >-
+      Set 'true' by callers that ALWAYS intend a Supabase override
+      (deploy.yml's deploy-web-preview, preview.yml's deploy-web). When true, an
+      incomplete override (either supabase-* input empty, including both) becomes
+      a ::warning:: instead of a silent fallback to Vercel's pulled env. Leave
+      'false' for callers that deliberately use the pulled env (ci.yml).
+    required: false
+    default: 'false'
   git-repo-owner:
     description: VERCEL_GIT_REPO_OWNER for the build (a CLI build gets no auto-injected VERCEL_GIT_* vars).
     required: false
@@ -137,16 +146,18 @@ runs:
           echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${ANON_KEY}"
         } >> "$ENV_FILE"
 
-    # A caller that pins a Supabase project but whose anon key came back empty
-    # meant to override and could not — the Override step above self-skipped, so
-    # the build silently keeps Vercel's pulled env (production for a prod-pulled
-    # project). Flag it; deploy.yml emitted this same signal before the flow was
-    # shared. Only fires when an override was INTENDED (project-ref set), so the
-    # deliberate no-override caller (ci.yml, which passes neither) stays quiet.
+    # A caller that declared it always overrides Supabase but supplied an
+    # incomplete pair — either input empty, INCLUDING both — meant to override
+    # and could not: the Override step above self-skipped, so the build silently
+    # keeps Vercel's pulled env (production for a prod-pulled project). Flag it;
+    # deploy.yml emitted this same signal (on an empty anon key) before the flow
+    # was shared. Gated on require-supabase-override, so the deliberate
+    # no-override caller (ci.yml, which passes neither input nor the flag) stays
+    # quiet while deploy-web-preview / deploy-web still catch a missing secret.
     - name: Warn on incomplete Supabase override
-      if: ${{ inputs.supabase-project-ref != '' && inputs.supabase-anon-key == '' }}
+      if: ${{ inputs.require-supabase-override == 'true' && (inputs.supabase-project-ref == '' || inputs.supabase-anon-key == '') }}
       shell: bash
-      run: echo "::warning::supabase-project-ref set but supabase-anon-key is empty — the Supabase override was skipped and the preview build uses Vercel's pulled ${{ inputs.environment }} env, which may point at production Supabase."
+      run: echo "::warning::require-supabase-override is set but supabase-project-ref and/or supabase-anon-key is empty — the Supabase override was skipped and the preview build uses Vercel's pulled ${{ inputs.environment }} env, which may point at production Supabase."
 
     # A CLI build gets none of Vercel's auto-injected VERCEL_GIT_* system env
     # vars, so pass them through — instrumentation-client.ts bakes them into

--- a/.github/actions/vercel-preview-deploy/action.yml
+++ b/.github/actions/vercel-preview-deploy/action.yml
@@ -73,10 +73,19 @@ inputs:
     description: VERCEL_GIT_COMMIT_SHA for the build.
     required: false
     default: ''
+  deploy:
+    description: >-
+      Set 'false' to run pull → override → build as a build-only GATE and skip
+      `vercel deploy` (so NO Vercel deployment is created and no quota is spent).
+      Used by deploy.yml's deploy-web-preview, whose deployment was never
+      smoke-tested — the build succeeding is the only signal it needs. When
+      'false' the `url` output is empty. Defaults to 'true' (build + deploy).
+    required: false
+    default: 'true'
 
 outputs:
   url:
-    description: The deployed Vercel preview URL.
+    description: The deployed Vercel preview URL (empty when deploy is 'false').
     value: ${{ steps.deploy.outputs.url }}
 
 runs:
@@ -176,8 +185,11 @@ runs:
         VERCEL_GIT_COMMIT_SHA: ${{ inputs.git-commit-sha }}
       run: vercel build --token="$VERCEL_TOKEN"
 
+    # Skipped in build-only mode (deploy: 'false') — the build above is the gate,
+    # and no deployment is created, so no Vercel quota is spent.
     - name: Deploy (prebuilt)
       id: deploy
+      if: ${{ inputs.deploy == 'true' }}
       shell: bash
       env:
         VERCEL_TOKEN: ${{ inputs.vercel-token }}

--- a/.github/actions/vercel-preview-deploy/action.yml
+++ b/.github/actions/vercel-preview-deploy/action.yml
@@ -190,7 +190,10 @@ runs:
         # line can never be mistaken for the deployment URL.
         out="$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")"
         echo "$out"
-        URL="$(printf '%s\n' "$out" | grep -Eo 'https://[^[:space:]]+' | tail -1)"
+        # `|| true` so grep's no-match exit (1) doesn't abort under pipefail/set -e
+        # before the guard below runs — an empty URL is handled by that guard,
+        # which prints a clear ::error:: and exits 1, so nothing is swallowed.
+        URL="$(printf '%s\n' "$out" | grep -Eo 'https://[^[:space:]]+' | tail -1 || true)"
         if [ -z "$URL" ]; then
           echo "::error::Could not parse Vercel preview deployment URL"
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,6 +250,141 @@ jobs:
           BASE: ${{ github.event.pull_request.base.sha }}
         run: npx vitest run --config vitest.storybook.config.ts --changed="$BASE" --passWithNoTests
 
+  # ── Web preview — deploy a Vercel preview, ONLY when web paths changed ────────
+  #    Replaces Vercel's native Git integration for the dashboard project. That
+  #    integration deployed a preview on EVERY PR/branch push — even docs- or
+  #    backend-only ones — and each deployment counts against the Vercel Hobby
+  #    quota even when the dashboard's Ignored Build Step skips the actual build.
+  #    Here the preview is gated on the `web` path filter, so a PR with no web
+  #    changes creates no Vercel deployment at all.
+  #
+  #    Quota-friendly build strategy: `vercel build` runs on THIS runner and
+  #    `vercel deploy --prebuilt` uploads the result, so Vercel spends no build
+  #    minutes — only a single deployment is created, and only when relevant.
+  #
+  #    The env is Vercel's own "preview" environment (`vercel pull
+  #    --environment=preview`) — a faithful replacement for what the Git
+  #    integration used, so the preview behaves exactly as before.
+  #
+  #    Non-blocking by design: it is deliberately NOT in the `summary` gate's
+  #    `needs`, so a transient Vercel failure can never block a merge (the old
+  #    Vercel preview check wasn't a merge gate either). It self-skips green on a
+  #    fork PR where the Vercel secrets are unavailable.
+  web-preview:
+    name: Web — Vercel preview (changed)
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.web == 'true'
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      # Are the Vercel secrets available? On a fork PR they are not, and there is
+      # nothing the contributor can do about it — warn and skip the deploy rather
+      # than red-X a PR over a missing secret. `contents: read` is safe on forks;
+      # the deploy steps below only run when this resolves to `true`.
+      - name: Check Vercel secrets are available
+        id: guard
+        run: |
+          if [ -n "$VERCEL_TOKEN" ] && [ -n "$VERCEL_ORG_ID" ] && [ -n "$VERCEL_PROJECT_ID" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Vercel secrets unavailable (fork PR?) — skipping the preview deploy for this run."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout repository
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up pnpm
+        if: steps.guard.outputs.run == 'true'
+        uses: pnpm/action-setup@v6
+
+      - name: Set up Node.js
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+          cache: pnpm
+
+      # Pinned to match deploy.yml's web jobs so a local `vercel build` and CI
+      # render on the same CLI.
+      - name: Install Vercel CLI
+        if: steps.guard.outputs.run == 'true'
+        run: pnpm add -g vercel@58
+
+      - name: Pull Vercel environment (preview)
+        if: steps.guard.outputs.run == 'true'
+        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
+
+      # A CLI build gets none of Vercel's auto-injected VERCEL_GIT_* system env
+      # vars, so set them by hand — instrumentation-client.ts bakes them into
+      # NEXT_PUBLIC_VCS_* (OTel VCS resource attributes) and service.version.
+      # Use the PR head ref/SHA (not github.ref_name/github.sha, which on a
+      # pull_request are the synthetic `refs/pull/N/merge` merge commit).
+      - name: Build (preview)
+        if: steps.guard.outputs.run == 'true'
+        env:
+          VERCEL_GIT_REPO_OWNER: ${{ github.repository_owner }}
+          VERCEL_GIT_REPO_SLUG: ${{ github.event.repository.name }}
+          VERCEL_GIT_COMMIT_REF: ${{ github.head_ref }}
+          VERCEL_GIT_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: vercel build --token="$VERCEL_TOKEN"
+
+      - name: Deploy to Vercel (preview)
+        id: deploy
+        if: steps.guard.outputs.run == 'true'
+        run: |
+          # Vercel prints the deployment URL to stdout and progress to stderr;
+          # grep the URL so a trailing stderr line is never mistaken for it.
+          out="$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")"
+          echo "$out"
+          URL="$(printf '%s\n' "$out" | grep -Eo 'https://[^[:space:]]+' | tail -1)"
+          if [ -z "$URL" ]; then
+            echo "::error::Could not parse Vercel preview deployment URL"
+            exit 1
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      # Post (or update) a single sticky comment with the preview URL — the same
+      # affordance the Vercel bot used to provide. Idempotent: it edits its own
+      # marker comment on re-run instead of stacking a new one per push.
+      - name: Comment preview URL on the PR
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const marker = '<!-- lorekit-web-preview -->';
+            const url = process.env.PREVIEW_URL;
+            const sha = process.env.PR_SHA.slice(0, 7);
+            const body = [
+              marker,
+              '### ▲ Web preview deployed',
+              '',
+              `🔗 **[Open preview → ${url}](${url})**`,
+              '',
+              `Commit \`${sha}\` · [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number,
+            });
+            const existing = comments.find(c => c.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
   # ── Migration-order guard — reject out-of-order migration prefixes ───────────
   #    Fails a PR that ADDS a migration numbered <= the highest already on the
   #    base branch — the collision that later wedges `supabase db push` on deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,59 +297,27 @@ jobs:
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Checkout repository
-        if: steps.guard.outputs.run == 'true'
-        uses: actions/checkout@v7.0.1
-
-      - name: Set up pnpm
-        if: steps.guard.outputs.run == 'true'
-        uses: pnpm/action-setup@v6
-
-      - name: Set up Node.js
-        if: steps.guard.outputs.run == 'true'
-        uses: actions/setup-node@v7
-        with:
-          node-version: 20
-          cache: pnpm
-
-      # Pinned to match deploy.yml's web jobs so a local `vercel build` and CI
-      # render on the same CLI.
-      - name: Install Vercel CLI
-        if: steps.guard.outputs.run == 'true'
-        run: pnpm add -g vercel@58
-
-      - name: Pull Vercel environment (preview)
-        if: steps.guard.outputs.run == 'true'
-        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
-
-      # A CLI build gets none of Vercel's auto-injected VERCEL_GIT_* system env
-      # vars, so set them by hand — instrumentation-client.ts bakes them into
-      # NEXT_PUBLIC_VCS_* (OTel VCS resource attributes) and service.version.
       # Use the PR head ref/SHA (not github.ref_name/github.sha, which on a
       # pull_request are the synthetic `refs/pull/N/merge` merge commit).
-      - name: Build (preview)
+      - name: Checkout repository
         if: steps.guard.outputs.run == 'true'
-        env:
-          VERCEL_GIT_REPO_OWNER: ${{ github.repository_owner }}
-          VERCEL_GIT_REPO_SLUG: ${{ github.event.repository.name }}
-          VERCEL_GIT_COMMIT_REF: ${{ github.head_ref }}
-          VERCEL_GIT_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-        run: vercel build --token="$VERCEL_TOKEN"
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Deploy to Vercel (preview)
-        id: deploy
+      # Shared build+deploy flow (see .github/actions/vercel-preview-deploy).
+      # No Supabase override: this uses Vercel's own preview env, a faithful
+      # replacement for what the Git integration deployed.
+      - name: Deploy Vercel preview
+        id: preview
         if: steps.guard.outputs.run == 'true'
-        run: |
-          # Vercel prints the deployment URL to stdout and progress to stderr;
-          # grep the URL so a trailing stderr line is never mistaken for it.
-          out="$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")"
-          echo "$out"
-          URL="$(printf '%s\n' "$out" | grep -Eo 'https://[^[:space:]]+' | tail -1)"
-          if [ -z "$URL" ]; then
-            echo "::error::Could not parse Vercel preview deployment URL"
-            exit 1
-          fi
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/vercel-preview-deploy
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          git-repo-owner: ${{ github.repository_owner }}
+          git-repo-slug: ${{ github.event.repository.name }}
+          git-commit-ref: ${{ github.head_ref }}
+          git-commit-sha: ${{ github.event.pull_request.head.sha }}
 
       # Post (or update) a single sticky comment with the preview URL — the same
       # affordance the Vercel bot used to provide. Idempotent: it edits its own
@@ -358,7 +326,7 @@ jobs:
         if: steps.guard.outputs.run == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+          PREVIEW_URL: ${{ steps.preview.outputs.url }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,10 @@ jobs:
   #    backend-only ones — and each deployment counts against the Vercel Hobby
   #    quota even when the dashboard's Ignored Build Step skips the actual build.
   #    Here the preview is gated on the `web` path filter, so a PR with no web
-  #    changes creates no Vercel deployment at all.
+  #    changes creates no Vercel deployment at all. It ALSO skips redeploying when
+  #    a new commit changed no web file SINCE this PR's last preview (the "Decide"
+  #    step diffs against the SHA recorded in the sticky comment), so a burst of
+  #    non-web commits on a web PR spends one deployment, not one per push.
   #
   #    Quota-friendly build strategy: `vercel build` runs on THIS runner and
   #    `vercel deploy --prebuilt` uploads the result, so Vercel spends no build
@@ -297,10 +300,54 @@ jobs:
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Incremental skip: redeploy only if a web file actually changed since this
+      # PR's LAST preview. The sticky comment records that commit (as `sha=<full>`
+      # in its marker); compare it to the current head via the GitHub API — no
+      # local git/checkout needed. Skip when nothing under the web globs changed,
+      # so a burst of non-web commits on a web PR doesn't spend a deployment each.
+      # Fail-safe to deploy on any doubt: no prior preview, a rebase/force-push
+      # (compare status not `ahead`), a diff too large to inspect, or an API error.
+      - name: Decide whether a redeploy is needed
+        id: decide
+        if: steps.guard.outputs.run == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        with:
+          script: |
+            const findMarker = '<!-- lorekit-web-preview';
+            const webRe = /^(packages\/web\/|package\.json$|pnpm-lock\.yaml$|nx\.json$|\.github\/actions\/vercel-preview-deploy\/|\.github\/workflows\/ci\.yml$)/;
+            const headSha = process.env.HEAD_SHA;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const deploy = (why) => { core.info(`web preview: deploy — ${why}`); core.setOutput('deploy', 'true'); };
+            const skip = (why) => { core.notice(`Skipping web-preview redeploy — ${why}.`); core.setOutput('deploy', 'false'); };
+            let prevSha = null;
+            try {
+              const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+              const existing = comments.find(c => c.body?.includes(findMarker));
+              prevSha = existing?.body?.match(/lorekit-web-preview sha=([0-9a-f]{40})/)?.[1] ?? null;
+            } catch (e) {
+              return deploy(`could not read the prior preview comment (${e.message})`);
+            }
+            if (!prevSha) return deploy('no prior preview on this PR');
+            if (prevSha === headSha) return skip(`head ${headSha.slice(0, 7)} is already the deployed preview`);
+            try {
+              const cmp = await github.rest.repos.compareCommitsWithBasehead({ owner, repo, basehead: `${prevSha}...${headSha}` });
+              if (cmp.data.status !== 'ahead') return deploy(`compare status '${cmp.data.status}' (rebase/force-push) — can't confirm`);
+              const files = cmp.data.files ?? [];
+              if (files.length >= 300) return deploy('diff too large to inspect fully');
+              return files.some(f => webRe.test(f.filename))
+                ? deploy(`web files changed since ${prevSha.slice(0, 7)}`)
+                : skip(`no web file changed since ${prevSha.slice(0, 7)}; the existing preview is still current`);
+            } catch (e) {
+              return deploy(`compare API failed (${e.message})`);
+            }
+
       # Use the PR head ref/SHA (not github.ref_name/github.sha, which on a
       # pull_request are the synthetic `refs/pull/N/merge` merge commit).
       - name: Checkout repository
-        if: steps.guard.outputs.run == 'true'
+        if: steps.guard.outputs.run == 'true' && steps.decide.outputs.deploy == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # Shared build+deploy flow (see .github/actions/vercel-preview-deploy).
@@ -308,7 +355,7 @@ jobs:
       # replacement for what the Git integration deployed.
       - name: Deploy Vercel preview
         id: preview
-        if: steps.guard.outputs.run == 'true'
+        if: steps.guard.outputs.run == 'true' && steps.decide.outputs.deploy == 'true'
         uses: ./.github/actions/vercel-preview-deploy
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
@@ -323,18 +370,22 @@ jobs:
       # affordance the Vercel bot used to provide. Idempotent: it edits its own
       # marker comment on re-run instead of stacking a new one per push.
       - name: Comment preview URL on the PR
-        if: steps.guard.outputs.run == 'true'
+        if: steps.guard.outputs.run == 'true' && steps.decide.outputs.deploy == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PREVIEW_URL: ${{ steps.preview.outputs.url }}
           PR_SHA: ${{ github.event.pull_request.head.sha }}
         with:
           script: |
-            const marker = '<!-- lorekit-web-preview -->';
+            const fullSha = process.env.PR_SHA;
+            // Stable find-key; the stored line also carries the full SHA so the
+            // "Decide" step above can diff the next commit against this deploy.
+            const findMarker = '<!-- lorekit-web-preview';
+            const markerLine = `<!-- lorekit-web-preview sha=${fullSha} -->`;
             const url = process.env.PREVIEW_URL;
-            const sha = process.env.PR_SHA.slice(0, 7);
+            const sha = fullSha.slice(0, 7);
             const body = [
-              marker,
+              markerLine,
               '### ▲ Web preview deployed',
               '',
               `🔗 **[Open preview → ${url}](${url})**`,
@@ -346,7 +397,7 @@ jobs:
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number,
             });
-            const existing = comments.find(c => c.body?.includes(marker));
+            const existing = comments.find(c => c.body?.includes(findMarker));
             if (existing) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
             } else {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           # Web gate: the Next.js dashboard, plus the workspace files that change
           # how it installs or is configured. Drives the Storybook interaction +
           # visual-regression job so it never boots a browser on unrelated PRs.
-          if printf '%s\n' "$CHANGED" | grep -qE '^(packages/web/|package\.json|pnpm-lock\.yaml|nx\.json|\.github/workflows/ci\.yml)'; then
+          if printf '%s\n' "$CHANGED" | grep -qE '^(packages/web/|package\.json|pnpm-lock\.yaml|nx\.json|\.github/actions/vercel-preview-deploy/|\.github/workflows/ci\.yml)'; then
             echo "web=true" >> "$GITHUB_OUTPUT"
           else
             echo "web=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -148,7 +148,7 @@ jobs:
           fi
           # Web = the Next.js dashboard + the schemas it transpiles + the workspace
           # files that change how it installs, plus this workflow.
-          if printf '%s\n' "$CHANGED" | grep -qE '^(packages/web/|packages/schemas/|package\.json|pnpm-lock\.yaml|nx\.json|\.github/workflows/deploy\.yml)'; then
+          if printf '%s\n' "$CHANGED" | grep -qE '^(packages/web/|packages/schemas/|package\.json|pnpm-lock\.yaml|nx\.json|\.github/actions/vercel-preview-deploy/|\.github/workflows/deploy\.yml)'; then
             WEB=true
           fi
           echo "api=$API" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -286,6 +286,9 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           supabase-project-ref: ${{ secrets.SUPABASE_PROJECT_REF }}
           supabase-anon-key: ${{ secrets.SUPABASE_ANON_KEY }}
+          # Always overrides at the PREVIEW Supabase project — warn (not silently
+          # fall back to the pulled env) if either secret is missing.
+          require-supabase-override: 'true'
           git-repo-owner: ${{ github.repository_owner }}
           git-repo-slug: ${{ github.event.repository.name }}
           git-commit-ref: ${{ github.ref_name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,10 @@
 # Both the API (Supabase edge functions + migrations) AND the web dashboard
 # (Next.js on Vercel) are deployed here, in lockstep, so the frontend and backend
 # flip to production together instead of skewing apart. Vercel's native Git
-# auto-deploy is disabled (packages/web/vercel.json → git.deploymentEnabled.main
-# = false); this workflow is now the ONLY path the dashboard reaches production.
+# auto-deploy is disabled entirely (packages/web/vercel.json →
+# git.deploymentEnabled = false); this workflow is the ONLY path the dashboard
+# reaches production, and ci.yml deploys PR previews. The shared Vercel
+# build+deploy flow lives in .github/actions/vercel-preview-deploy.
 #
 #   deploy-preview (API) ────────┐
 #   deploy-web-preview (FE) ──────┤
@@ -267,94 +269,27 @@ jobs:
     environment: preview
     permissions:
       contents: read
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v7
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Verify Vercel secrets are set
-        run: |
-          missing=""
-          [ -z "$VERCEL_TOKEN" ] && missing="$missing VERCEL_TOKEN"
-          [ -z "$VERCEL_ORG_ID" ] && missing="$missing VERCEL_ORG_ID"
-          [ -z "$VERCEL_PROJECT_ID" ] && missing="$missing VERCEL_PROJECT_ID"
-          if [ -n "$missing" ]; then
-            echo "::error::Missing repo-level Vercel secrets:$missing. Add them under Settings ▸ Secrets and variables ▸ Actions."
-            exit 1
-          fi
-
-      - name: Install Vercel CLI
-        run: pnpm add -g vercel@58
-
-      - name: Pull Vercel environment (preview)
-        run: vercel pull --yes --environment=preview --token="$VERCEL_TOKEN"
-
-      # Point the preview FE at the PREVIEW Supabase project so smoke exercises the
-      # same API bundle deploy-preview just shipped. Mirrors preview.yml: rewrite
-      # the env file `vercel build` actually reads (.vercel/.env.preview.local), the
-      # only file whose values win over a .env.local entry. Skipped when
-      # SUPABASE_ANON_KEY is unset — the pulled Vercel preview env values remain
-      # (which may target production); set it in the preview environment to
-      # guarantee the FE talks to the preview API.
-      - name: Override Supabase config with preview-project values
-        env:
-          PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-          ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-        run: |
-          ENV_FILE=".vercel/.env.preview.local"
-          if [ -z "$ANON_KEY" ]; then
-            echo "::warning::SUPABASE_ANON_KEY unset for the preview environment — the preview web build uses Vercel's pulled Supabase env, which may point at production. Set it to pin the FE at the preview API."
-            exit 0
-          fi
-          if [ ! -f "$ENV_FILE" ]; then
-            echo "::error::$ENV_FILE not found — did 'vercel pull' run?"
-            exit 1
-          fi
-          grep -vE '^(NEXT_PUBLIC_SUPABASE_URL|NEXT_PUBLIC_SUPABASE_ANON_KEY|NEXT_PUBLIC_SUPABASE_PROJECT_REF)=' \
-            "$ENV_FILE" > "$ENV_FILE.tmp" || true
-          mv "$ENV_FILE.tmp" "$ENV_FILE"
-          {
-            echo "NEXT_PUBLIC_SUPABASE_URL=https://${PROJECT_REF}.supabase.co"
-            echo "NEXT_PUBLIC_SUPABASE_PROJECT_REF=${PROJECT_REF}"
-            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${ANON_KEY}"
-          } >> "$ENV_FILE"
-
-      # A CLI build gets none of Vercel's auto-injected VERCEL_GIT_* system env
-      # vars, so set them by hand — instrumentation-client.ts bakes them into
-      # NEXT_PUBLIC_VCS_* (OTel VCS resource attributes) and service.version.
-      - name: Build (preview)
-        env:
-          VERCEL_GIT_REPO_OWNER: ${{ github.repository_owner }}
-          VERCEL_GIT_REPO_SLUG: ${{ github.event.repository.name }}
-          VERCEL_GIT_COMMIT_REF: ${{ github.ref_name }}
-          VERCEL_GIT_COMMIT_SHA: ${{ github.sha }}
-        run: vercel build --token="$VERCEL_TOKEN"
-
-      - name: Deploy to Vercel (preview)
+      # Shared build+deploy flow (see .github/actions/vercel-preview-deploy).
+      # Pins the FE at the PREVIEW Supabase project so smoke exercises the same
+      # API bundle deploy-preview just shipped; the override self-skips when the
+      # anon key is unset, leaving Vercel's pulled preview env in place.
+      - name: Deploy Vercel preview
         id: deploy
-        run: |
-          # Vercel prints the deployment URL to stdout and progress to stderr;
-          # grep the URL so a trailing stderr line is never mistaken for it.
-          out="$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")"
-          echo "$out"
-          URL="$(printf '%s\n' "$out" | grep -Eo 'https://[^[:space:]]+' | tail -1)"
-          if [ -z "$URL" ]; then
-            echo "::error::Could not parse Vercel preview deployment URL"
-            exit 1
-          fi
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/vercel-preview-deploy
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          supabase-project-ref: ${{ secrets.SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ secrets.SUPABASE_ANON_KEY }}
+          git-repo-owner: ${{ github.repository_owner }}
+          git-repo-slug: ${{ github.event.repository.name }}
+          git-commit-ref: ${{ github.ref_name }}
+          git-commit-sha: ${{ github.sha }}
 
       - name: Verify preview deployment responds
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -256,13 +256,17 @@ jobs:
             sleep 10
           done
 
-  # ── 1b. Deploy WEB to PREVIEW (Vercel) ────────────────────────────────────────
-  #    Builds the dashboard against the PREVIEW Supabase project and deploys a
-  #    Vercel preview, so the FE that smoke-preview exercises is the same bundle
-  #    the API preview just shipped. Runs in parallel with deploy-preview — a
-  #    Vercel build does not need the freshly-deployed functions to compile.
+  # ── 1b. Verify WEB build → PREVIEW (Vercel, BUILD-ONLY) ───────────────────────
+  #    Builds the dashboard against the PREVIEW Supabase project as a GATE — if
+  #    web changed, prove the FE still builds before we touch production — but
+  #    does NOT deploy (deploy: 'false'), so it spends ZERO Vercel deployment
+  #    quota. The deployment this used to create was pure waste: smoke-preview
+  #    tests the API only (it never hit the web URL — this job has no job-level
+  #    output), and production is promoted from the SEPARATE stage-web-production
+  #    build, never from this preview. Runs in parallel with deploy-preview — the
+  #    build needs no freshly-deployed functions to compile.
   deploy-web-preview:
-    name: Deploy web → preview (Vercel)
+    name: Verify web build → preview (Vercel, build-only)
     runs-on: ubuntu-latest
     needs: changes
     if: needs.changes.outputs.web == 'true'
@@ -273,11 +277,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
 
-      # Shared build+deploy flow (see .github/actions/vercel-preview-deploy).
-      # Pins the FE at the PREVIEW Supabase project so smoke exercises the same
-      # API bundle deploy-preview just shipped; the override self-skips when the
-      # anon key is unset, leaving Vercel's pulled preview env in place.
-      - name: Deploy Vercel preview
+      # Shared flow (see .github/actions/vercel-preview-deploy) in BUILD-ONLY mode
+      # (deploy: 'false' below): builds the FE against the PREVIEW Supabase project
+      # as a gate, creating no Vercel deployment. require-supabase-override warns
+      # if either preview secret is missing.
+      - name: Verify web build (preview, build-only)
         id: deploy
         uses: ./.github/actions/vercel-preview-deploy
         with:
@@ -293,20 +297,15 @@ jobs:
           git-repo-slug: ${{ github.event.repository.name }}
           git-commit-ref: ${{ github.ref_name }}
           git-commit-sha: ${{ github.sha }}
+          # Build-only gate: prove the FE builds against the preview backend, but
+          # create NO Vercel deployment — this preview was never smoke-tested and
+          # production promotes the separate stage-web-production build.
+          deploy: 'false'
 
-      - name: Verify preview deployment responds
-        env:
-          URL: ${{ steps.deploy.outputs.url }}
+      - name: Note build result
         run: |
-          CODE=$(curl -s -o /dev/null -w '%{http_code}' -L "$URL")
-          echo "### Web preview" >> "$GITHUB_STEP_SUMMARY"
-          echo "- URL: $URL (HTTP $CODE)" >> "$GITHUB_STEP_SUMMARY"
-          # Vercel deployment protection can return 401 for a raw preview URL;
-          # accept any non-5xx as "the build served".
-          if [ "$CODE" -ge 500 ]; then
-            echo "::error::Web preview returned HTTP $CODE"
-            exit 1
-          fi
+          echo "### Web build (preview backend)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Built the dashboard against the preview Supabase project as a gate (build-only — no Vercel deployment created)." >> "$GITHUB_STEP_SUMMARY"
 
   # ── 1c. STAGE web production build (Vercel, pre-built, no domain) ──────────────
   #    Builds the production dashboard bundle (against Vercel's PRODUCTION env, so

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -178,7 +178,7 @@ jobs:
       # Overrides the pulled preview env with the staging Supabase project so the
       # /preview build talks to staging, in lock-step with deploy.yml's
       # smoke-preview. This mutates only the runner's local copy for this one
-      # build; push-triggered Vercel previews never run this workflow.
+      # build; nothing is written back to Vercel's stored env.
       - name: Deploy Vercel preview
         id: deploy
         uses: ./.github/actions/vercel-preview-deploy

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -188,6 +188,9 @@ jobs:
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           supabase-project-ref: ${{ secrets.SUPABASE_PROJECT_REF }}
           supabase-anon-key: ${{ secrets.SUPABASE_ANON_KEY }}
+          # Always overrides at the staging Supabase project — warn (not silently
+          # fall back to the pulled env) if either secret is missing.
+          require-supabase-override: 'true'
           git-repo-owner: ${{ github.repository_owner }}
           git-repo-slug: ${{ github.event.repository.name }}
           git-commit-ref: ${{ needs.guard.outputs.pr_branch }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -174,83 +174,24 @@ jobs:
         with:
           ref: ${{ needs.guard.outputs.pr_sha }}
 
-      - name: Set up pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Install Vercel CLI
-        run: pnpm add -g vercel
-
-      - name: Pull Vercel environment
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: vercel pull --yes --environment=preview
-
-      # Overrides the Vercel-pulled preview vars with staging values by
-      # rewriting the env file `vercel pull` produced and `vercel build`
-      # actually reads (.vercel/.env.preview.local). Editing this file — not
-      # .env.local — is what guarantees the override: `vercel build` injects
-      # these values into process.env, and Next.js never lets a .env.local
-      # entry override a variable already set in process.env. We strip any
-      # pulled NEXT_PUBLIC_SUPABASE_* lines first so ours are the only
-      # definitions. This mutates only the runner's local copy for this one
-      # build; push-triggered Vercel previews never run this workflow, so
-      # their env is unchanged.
-      - name: Override Supabase config with staging values
-        env:
-          PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
-          ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-        run: |
-          ENV_FILE=".vercel/.env.preview.local"
-          if [ ! -f "$ENV_FILE" ]; then
-            echo "::error::$ENV_FILE not found — did 'vercel pull' run?"
-            exit 1
-          fi
-          # Drop any pulled Supabase vars so ours are the only definitions.
-          grep -vE '^(NEXT_PUBLIC_SUPABASE_URL|NEXT_PUBLIC_SUPABASE_ANON_KEY|NEXT_PUBLIC_SUPABASE_PROJECT_REF)=' \
-            "$ENV_FILE" > "$ENV_FILE.tmp" || true
-          mv "$ENV_FILE.tmp" "$ENV_FILE"
-          {
-            echo "NEXT_PUBLIC_SUPABASE_URL=https://${PROJECT_REF}.supabase.co"
-            echo "NEXT_PUBLIC_SUPABASE_PROJECT_REF=${PROJECT_REF}"
-            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=${ANON_KEY}"
-          } >> "$ENV_FILE"
-
-      - name: Build Vercel preview
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: vercel build
-
-      - name: Deploy to Vercel preview
+      # Shared build+deploy flow (see .github/actions/vercel-preview-deploy).
+      # Overrides the pulled preview env with the staging Supabase project so the
+      # /preview build talks to staging, in lock-step with deploy.yml's
+      # smoke-preview. This mutates only the runner's local copy for this one
+      # build; push-triggered Vercel previews never run this workflow.
+      - name: Deploy Vercel preview
         id: deploy
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-        run: |
-          # Vercel prints the deployment URL to stdout and progress to stderr;
-          # keep them separate (no 2>&1) and grep the URL so a trailing stderr
-          # line can never be mistaken for the deployment URL.
-          deploy_out="$(vercel deploy --prebuilt)"
-          echo "$deploy_out"
-          URL="$(printf '%s\n' "$deploy_out" | grep -Eo 'https://[^[:space:]]+' | tail -1)"
-          if [ -z "$URL" ]; then
-            echo "::error::Could not parse Vercel deployment URL"
-            exit 1
-          fi
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/vercel-preview-deploy
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          supabase-project-ref: ${{ secrets.SUPABASE_PROJECT_REF }}
+          supabase-anon-key: ${{ secrets.SUPABASE_ANON_KEY }}
+          git-repo-owner: ${{ github.repository_owner }}
+          git-repo-slug: ${{ github.event.repository.name }}
+          git-commit-ref: ${{ needs.guard.outputs.pr_branch }}
+          git-commit-sha: ${{ needs.guard.outputs.pr_sha }}
 
   smoke:
     name: Smoke test → preview API

--- a/SETUP.md
+++ b/SETUP.md
@@ -106,9 +106,11 @@ pnpm nx test mcp-core                            # needs supabase start
 | Output Directory | `.next` |
 | Install Command | `cd ../.. && pnpm install` |
 
-> Production auto-deploy on `main` is **off** (`packages/web/vercel.json` →
-> `git.deploymentEnabled.main = false`) — the `deploy.yml` pipeline promotes the
-> dashboard in lockstep with the API. PR preview deploys still work. See
+> Vercel Git auto-deploy is **off entirely** (`packages/web/vercel.json` →
+> `git.deploymentEnabled = false`), so Vercel deploys nothing on a Git push —
+> the `deploy.yml` pipeline promotes the dashboard to production in lockstep
+> with the API, and `ci.yml`'s `web-preview` job deploys PR previews, gated on
+> the `web` path filter so a PR with no web changes spends no quota. See
 > [docs/deployment.md](./docs/deployment.md).
 
 ---
@@ -119,7 +121,7 @@ pnpm nx test mcp-core                            # needs supabase start
 |--------|-------------|
 | `SUPABASE_PROJECT_REF` | Your project ref |
 | `SUPABASE_ACCESS_TOKEN` | From [supabase.com/dashboard/account/tokens](https://supabase.com/dashboard/account/tokens) |
-| `VERCEL_TOKEN` | Vercel access token (Account Settings → Tokens) — lets `deploy.yml` build + promote the web dashboard |
+| `VERCEL_TOKEN` | Vercel access token (Account Settings → Tokens) — lets `deploy.yml` build + promote the web dashboard, and `ci.yml`'s `web-preview` job deploy PR previews |
 | `VERCEL_ORG_ID` | From `.vercel/project.json` after `vercel link` (or Vercel project settings) |
 | `VERCEL_PROJECT_ID` | From `.vercel/project.json` after `vercel link` |
 | `LOREKIT_TELEMETRY_TOKEN` | Dash0 ingest-only token — the smoke/CI jobs pass it so their edge telemetry exports (tagged `deployment.environment.name=test`); also injected into the CLI tarball at publish by `release.yml`. Fork PRs without it skip telemetry gracefully. |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -26,10 +26,15 @@ and local operations.
 > pipeline. PR **previews** are deployed by `ci.yml`'s `web-preview` job, gated
 > on the `web` path filter — so a PR with no web changes creates **no** Vercel
 > deployment (and spends no quota), where the Git integration used to deploy on
-> every push. If you fork this, mirror the flag (or disable Git deployments in
-> the Vercel dashboard) or you will double-deploy.
+> every push. It goes further: on a web PR it **skips redeploying between commits
+> when no web file changed since that PR's last preview** (`web-preview`'s
+> "Decide" step diffs the current head against the SHA recorded in the sticky
+> preview comment via the compare API, and fails safe to deploy on any doubt), so
+> a burst of non-web commits spends one deployment, not one per push. If you fork
+> this, mirror the flag (or disable Git deployments in the Vercel dashboard) or
+> you will double-deploy.
 >
-> The three preview-deploy jobs (`ci.yml` `web-preview`, `deploy.yml`
+> The three preview jobs (`ci.yml` `web-preview`, `deploy.yml`
 > `deploy-web-preview`, `preview.yml` `deploy-web`) share one implementation:
 > the composite action **`.github/actions/vercel-preview-deploy`** (pull → build
 > on the runner → deploy prebuilt → return the URL; callers supply only the env
@@ -37,6 +42,14 @@ and local operations.
 > exist at the checked-out ref: `ci.yml`/`deploy.yml` always have it (they check
 > out the PR merge ref / `main`), but a `/preview` on a branch that predates this
 > action will fail to resolve it until that branch merges `main`.
+>
+> **`deploy.yml`'s `deploy-web-preview` runs the composite in BUILD-ONLY mode**
+> (`deploy: 'false'`): it builds the FE against the preview Supabase project as a
+> gate but creates **no** deployment. That deployment was pure quota waste —
+> `smoke-preview` tests the API only (it never fetched the web URL) and
+> production is promoted from the separate `stage-web-production` build, so
+> nothing consumed the preview. The build still fails the pipeline if the FE
+> can't compile.
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,6 +28,15 @@ and local operations.
 > deployment (and spends no quota), where the Git integration used to deploy on
 > every push. If you fork this, mirror the flag (or disable Git deployments in
 > the Vercel dashboard) or you will double-deploy.
+>
+> The three preview-deploy jobs (`ci.yml` `web-preview`, `deploy.yml`
+> `deploy-web-preview`, `preview.yml` `deploy-web`) share one implementation:
+> the composite action **`.github/actions/vercel-preview-deploy`** (pull → build
+> on the runner → deploy prebuilt → return the URL; callers supply only the env
+> to pin and the git ref to attribute). It is a **local** action, so it must
+> exist at the checked-out ref: `ci.yml`/`deploy.yml` always have it (they check
+> out the PR merge ref / `main`), but a `/preview` on a branch that predates this
+> action will fail to resolve it until that branch merges `main`.
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -17,14 +17,17 @@ production** with smoke gates and automatic rollback of both the functions and
 the web deployment. The manual commands below are for first-time project setup
 and local operations.
 
-> **The web dashboard is deployed by `deploy.yml`, not by Vercel's Git
-> integration.** Vercel's native auto-deploy on `main` is turned off
-> (`packages/web/vercel.json` → `git.deploymentEnabled.main = false`), so the FE
-> and API flip to production together instead of skewing apart — Vercel used to
-> deploy the frontend the instant `main` was pushed, while the API crawled
-> through the preview→smoke→prod pipeline. If you fork this, mirror the flag (or
-> disable Git deployments for `main` in the Vercel dashboard) or you will
-> double-deploy.
+> **The web dashboard is deployed by `deploy.yml` / `ci.yml`, not by Vercel's
+> Git integration.** Vercel's native auto-deploy is turned off entirely
+> (`packages/web/vercel.json` → `git.deploymentEnabled = false`). Production is
+> promoted by `deploy.yml`, so the FE and API flip to production together
+> instead of skewing apart — Vercel used to deploy the frontend the instant
+> `main` was pushed, while the API crawled through the preview→smoke→prod
+> pipeline. PR **previews** are deployed by `ci.yml`'s `web-preview` job, gated
+> on the `web` path filter — so a PR with no web changes creates **no** Vercel
+> deployment (and spends no quota), where the Git integration used to deploy on
+> every push. If you fork this, mirror the flag (or disable Git deployments in
+> the Vercel dashboard) or you will double-deploy.
 
 ---
 
@@ -34,7 +37,7 @@ Two GitHub Actions workflows own the lifecycle:
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| `.github/workflows/ci.yml` | PRs to `main` | **Verify before merge.** `check` (affected typecheck/test/lint — unit tests, all mocked) and `integration` (boots a local Supabase → migrations apply → serves the real Edge Functions → asserts an authenticated MCP `tools/list` returns 200, plus schema lint). `integration` only runs when API/backend paths change (see [below](#only-runs-when-relevant)); the web build is verified by Vercel's own PR check (preview deploys on a PR are unaffected — the `deploymentEnabled` flag only turns off the `main` production auto-deploy). |
+| `.github/workflows/ci.yml` | PRs to `main` | **Verify before merge.** `check` (affected typecheck/test/lint — unit tests, all mocked) and `integration` (boots a local Supabase → migrations apply → serves the real Edge Functions → asserts an authenticated MCP `tools/list` returns 200, plus schema lint). `integration` only runs when API/backend paths change (see [below](#only-runs-when-relevant)); the web build is verified by the `web-test` (Storybook) and `web-preview` (Vercel preview deploy) jobs, both gated on the `web` path filter so a PR with no web changes deploys nothing and spends no Vercel quota. |
 | `.github/workflows/deploy.yml` | push to `main`, `workflow_dispatch` | **Deploy the already-verified commit** — Supabase (migrations + Edge Functions) **and** the Vercel web dashboard, in lockstep. No test re-run — preview-first promotion only. |
 
 ### Tests run once, on the PR
@@ -755,14 +758,18 @@ In your Vercel project → Settings → General:
 | Output Directory | `.next` |
 | Install Command | `cd ../.. && pnpm install` |
 
-> **Production auto-deploy is off.** `packages/web/vercel.json` sets
-> `git.deploymentEnabled.main = false`, so Vercel no longer deploys the
-> production dashboard when `main` is pushed — `deploy.yml` promotes it instead
-> (see [FE ↔ API deploy in lockstep](#fe--api-deploy-in-lockstep-no-availability-skew)).
-> PR/branch preview deploys are unaffected. Create a **Vercel access token**
+> **Vercel Git auto-deploy is off.** `packages/web/vercel.json` sets
+> `git.deploymentEnabled = false`, so Vercel deploys nothing on a Git push —
+> `deploy.yml` promotes production (see [FE ↔ API deploy in lockstep](#fe--api-deploy-in-lockstep-no-availability-skew))
+> and `ci.yml`'s `web-preview` job deploys PR previews, gated on the `web` path
+> filter so unrelated PRs spend no quota. This also disables the dashboard's
+> Ignored Build Step approach, which still created (quota-counting) deployments
+> even when it skipped the build. Create a **Vercel access token**
 > (Account Settings → Tokens) and store it as the repo secret `VERCEL_TOKEN`,
 > alongside `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` (found in `.vercel/project.json`
-> after `vercel link`, or in the project's Settings).
+> after `vercel link`, or in the project's Settings). These three secrets are
+> repo-level, so `ci.yml`'s `web-preview` job reads them on PR runs (a fork PR
+> with no access self-skips green).
 
 Environment variables to add:
 

--- a/packages/web/vercel.json
+++ b/packages/web/vercel.json
@@ -5,8 +5,6 @@
   "installCommand": "cd ../.. && pnpm install",
   "framework": "nextjs",
   "git": {
-    "deploymentEnabled": {
-      "main": false
-    }
+    "deploymentEnabled": false
   }
 }


### PR DESCRIPTION
Vercel's native Git integration deployed a dashboard preview on **every** PR/branch push, so docs-only and backend-only PRs still burned Vercel Hobby daily-deploy quota (100/day) even though the Ignored Build Step skipped the build. This moves the preview into CI, path-gated, then cuts redundant deploys further and extracts the shared flow.

## What changed

**Stop deploying when nothing web-relevant changed**
- **`packages/web/vercel.json`** — disable Vercel Git auto-deploy entirely (`git.deploymentEnabled: false`). CLI deploys (deploy.yml prod promote, the CI job) are unaffected — the flag only gates Git-*triggered* auto-deploys.
- **`ci.yml` `web-preview`** — new job gated on the `web` path filter (no web change ⇒ no deployment). Plus an **incremental skip**: a "Decide" step diffs the current head against the SHA recorded in this PR's sticky preview comment (compare API) and skips the redeploy when no web file changed since the last preview — so a burst of non-web commits on a web PR spends **one** deployment, not one per push. Fails safe to deploy on any doubt (no prior preview, rebase/force-push, >300-file diff, API error). Posts a sticky preview-URL comment; non-blocking (not in the required `summary` gate); self-skips green on fork PRs without secrets.

**Don't deploy a preview nobody tests**
- **`deploy.yml` `deploy-web-preview`** — runs the shared flow in **build-only** mode (`deploy: 'false'`): builds the FE against the preview Supabase project as a gate but creates **no** deployment. `smoke-preview` only ever tested the API (it never fetched the web URL, and the job exposed no output), and production is promoted from the separate `stage-web-production` build — so the preview deployment was pure quota waste. The build still fails the pipeline if the FE can't compile.

**Share one implementation**
- **`.github/actions/vercel-preview-deploy/action.yml`** (new) — composite holding pull → *(optional Supabase override)* → build-on-runner → *(optional)* deploy-prebuilt → return URL. Consumed by all three preview jobs (`ci.yml` `web-preview`, `deploy.yml` `deploy-web-preview`, `preview.yml` `deploy-web`), which now supply only what differs. Actions inside are SHA-pinned; deploy step runs under `set -euo pipefail`. Inputs `require-supabase-override` (warn on an incomplete intended override) and `deploy` (build-only) let the callers diverge safely.
- **`preview.yml` `deploy-web`** — consumes the composite; drops a redundant standalone `pnpm install`, pins Vercel CLI to 58, gains `VERCEL_GIT_*` attribution, and its Supabase override is now the composite's conditional one (skips + warns if a secret is missing, vs the old unconditional write).

**Docs** — `docs/deployment.md` + `SETUP.md` updated.

## Result
- PRs with no web changes → **zero** Vercel deployments.
- Web PRs → one deployment per commit that actually changes web (not per push), built on the GitHub runner (no Vercel build minutes).
- Each web-merge to main → one fewer deployment (the preview is now build-only).

## Follow-up (separate PR)
- Gating the **Storybook** Vercel project (still on native Git integration, deploying on every push to every branch — likely the biggest quota drain). Deferred because it needs a new `VERCEL_STORYBOOK_PROJECT_ID` secret and is a hard cutover.

## Notes for the reviewer
- `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` must be **repo-level** Actions secrets (as deploy.yml already assumes).
- The composite is a **local** action, so a `/preview` on a branch predating it fails to resolve until that branch merges `main` (ci.yml/deploy.yml check out the merge ref / `main`, so they always have it).
- `ci.yml`'s `web-preview` checkout intentionally builds the PR **merge ref**; `git-commit-sha` is passed as the **head** SHA for VCS attribution.
- The `Web — Vercel preview` check may be red on the Vercel daily-deploy cap (`api-deployments-free-per-day`) — transient, non-blocking, not a code failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)