### PR TITLE
test(web): pin focus before the open-focus timer in the guard story

### DIFF
--- a/packages/web/src/components/lore/LessonDetailSheet.test.stories.tsx
+++ b/packages/web/src/components/lore/LessonDetailSheet.test.stories.tsx
@@ -206,14 +206,21 @@ export const OpenFocusSkipsWhenAlreadyInside: Story = {
   // both assertions below (same shape as ArchivedLoreIsPreviewOnly, written to
   // fail the pre-fix behaviour).
   play: async ({ step }) => {
-    await body().findByRole('dialog', { name: /memory detail/i });
+    // Place focus inside the dialog SYNCHRONOUSLY, before the first `await` can
+    // yield to the event loop and let the ~80 ms open-focus timer fire. The
+    // component is already mounted when `play` runs (the harness opens with the
+    // lesson set, and AnimatePresence renders its children on the mount commit),
+    // so the Edit tab is queryable with a synchronous `getByRole` — no async
+    // `findBy*` needed. Gating this focus behind an awaited query would race the
+    // timer: if the query resolved after ~80 ms the timer would already have run
+    // with focus OUTSIDE the panel, the guard's skip-branch would never be
+    // exercised, and the story would go green without testing the guard at all.
+    // A tab is focusable via .focus() (roving tabindex uses -1, not removal) and
+    // focusing it does not select it, so the panel is otherwise untouched.
+    const editTab = body().getByRole('tab', { name: /edit/i });
+    editTab.focus();
+    await expect(editTab).toHaveFocus();
     await step('focus placed inside the panel before the timer is not stolen', async () => {
-      // Place focus inside the dialog well within the ~80 ms open-focus window.
-      // A tab is focusable via .focus() (roving tabindex uses -1, not removal)
-      // and focusing it does not select it, so the panel is otherwise untouched.
-      const editTab = body().getByRole('tab', { name: /edit/i });
-      editTab.focus();
-      await expect(editTab).toHaveFocus();
       // Wait past the ~80 ms timer. With the guard this is a no-op; the pre-guard
       // unconditional focus would have pulled focus onto the close button by now.
       await new Promise((resolve) => setTimeout(resolve, 250));


### PR DESCRIPTION
Follow-up to #419 (merged). That PR added the `OpenFocusSkipsWhenAlreadyInside`
story, but its hardening commit landed a moment after #419 auto-merged, so it
never reached `main`. This PR carries just that one test-only fix.

**Problem.** The story acquired the Edit tab via an awaited async query
(`findByRole`) and only then focused it. If that query resolved after the
component's ~80ms open-focus timer, the timer had already run with focus
*outside* the panel — so the guard's skip-branch was never exercised, yet the
later `toHaveFocus` assertion could still pass. Vacuity-under-race, the same
focus-timer class the rest of the suite was hardened against.

**Fix.** Acquire the Edit tab with a **synchronous** query at the top of `play`
and focus it before any `await` yields, so focus is provably inside the dialog
before the 80ms window elapses; then advance past the timer and assert focus is
not stolen.

**Non-vacuity.** Mutation-tested: with the guard stripped (unconditional
`close.focus()`) the story FAILS; guard restored, component unchanged.

**Verification.** `vitest --config vitest.storybook.config.ts` green over two
consecutive runs (21 files / 70 tests), no visual-baseline shift.

Test-only change (one file); no product code. Docs: none — no user-facing
behavior, MCP tool, REST route, CLI, or config changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018o5zXxMPixfXKs2x4Px1FH)_