### PR TITLE
ci(web): refine update-baselines — visual-only scope + terminal reaction

### DIFF
--- a/.github/workflows/update-baselines.yml
+++ b/.github/workflows/update-baselines.yml
@@ -253,3 +253,14 @@ jobs:
               issue_number: number,
               body,
             });
+            // Close the loop on the triggering comment with a terminal reaction
+            // (rocket = done, confused = failed), mirroring preview.yml. Only a
+            // comment trigger has a reaction target; a dispatch run has none.
+            if (context.eventName === 'issue_comment') {
+              await github.rest.reactions.createForIssueComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: ok ? 'rocket' : 'confused',
+              });
+            }


### PR DESCRIPTION
## Why

Two refinements to the `update-baselines` workflow added in #433, the first prompted by a real failed run.

**Its first live run failed and committed nothing** ([run](https://github.com/mthines/lorekit/actions/runs/31322946261)). The cause wasn't the workflow — PR #424's branch has two failing Combobox *interaction* tests (Escape / click-outside not dismissing the listbox). But because the job ran `vitest -u` over the **whole** suite, that unrelated interaction failure aborted the job before the regenerated screenshots were committed — discarding the baseline refresh it was asked to do. `-u` only updates *visual* baselines; it can't fix a `play`-function assertion, and interaction stories set `chromatic.disableSnapshot` so they produce no baseline anyway. Running them here served no purpose except to introduce that failure mode.

## What changed

- **Scope the run to visual stories only** — `--exclude '**/*.test.stories.tsx'`. The tool's single responsibility is refreshing visual baselines; interaction correctness stays the `web-test` gate's job. No baseline coverage is lost (interaction stories generate none).
- **Terminal reaction on the comment** — after posting the result comment, react `rocket` on success / `confused` on failure, mirroring `preview.yml`. Gated to `issue_comment`, inside the existing `if: always()` step.
- Docs updated in `docs/storybook.md`.

## Not in scope (separate)

The two failing Combobox interaction tests are a real red on **#424** and need a code fix in that PR — they'd fail `web-test` regardless of this workflow.

## How to verify

- After merge, comment `/update-baselines` on a PR with intentional visual changes → 👀 immediately, then the baselines commit back and 🚀 lands (😕 on failure) alongside the result comment — even if that branch has unrelated failing interaction tests.