### PR TITLE
feat(evals): retrieval-relevance metrics harness (precision@k/recall@k/MRR)

### DIFF
--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -289,11 +289,94 @@ exactly what the relevance work will change; a harness that hard-coded it would
 be blind to the only change it exists to detect. Re-running the suite before and
 after that change is the intended measurement.
 
+## Retrieval relevance (precision@k / recall@k / MRR)
+
+A second, complementary measurement lives beside the `claude -p` arms: **does the
+retriever surface the _right_ lessons for a query in the first place?** The live
+arms measure whether an injected lesson changes the agent's output — the
+_downstream_ half. This measures the _upstream_ half — the ranking — as pure,
+deterministic **precision@k / recall@k / MRR** against a ground-truth set.
+
+> **This complements the live eval; it never gates it.** These metrics run under
+> `node --test` in milliseconds against fixtures, with no model, no network and
+> no sandbox. Nothing here is added to a CI gate, and the live `claude -p` path
+> is untouched.
+
+### Ground truth is pinned to the real outcome signal, in code
+
+The set of lessons that _should_ surface for a query is **not** a hand-authored
+label list — it is computed (`src/ground-truth.mjs`) from the memories the loop
+machinery itself treats as outcome/relevance signal:
+
+- a row qualifies iff the shipped `inferKindHost` (from `@lorekit/schemas`)
+  resolves its tags to an outcome/relevance bucket —
+  `loop::review-outcomes` (`host: review`) or
+  `loop::reviewer-comment-relevance` (`host: reviewer`); **and**
+- it matches the query repo (by scope, falling back to `origin_repo`; an
+  `origin_pr` pin narrows but is never required — the spec's match is
+  "`origin_pr` / repo scope matches", a disjunction); with
+- `seen_count` as the relevance **weight**, and `seen_count >= 3` marking a row
+  **recurrence-confirmed**.
+
+`ground-truth.mjs` imports `inferKindHost` and **never re-encodes** the literal
+`loop::…` strings — a local copy would keep passing while the product's bucket
+set moved underneath it (the recurring "mock that reimplements the thing under
+test" trap). A grep guard (`AC-1-reuse`) fails if the literals reappear.
+
+### The committed baseline is a 2-row BOOTSTRAP PLACEHOLDER
+
+`fixtures/ground-truth.seed.json` is a **BOOTSTRAP PLACEHOLDER**, not a real
+baseline. It holds the only two outcome/relevance-tagged rows that already exist
+in-repo — `audit::one-vocabulary` (`loop::reviewer-comment-relevance`, PR 311)
+and `rls::service-role-user-filter` (`loop::review-outcomes`) — lifted
+**metadata-only** from `packages/web/src/mocks/memories.ts` (rows m05, m06). Its
+`seenCount` is `0` because the mock carries no `seen_count` (that lives only in
+the hosted projection) — itself a tell that this is a seed, not a mined baseline.
+
+Every metrics object built on this seed carries a loud `baseline.warning`:
+
+> **The numbers this seed produces MUST NOT be used to gate downstream PRs
+> (e.g. A1/A4)** until `bin/mine-ground-truth.mjs` has been run against the
+> hosted store and a real `fixtures/ground-truth.real.json` snapshot has been
+> committed.
+
+### Making the baseline real: the `mine` runbook
+
+`bin/mine-ground-truth.mjs` is a **manual, one-shot** step. It is wired into no
+CI job, npm script, nx target or `node --test` file (`AC-7-nowire` keeps it that
+way), and it refuses to touch the network without `--confirm` **and** a usable
+remote connection. Running it — and committing its output — is the step, and the
+only step, that turns the placeholder baseline into a real one.
+
+```bash
+cd packages/evals
+# Requires a usable remote connection (run `lorekit install`, or set
+# LOREKIT_MCP_URL + LOREKIT_TOKEN). A bare run just prints usage + the
+# placeholder→real explanation and exits non-zero.
+node bin/mine-ground-truth.mjs --confirm --scope repo::mthines/lorekit
+# → writes fixtures/ground-truth.real.json (metadata only: scope, key, tags,
+#   origin_pr, seenCount — NEVER the lesson body), after a privacy pre-flight.
+git add fixtures/ground-truth.real.json && git commit -m "chore(evals): real relevance baseline"
+```
+
+The CLI token is **user-scoped**. A maintainer who needs a **cross-tenant**
+(service-role) read can set `LOREKIT_GROUND_TRUTH_SERVICE_ROLE=1` to acknowledge
+that intent and wire in `@lorekit/mcp-core`'s `createHostedAdapter`
+(`SUPABASE_SERVICE_ROLE_KEY`) — kept off the happy path because a service-role
+read can surface other users' rows, which must be an explicit choice.
+
+The **privacy pre-flight** (`privacyPreflight`) runs on the entries about to be
+written and aborts the whole write if any still carries a `value`/`body`, any
+non-metadata field, or a secret/PII-shaped string — the backstop behind
+`redactToMetadata`, which is where bodies are dropped.
+
 ## Docs applicability
 
 **User-facing docs, `llms.txt`, MDX and dashboard copy do not apply.**
 `@lorekit/evals` is a private internal research tool: it ships no MCP tool, REST
 route, CLI command or flag, config key, env var, scope rule, error contract or
-dashboard surface, and only consumes the existing CLI and store. Per
-`CLAUDE.md` → "User-facing docs", the rule fires on a user-observable capability
-change; there is none. This README is the documentation surface that applies.
+dashboard surface, and only consumes the existing CLI and store. The
+retrieval-relevance harness and its `mine` script are the same — a private
+maintenance tool with no user-observable surface. Per `CLAUDE.md` →
+"User-facing docs", the rule fires on a user-observable capability change; there
+is none. This README is the documentation surface that applies.

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -359,6 +359,14 @@ node bin/mine-ground-truth.mjs --confirm --scope repo::mthines/lorekit
 git add fixtures/ground-truth.real.json && git commit -m "chore(evals): real relevance baseline"
 ```
 
+The mine **walks every page** of `remote.list` (`hasMore` / `nextCursor`, the
+same termination `gatherStream` uses), so a tag with more than one page of rows
+is never frozen as a silently truncated snapshot; a repeating cursor or a walk
+past `MAX_PAGES` aborts with exit 4 and writes nothing. Its flags are strict:
+`--scope` and `--out` each require a present, non-empty value — `--confirm
+--scope` is a usage error rather than a run that quietly mines *every* scope —
+and an unrecognised flag is refused rather than ignored.
+
 The CLI token is **user-scoped**. A maintainer who needs a **cross-tenant**
 (service-role) read can set `LOREKIT_GROUND_TRUTH_SERVICE_ROLE=1` to acknowledge
 that intent and wire in `@lorekit/mcp-core`'s `createHostedAdapter`

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -367,11 +367,16 @@ past `MAX_PAGES` aborts with exit 4 and writes nothing. Its flags are strict:
 --scope` is a usage error rather than a run that quietly mines *every* scope —
 and an unrecognised flag is refused rather than ignored.
 
-The CLI token is **user-scoped**. A maintainer who needs a **cross-tenant**
-(service-role) read can set `LOREKIT_GROUND_TRUTH_SERVICE_ROLE=1` to acknowledge
-that intent and wire in `@lorekit/mcp-core`'s `createHostedAdapter`
-(`SUPABASE_SERVICE_ROLE_KEY`) — kept off the happy path because a service-role
-read can surface other users' rows, which must be an explicit choice.
+The CLI token is **user-scoped**, and so is every mine this script performs — it
+does **not** implement a cross-tenant read. A maintainer who needs one wires
+`@lorekit/mcp-core`'s `createHostedAdapter` (`SUPABASE_SERVICE_ROLE_KEY`) in by
+hand; it is kept off the happy path because a service-role read can surface other
+users' rows, which must be an explicit choice.
+
+`LOREKIT_GROUND_TRUTH_SERVICE_ROLE=1` is an **acknowledgement flag, not a
+switch**: setting it does not widen the read, and the script prints a notice
+saying exactly that, so a user-scoped mine is never mistaken for a cross-tenant
+one.
 
 The **privacy pre-flight** (`privacyPreflight`) runs on the entries about to be
 written and aborts the whole write if any still carries a `value`/`body`, any

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -362,7 +362,10 @@ git add fixtures/ground-truth.real.json && git commit -m "chore(evals): real rel
 The mine **walks every page** of `remote.list` (`hasMore` / `nextCursor`, the
 same termination `gatherStream` uses), so a tag with more than one page of rows
 is never frozen as a silently truncated snapshot; a repeating cursor or a walk
-past `MAX_PAGES` aborts with exit 4 and writes nothing. Its flags are strict:
+past `MAX_PAGES` aborts with exit 4 and writes nothing. A **zero-row** mine is
+refused too (exit 5): an empty ground truth scores `recallAtK = 1` by design
+("nothing to miss"), so an empty `real-hosted-snapshot` would look perfect while
+measuring nothing. Its flags are strict:
 `--scope` and `--out` each require a present, non-empty value — `--confirm
 --scope` is a usage error rather than a run that quietly mines *every* scope —
 and an unrecognised flag is refused rather than ignored.

--- a/packages/evals/bin/mine-ground-truth.mjs
+++ b/packages/evals/bin/mine-ground-truth.mjs
@@ -42,6 +42,10 @@ export const OUTCOME_TAGS = [
   "loop::reviewer-comment-relevance",
 ];
 
+/** Rows per `remote.list` page, and the page ceiling the cursor walk refuses past. */
+export const PAGE_LIMIT = 100;
+export const MAX_PAGES = 100;
+
 /** The ONLY fields a mined entry may carry. A lesson body is never among them. */
 export const METADATA_FIELDS = ["scope", "key", "tags", "origin_pr", "seenCount"];
 
@@ -221,15 +225,51 @@ export async function main(
 
   // Query each outcome tag and union the rows (server-side ANY match would also
   // work; querying per-tag keeps the intent explicit and the round-trips small).
+  //
+  // PAGINATED. `remote.list` caps a page at `limit` and reports `hasMore` +
+  // `nextCursor`; reading only the first page would freeze a SILENTLY TRUNCATED
+  // snapshot whose header calls it safe to gate PRs on. The cursor walk mirrors
+  // `gatherStream` in `@lorekit/cli/src/lessons-view.mjs` — the same
+  // `!hasMore || !nextCursor → stop` termination the read commands use, so a
+  // local store (which returns everything in one page and no cursor) still ends
+  // after one iteration.
   const byKey = new Map();
   for (const tag of OUTCOME_TAGS) {
-    const res = await remote.list({ scope: args.scope, tags: [tag], limit: 100 });
-    if (!res || res.ok === false) {
-      err(`remote.list failed for tag ${tag}: ${res?.error ?? "unknown error"}`);
-      return 4;
-    }
-    for (const row of res.entries ?? []) {
-      byKey.set(`${row.scope}::${row.key}`, row);
+    let cursor;
+    let pages = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const res = await remote.list({
+        scope: args.scope,
+        tags: [tag],
+        limit: PAGE_LIMIT,
+        ...(cursor ? { cursor } : {}),
+      });
+      if (!res || res.ok === false) {
+        err(`remote.list failed for tag ${tag}: ${res?.error ?? "unknown error"}`);
+        return 4;
+      }
+      for (const row of res.entries ?? []) {
+        byKey.set(`${row.scope}::${row.key}`, row);
+      }
+      pages += 1;
+      if (!res.hasMore || !res.nextCursor) break;
+      // A server that repeats a cursor would spin forever; refuse rather than
+      // hang, and refuse rather than write a snapshot we know is partial.
+      if (res.nextCursor === cursor) {
+        err(
+          `remote.list returned a repeating cursor for tag ${tag}; refusing to write a possibly partial snapshot.`,
+        );
+        return 4;
+      }
+      if (pages >= MAX_PAGES) {
+        err(
+          `remote.list still reports more rows for tag ${tag} after ${MAX_PAGES} pages (${PAGE_LIMIT}/page). ` +
+            "Refusing to write a TRUNCATED snapshot — narrow --scope and re-run.",
+        );
+        return 4;
+      }
+      cursor = res.nextCursor;
     }
   }
 

--- a/packages/evals/bin/mine-ground-truth.mjs
+++ b/packages/evals/bin/mine-ground-truth.mjs
@@ -326,6 +326,21 @@ export async function main(
   const redacted = [...byKey.values()].map(redactToMetadata);
   const entries = privacyPreflight(redacted); // throws → abort before any write
 
+  // The THIRD way this snapshot can be untrustworthy, alongside truncated and
+  // partial: EMPTY. An empty baseline is worse than a truncated one, because
+  // `recallAtK` returns 1 for an empty ground truth ("nothing to miss") — so a
+  // zero-row mine would score PERFECTLY, stamped `real-hosted-snapshot`, with no
+  // warning anywhere. Nothing is written; the operator gets the two ordinary
+  // causes to check.
+  if (entries.length === 0) {
+    err(
+      `No outcome/relevance rows found for scope ${args.scope} (tags: ${OUTCOME_TAGS.join(", ")}). ` +
+        "Refusing to write an EMPTY baseline — it would score a perfect recall against nothing. " +
+        "Check --scope, and that this token can see those rows. Nothing was written.",
+    );
+    return 5;
+  }
+
   const snapshot = {
     _README:
       "REAL retrieval-relevance baseline mined from the hosted store. Metadata only — no lesson bodies. Safe to commit and to gate downstream PRs against, subject to review.",

--- a/packages/evals/bin/mine-ground-truth.mjs
+++ b/packages/evals/bin/mine-ground-truth.mjs
@@ -29,6 +29,8 @@ import path from "node:path";
 import process from "node:process";
 import { fileURLToPath } from "node:url";
 
+import { seenCountOf } from "../src/ground-truth.mjs";
+
 const FIXTURES = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
@@ -55,17 +57,18 @@ export const METADATA_FIELDS = ["scope", "key", "tags", "origin_pr", "seenCount"
  * point every emitted entry passes through.
  */
 export function redactToMetadata(row) {
-  const seenCount =
-    row?.seenCount ?? row?.seen_count ?? null;
+  // ABSENT stays `null` (the placeholder tell: the seed carries no count at
+  // all), but a PRESENT count is read with the same coercion `seenCountOf`
+  // applies — the hosted projection hands `seen_count` back as a string on some
+  // paths, and a local re-implementation that required a `number` mined it as
+  // `null` and had it later weighted 0.
+  const raw = row?.seenCount ?? row?.seen_count ?? null;
   return {
     scope: row?.scope ?? null,
     key: row?.key ?? null,
     tags: Array.isArray(row?.tags) ? [...row.tags] : [],
     origin_pr: row?.origin_pr ?? null,
-    seenCount:
-      typeof seenCount === "number" && Number.isFinite(seenCount)
-        ? Math.max(0, Math.floor(seenCount))
-        : null,
+    seenCount: raw == null ? null : seenCountOf({ seenCount: raw }),
   };
 }
 

--- a/packages/evals/bin/mine-ground-truth.mjs
+++ b/packages/evals/bin/mine-ground-truth.mjs
@@ -17,13 +17,17 @@
 //
 // REUSE, NOT A NEW CLIENT. The query goes through the CLI's shipped remote store
 // (`resolveStores` → `remote.list({ scope, tags })`), which is the same
-// server-side `overlaps('tags', …)` path the product uses. A maintainer who
-// needs a cross-tenant (service-role) read — the CLI token is user-scoped — can
-// set LOREKIT_GROUND_TRUTH_SERVICE_ROLE=1 to acknowledge that intent; the wiring
-// for `@lorekit/mcp-core`'s `createHostedAdapter` (SUPABASE_SERVICE_ROLE_KEY) is
-// documented in the README runbook rather than defaulted on, because a
-// service-role read can surface OTHER users' rows and that must be an explicit
-// choice, never the happy path.
+// server-side `overlaps('tags', …)` path the product uses. That store is always
+// USER-SCOPED (the CLI token is), and this script does NOT implement a
+// cross-tenant read: a maintainer who needs one wires `@lorekit/mcp-core`'s
+// `createHostedAdapter` (SUPABASE_SERVICE_ROLE_KEY) by hand per the README
+// runbook, because a service-role read can surface OTHER users' rows and that
+// must be an explicit choice, never the happy path.
+//
+// LOREKIT_GROUND_TRUTH_SERVICE_ROLE=1 is therefore an ACKNOWLEDGEMENT flag, not
+// a switch. Setting it does not widen the read; the script says so out loud
+// (`SERVICE_ROLE_NOTICE`) rather than letting an operator believe a cross-tenant
+// mine happened when a user-scoped one did.
 import fsp from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
@@ -153,9 +157,19 @@ const USAGE = `mine-ground-truth — freeze a real retrieval-relevance baseline 
     --out       Output path (default: fixtures/ground-truth.real.json).
 
   A usable remote connection is required (run \`lorekit install\` or set
-  LOREKIT_MCP_URL + LOREKIT_TOKEN). Set LOREKIT_GROUND_TRUTH_SERVICE_ROLE=1 only
-  if you intend a cross-tenant service-role read (see the README runbook).
+  LOREKIT_MCP_URL + LOREKIT_TOKEN). The read is ALWAYS user-scoped: this script
+  does not implement a cross-tenant service-role read, and
+  LOREKIT_GROUND_TRUTH_SERVICE_ROLE=1 only acknowledges that intent — the
+  \`createHostedAdapter\` wiring is manual (see the README runbook).
 `;
+
+/** The env var that acknowledges cross-tenant intent, and the notice it earns. */
+export const SERVICE_ROLE_ENV = "LOREKIT_GROUND_TRUTH_SERVICE_ROLE";
+export const SERVICE_ROLE_NOTICE =
+  `${SERVICE_ROLE_ENV}=1 is set, but this script does NOT implement a cross-tenant ` +
+  "service-role read — the mine below is USER-SCOPED via the CLI token. Wire " +
+  "@lorekit/mcp-core's createHostedAdapter (SUPABASE_SERVICE_ROLE_KEY) by hand per " +
+  "the README runbook if you need one.";
 
 /**
  * Is `raw` a missing value for a value-taking flag — end of argv, or the NEXT
@@ -233,6 +247,12 @@ export async function main(
     );
     err(USAGE);
     return 2;
+  }
+
+  // The acknowledgement flag is READ, so setting it is never silently inert —
+  // it earns an explicit "this did not widen the read" notice.
+  if (process.env[SERVICE_ROLE_ENV]) {
+    err(SERVICE_ROLE_NOTICE);
   }
 
   // Only now do we reach for the store. Import lazily so the refusal path above

--- a/packages/evals/bin/mine-ground-truth.mjs
+++ b/packages/evals/bin/mine-ground-truth.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+// `mine-ground-truth` — the one-shot, MANUAL step that turns the placeholder
+// retrieval-relevance baseline into a real one.
+//
+// It queries the HOSTED store for the outcome/relevance-tagged memories
+// (`loop::review-outcomes`, `loop::reviewer-comment-relevance`) and freezes a
+// METADATA-ONLY snapshot at `fixtures/ground-truth.real.json` — scope, key,
+// tags, origin_pr, seenCount, and NOTHING ELSE. No lesson body ever leaves the
+// hosted store through this script.
+//
+// It is deliberately NOT wired into any CI job, npm script, nx target or
+// `node --test` file: `AC-7-nowire` greps to keep it that way. A bare run prints
+// usage and the placeholder→real explanation and exits non-zero; a real run
+// requires BOTH `--confirm` AND a usable remote connection. This is the
+// executable form of "the committed baseline is a placeholder until someone
+// deliberately mines the real one".
+//
+// REUSE, NOT A NEW CLIENT. The query goes through the CLI's shipped remote store
+// (`resolveStores` → `remote.list({ scope, tags })`), which is the same
+// server-side `overlaps('tags', …)` path the product uses. A maintainer who
+// needs a cross-tenant (service-role) read — the CLI token is user-scoped — can
+// set LOREKIT_GROUND_TRUTH_SERVICE_ROLE=1 to acknowledge that intent; the wiring
+// for `@lorekit/mcp-core`'s `createHostedAdapter` (SUPABASE_SERVICE_ROLE_KEY) is
+// documented in the README runbook rather than defaulted on, because a
+// service-role read can surface OTHER users' rows and that must be an explicit
+// choice, never the happy path.
+import fsp from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const FIXTURES = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "fixtures",
+);
+export const REAL_SNAPSHOT_PATH = path.join(FIXTURES, "ground-truth.real.json");
+
+/** The two loop tags that define the outcome/relevance signal, ANY-matched. */
+export const OUTCOME_TAGS = [
+  "loop::review-outcomes",
+  "loop::reviewer-comment-relevance",
+];
+
+/** The ONLY fields a mined entry may carry. A lesson body is never among them. */
+export const METADATA_FIELDS = ["scope", "key", "tags", "origin_pr", "seenCount"];
+
+/**
+ * Project a store row down to the metadata-only shape. Anything not in
+ * METADATA_FIELDS — crucially `value`/`body` — is dropped here, at the one choke
+ * point every emitted entry passes through.
+ */
+export function redactToMetadata(row) {
+  const seenCount =
+    row?.seenCount ?? row?.seen_count ?? null;
+  return {
+    scope: row?.scope ?? null,
+    key: row?.key ?? null,
+    tags: Array.isArray(row?.tags) ? [...row.tags] : [],
+    origin_pr: row?.origin_pr ?? null,
+    seenCount:
+      typeof seenCount === "number" && Number.isFinite(seenCount)
+        ? Math.max(0, Math.floor(seenCount))
+        : null,
+  };
+}
+
+// Secret-shaped patterns. Deliberately broad — this runs on METADATA that should
+// never contain a credential in the first place, so a false positive (which
+// aborts the write) is far cheaper than leaking one. It is the backstop behind
+// `redactToMetadata`, not the primary defence.
+const SECRET_PATTERNS = [
+  /\bsk-[A-Za-z0-9]{16,}\b/, // OpenAI-style
+  /\bghp_[A-Za-z0-9]{20,}\b/, // GitHub PAT
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/, // Slack
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/, // JWT
+  /\bAKIA[0-9A-Z]{16}\b/, // AWS access key id
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/, // PEM private key
+  /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/, // email (PII)
+];
+
+/**
+ * The privacy pre-flight. Runs on the ENTRIES ABOUT TO BE WRITTEN, and throws —
+ * aborting the whole write — if any entry:
+ *   1. still carries a body key (`value`/`body`) that redaction should have
+ *      dropped, or any key outside METADATA_FIELDS; or
+ *   2. contains a secret-shaped or PII-shaped string in any of its values.
+ *
+ * Returns the entries unchanged on success so it reads as a pass-through guard:
+ * `write(privacyPreflight(entries))`.
+ */
+export function privacyPreflight(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  const allowed = new Set(METADATA_FIELDS);
+  for (const [i, entry] of list.entries()) {
+    if (!entry || typeof entry !== "object") {
+      throw new Error(`privacyPreflight: entry ${i} is not an object`);
+    }
+    for (const key of Object.keys(entry)) {
+      if (key === "value" || key === "body") {
+        throw new Error(
+          `privacyPreflight: entry ${i} (${entry.key}) still carries a "${key}" — lesson bodies must never be emitted`,
+        );
+      }
+      if (!allowed.has(key)) {
+        throw new Error(
+          `privacyPreflight: entry ${i} (${entry.key}) carries a non-metadata field "${key}"; only ${METADATA_FIELDS.join(", ")} are permitted`,
+        );
+      }
+    }
+    const haystack = JSON.stringify(entry);
+    for (const pattern of SECRET_PATTERNS) {
+      if (pattern.test(haystack)) {
+        throw new Error(
+          `privacyPreflight: entry ${i} (${entry.key}) contains a secret/PII-shaped string matching ${pattern} — refusing to write`,
+        );
+      }
+    }
+  }
+  return list;
+}
+
+const USAGE = `mine-ground-truth — freeze a real retrieval-relevance baseline from the hosted store
+
+  This is a MANUAL, one-shot maintenance step. It is not run by CI, by any npm
+  script, or by \`node --test\`.
+
+  What it does:
+    Queries the hosted LoreKit store for outcome/relevance-tagged memories
+    (${OUTCOME_TAGS.join(", ")}) and writes a METADATA-ONLY snapshot
+    (scope, key, tags, origin_pr, seenCount — never the lesson body) to
+    fixtures/ground-truth.real.json, after a privacy pre-flight.
+
+  Placeholder → real:
+    Until this script has run, the harness scores against the 2-row BOOTSTRAP
+    PLACEHOLDER seed (fixtures/ground-truth.seed.json). Those numbers MUST NOT be
+    used to gate downstream PRs (A1/A4). Running this script against the hosted
+    store and committing fixtures/ground-truth.real.json is the step — and the
+    only step — that turns the placeholder baseline into a real one.
+
+  Usage:
+    node bin/mine-ground-truth.mjs --confirm [--scope <repo::owner/name>] [--out <path>]
+
+    --confirm   Required. Without it, nothing is queried or written.
+    --scope     Repo scope to mine (default: repo::mthines/lorekit).
+    --out       Output path (default: fixtures/ground-truth.real.json).
+
+  A usable remote connection is required (run \`lorekit install\` or set
+  LOREKIT_MCP_URL + LOREKIT_TOKEN). Set LOREKIT_GROUND_TRUTH_SERVICE_ROLE=1 only
+  if you intend a cross-tenant service-role read (see the README runbook).
+`;
+
+/** Minimal, dependency-free arg parse. */
+export function parseMineArgs(argv = []) {
+  const out = {
+    confirm: false,
+    scope: "repo::mthines/lorekit",
+    out: REAL_SNAPSHOT_PATH,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--confirm") out.confirm = true;
+    else if (a === "--scope") out.scope = argv[++i];
+    else if (a === "--out") out.out = argv[++i];
+    else if (a === "--help" || a === "-h") out.help = true;
+    else throw new Error(`unknown option "${a}"`);
+  }
+  return out;
+}
+
+/**
+ * Entry point. Returns a process exit code (never calls `process.exit` itself so
+ * it stays testable). Prints to the injected `log`/`err` sinks (default
+ * console) so a test can assert on output with no capture plumbing.
+ *
+ * IMPORTANT: with no `--confirm`, this returns BEFORE resolving any store or
+ * touching the network — the refusal is pure argument validation, so `main([])`
+ * in a test with no token configured makes zero network calls.
+ */
+export async function main(
+  argv = [],
+  { log = console.log, err = console.error, deps = {} } = {},
+) {
+  let args;
+  try {
+    args = parseMineArgs(argv);
+  } catch (e) {
+    err(String(e.message));
+    err(USAGE);
+    return 2;
+  }
+  if (args.help) {
+    log(USAGE);
+    return 0;
+  }
+  if (!args.confirm) {
+    err(
+      "Refusing to run without --confirm. This script mines a REAL baseline from the hosted store.",
+    );
+    err(USAGE);
+    return 2;
+  }
+
+  // Only now do we reach for the store. Import lazily so the refusal path above
+  // never even loads the CLI store module.
+  const { resolveStores } =
+    deps.resolveStores
+      ? { resolveStores: deps.resolveStores }
+      : await import("@lorekit/cli/src/stores.mjs");
+
+  const { remote, connection } = resolveStores(process.cwd(), {
+    env: process.env,
+  });
+  if (!remote || !remote.usable()) {
+    err(
+      `No usable remote connection (endpoint=${connection?.endpoint ?? "none"}). ` +
+        "Run `lorekit install` or set LOREKIT_MCP_URL + LOREKIT_TOKEN. Nothing was written.",
+    );
+    return 3;
+  }
+
+  // Query each outcome tag and union the rows (server-side ANY match would also
+  // work; querying per-tag keeps the intent explicit and the round-trips small).
+  const byKey = new Map();
+  for (const tag of OUTCOME_TAGS) {
+    const res = await remote.list({ scope: args.scope, tags: [tag], limit: 100 });
+    if (!res || res.ok === false) {
+      err(`remote.list failed for tag ${tag}: ${res?.error ?? "unknown error"}`);
+      return 4;
+    }
+    for (const row of res.entries ?? []) {
+      byKey.set(`${row.scope}::${row.key}`, row);
+    }
+  }
+
+  const redacted = [...byKey.values()].map(redactToMetadata);
+  const entries = privacyPreflight(redacted); // throws → abort before any write
+
+  const snapshot = {
+    _README:
+      "REAL retrieval-relevance baseline mined from the hosted store. Metadata only — no lesson bodies. Safe to commit and to gate downstream PRs against, subject to review.",
+    source: "real-hosted-snapshot",
+    scope: args.scope,
+    minedAt: new Date().toISOString(),
+    entries,
+  };
+  await fsp.writeFile(args.out, JSON.stringify(snapshot, null, 2) + "\n", "utf8");
+  log(
+    `Wrote ${entries.length} metadata-only entries to ${args.out} (source: real-hosted-snapshot).`,
+  );
+  return 0;
+}
+
+// Only auto-run when invoked directly, never on import.
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  main(process.argv.slice(2)).then((code) => {
+    process.exitCode = code;
+  });
+}

--- a/packages/evals/bin/mine-ground-truth.mjs
+++ b/packages/evals/bin/mine-ground-truth.mjs
@@ -154,18 +154,45 @@ const USAGE = `mine-ground-truth — freeze a real retrieval-relevance baseline 
   if you intend a cross-tenant service-role read (see the README runbook).
 `;
 
-/** Minimal, dependency-free arg parse. */
+/**
+ * Is `raw` a missing value for a value-taking flag — end of argv, or the NEXT
+ * flag? `--confirm --scope` must not leave `scope` undefined (which would mine
+ * EVERY scope), and `--scope --confirm` must not swallow the confirm flag.
+ * A value-taking flag that consumes the next FLAG is wrong regardless of how
+ * safe its own default happens to be.
+ */
+function isMissingValue(raw) {
+  return raw === undefined || (typeof raw === "string" && raw.startsWith("-"));
+}
+
+/**
+ * Minimal, dependency-free arg parse.
+ *
+ * Every value-taking flag answers the same three questions, so no sibling is
+ * left behind: is a value PRESENT (`isMissingValue`), is it WELL-FORMED for this
+ * flag (non-empty), and is the flag itself RECOGNISED (the `else` throw closes
+ * the set, so a typo like `--scpoe` is a usage error, never a silent widening).
+ */
 export function parseMineArgs(argv = []) {
   const out = {
     confirm: false,
     scope: "repo::mthines/lorekit",
     out: REAL_SNAPSHOT_PATH,
   };
+  const valueFor = (flag, raw) => {
+    if (isMissingValue(raw)) {
+      throw new Error(`${flag} requires a value`);
+    }
+    if (raw.trim() === "") {
+      throw new Error(`${flag} requires a non-empty value`);
+    }
+    return raw;
+  };
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
     if (a === "--confirm") out.confirm = true;
-    else if (a === "--scope") out.scope = argv[++i];
-    else if (a === "--out") out.out = argv[++i];
+    else if (a === "--scope") out.scope = valueFor("--scope", argv[++i]);
+    else if (a === "--out") out.out = valueFor("--out", argv[++i]);
     else if (a === "--help" || a === "-h") out.help = true;
     else throw new Error(`unknown option "${a}"`);
   }

--- a/packages/evals/fixtures/ground-truth.seed.json
+++ b/packages/evals/fixtures/ground-truth.seed.json
@@ -1,0 +1,22 @@
+{
+  "_README": "BOOTSTRAP PLACEHOLDER — do NOT treat as a real baseline. These are the only two outcome/relevance-tagged rows that already exist in-repo, lifted (metadata only) from packages/web/src/mocks/memories.ts (rows m05 and m06). They exist so the retrieval-relevance harness has SOMETHING to score against before the hosted store has been mined. The numbers this seed produces MUST NOT be used to gate downstream PRs (e.g. A1/A4). Run `node bin/mine-ground-truth.mjs --confirm` against the hosted store to produce the real fixtures/ground-truth.real.json snapshot; that run — not this file — is what turns the placeholder baseline into a real one. seenCount is 0 here because the mock rows carry no seen_count (it lives only in the hosted projection), which is itself a tell that this is a placeholder and not a mined baseline.",
+  "source": "bootstrap-seed",
+  "origin": "packages/web/src/mocks/memories.ts (rows m05, m06)",
+  "mustNotGate": "MUST NOT be used to gate downstream PRs (A1/A4) until mine-ground-truth has run against hosted and fixtures/ground-truth.real.json is committed.",
+  "entries": [
+    {
+      "scope": "repo::mthines/lorekit",
+      "key": "audit::one-vocabulary",
+      "tags": ["audit", "loop::reviewer-comment-relevance"],
+      "origin_pr": 311,
+      "seenCount": 0
+    },
+    {
+      "scope": "repo::mthines/lorekit",
+      "key": "rls::service-role-user-filter",
+      "tags": ["security", "rls", "loop::review-outcomes"],
+      "origin_pr": null,
+      "seenCount": 0
+    }
+  ]
+}

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -17,6 +17,9 @@
     "@lorekit/core": "workspace:*",
     "@lorekit/schemas": "workspace:*"
   },
+  "devDependencies": {
+    "@lorekit/web": "workspace:*"
+  },
   "scripts": {
     "test": "node --test test/*.test.mjs",
     "eval": "node bin/run-eval.mjs"

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -14,7 +14,8 @@
   },
   "dependencies": {
     "@lorekit/cli": "workspace:*",
-    "@lorekit/core": "workspace:*"
+    "@lorekit/core": "workspace:*",
+    "@lorekit/schemas": "workspace:*"
   },
   "scripts": {
     "test": "node --test test/*.test.mjs",

--- a/packages/evals/src/ground-truth.mjs
+++ b/packages/evals/src/ground-truth.mjs
@@ -109,8 +109,13 @@ export function shouldSurface(row, query = {}) {
 
   const wantRepo = repoOfQuery(query);
   if (wantRepo) {
-    const rowRepo = repoOfScope(row.scope) ?? row.origin_repo ?? null;
-    if (rowRepo !== wantRepo) return false;
+    // A real disjunction, as documented: `??` would consult `origin_repo` ONLY
+    // when the scope names no repo, so a row scoped to another repo but
+    // ORIGINATING in this one was dropped outright — the opposite of "scope
+    // matches OR origin_repo matches".
+    const scopeRepo = repoOfScope(row.scope);
+    const originRepo = typeof row.origin_repo === "string" ? row.origin_repo : null;
+    if (scopeRepo !== wantRepo && originRepo !== wantRepo) return false;
   }
 
   // A PR pin narrows only when the row actually declares one; a null-PR row is

--- a/packages/evals/src/ground-truth.mjs
+++ b/packages/evals/src/ground-truth.mjs
@@ -26,8 +26,20 @@ import { inferKindHost } from "@lorekit/schemas/tags";
  */
 export const RECURRENCE_CONFIRMED_AT = 3;
 
-/** The two buckets the spec names as the outcome signal, by their resolved host. */
+/**
+ * The two buckets the spec names as the outcome signal, identified by the
+ * `{ kind, host }` the shipped resolver returns.
+ *
+ * HOST ALONE IS NOT ENOUGH. `inferKindHost` maps `loop::<host>-lessons` to that
+ * host, so a plain `loop::reviewer-lessons` row also resolves to host
+ * `reviewer` — it would clear a host-only check and pollute the ground truth
+ * with ordinary lessons. The outcome buckets are the NON-lesson kinds: the
+ * `bus` (`host: review`) and the `signal` (`host: reviewer`). Gating on the
+ * pair keeps the classification owned by `@lorekit/schemas` while excluding
+ * every `lesson` bucket, present or future.
+ */
 const OUTCOME_HOSTS = new Set(["review", "reviewer"]);
+const OUTCOME_KINDS = new Set(["bus", "signal"]);
 
 /**
  * Read a non-negative integer `seen_count` off a row in either shape the stores
@@ -76,7 +88,9 @@ export function repoOfQuery(query = {}) {
  *
  * A row qualifies iff BOTH hold:
  *   1. its tags resolve (via the shipped `inferKindHost`) to an outcome/relevance
- *      bucket — `host` ∈ {review, reviewer}; and
+ *      bucket — `kind` ∈ {bus, signal} AND `host` ∈ {review, reviewer}. The kind
+ *      half is load-bearing: a `loop::reviewer-lessons` row resolves to host
+ *      `reviewer` too, and a host-only check would admit it; and
  *   2. it matches the query repo. Match is a DISJUNCTION, per the spec's
  *      "`origin_pr` / repo scope matches": the row's scope names the query repo,
  *      OR its `origin_repo` does. `origin_pr`, when the query pins one, further
@@ -89,8 +103,9 @@ export function repoOfQuery(query = {}) {
 export function shouldSurface(row, query = {}) {
   if (!row || typeof row !== "object") return false;
 
-  const { host } = inferKindHost(row.tags);
+  const { kind, host } = inferKindHost(row.tags);
   if (!host || !OUTCOME_HOSTS.has(host)) return false;
+  if (!kind || !OUTCOME_KINDS.has(kind)) return false;
 
   const wantRepo = repoOfQuery(query);
   if (wantRepo) {

--- a/packages/evals/src/ground-truth.mjs
+++ b/packages/evals/src/ground-truth.mjs
@@ -1,0 +1,162 @@
+// Ground truth for the retrieval-relevance eval, pinned to the REAL outcome
+// signal — never a hand-authored label list.
+//
+// The question this file answers is: for a given query (a repository, optionally
+// narrowed to one PR), which stored memories SHOULD a relevance-aware retriever
+// surface? The spec pins that to the memories the loop machinery itself treats
+// as outcome/relevance signal — the `loop::review-outcomes` bus and the
+// `loop::reviewer-comment-relevance` signal — matched to the query's repo and
+// weighted by how often they have recurred (`seen_count`).
+//
+// REUSE, NOT RE-ENCODING. The tag → bucket classification is owned by
+// `@lorekit/schemas` and shipped to every write surface. This module imports it
+// (`inferKindHost`) and NEVER re-encodes the literal `loop::…` strings. A copy
+// here would keep passing while the product's bucket set moved underneath it —
+// the single failure mode that would make every number this harness prints
+// meaningless (see the package README, "Reuse, not re-implementation", and the
+// recurring `mock-that-reimplements-the-thing-under-test` lesson). `AC-1-reuse`
+// greps this file to prove the literals are absent and the import is present.
+import { inferKindHost } from "@lorekit/schemas/tags";
+
+/**
+ * The recurrence threshold. A memory seen at least this many times is treated as
+ * a confirmed, high-value signal (the same `seen_count >= 3` bar the promotion
+ * loop uses). Below it a memory is still ground truth if it matches — recurrence
+ * only WEIGHTS relevance, it does not gate membership — but it is not "confirmed".
+ */
+export const RECURRENCE_CONFIRMED_AT = 3;
+
+/** The two buckets the spec names as the outcome signal, by their resolved host. */
+const OUTCOME_HOSTS = new Set(["review", "reviewer"]);
+
+/**
+ * Read a non-negative integer `seen_count` off a row in either shape the stores
+ * hand back — the hosted projection uses `seenCount` (camel, via the CLI store's
+ * `withReadFields`) and the raw REST/DB row uses `seen_count`. Absent or
+ * unparseable → 0, never a throw: the bootstrap seed carries no count at all,
+ * and a weight of 0 for it is correct AND is itself a placeholder tell.
+ */
+export function seenCountOf(row) {
+  const raw = row?.seenCount ?? row?.seen_count;
+  const n = typeof raw === "string" ? Number(raw) : raw;
+  if (typeof n !== "number" || !Number.isFinite(n)) return 0;
+  return Math.max(0, Math.floor(n));
+}
+
+/**
+ * The `owner/repo` a scope names, or null. Handles `repo::owner/repo` and
+ * `branch::owner/repo::branch`; a `global`/`project::…` scope names no repo.
+ *
+ * Deliberately a small structural read of an already-canonical scope string
+ * rather than a re-implementation of scope VALIDATION — the rows come straight
+ * from the store, so their scopes are already the canonical `::` form. The
+ * validator (`@lorekit/core/src/scope.ts`) remains the authority on validity;
+ * this only extracts the repo segment from a valid one.
+ */
+export function repoOfScope(scope) {
+  if (typeof scope !== "string") return null;
+  if (scope.startsWith("repo::")) return scope.slice("repo::".length) || null;
+  if (scope.startsWith("branch::")) {
+    return scope.slice("branch::".length).split("::")[0] || null;
+  }
+  return null;
+}
+
+/**
+ * The `owner/repo` a query is about. A query may pass `repo` directly
+ * (`mthines/lorekit`) or a full `scope` string to extract it from.
+ */
+export function repoOfQuery(query = {}) {
+  if (typeof query.repo === "string" && query.repo) return query.repo;
+  return repoOfScope(query.scope);
+}
+
+/**
+ * Does this row belong to the ground-truth set for this query?
+ *
+ * A row qualifies iff BOTH hold:
+ *   1. its tags resolve (via the shipped `inferKindHost`) to an outcome/relevance
+ *      bucket — `host` ∈ {review, reviewer}; and
+ *   2. it matches the query repo. Match is a DISJUNCTION, per the spec's
+ *      "`origin_pr` / repo scope matches": the row's scope names the query repo,
+ *      OR its `origin_repo` does. `origin_pr`, when the query pins one, further
+ *      NARROWS but is never REQUIRED — mock row m06 carries a real
+ *      `loop::review-outcomes` signal with `origin_pr: null`, and requiring a PR
+ *      would silently drop it.
+ *
+ * Pure and total: a malformed row degrades to `false`, never a throw.
+ */
+export function shouldSurface(row, query = {}) {
+  if (!row || typeof row !== "object") return false;
+
+  const { host } = inferKindHost(row.tags);
+  if (!host || !OUTCOME_HOSTS.has(host)) return false;
+
+  const wantRepo = repoOfQuery(query);
+  if (wantRepo) {
+    const rowRepo = repoOfScope(row.scope) ?? row.origin_repo ?? null;
+    if (rowRepo !== wantRepo) return false;
+  }
+
+  // A PR pin narrows only when the row actually declares one; a null-PR row is
+  // kept (see the m06 rationale above).
+  if (query.origin_pr != null && row.origin_pr != null) {
+    if (row.origin_pr !== query.origin_pr) return false;
+  }
+
+  return true;
+}
+
+/**
+ * The relevance weight of a ground-truth row: its `seen_count`, with a small
+ * confirmed-bump so a recurrence-confirmed row always outranks an unconfirmed
+ * one even when both have low raw counts. Non-members weigh 0.
+ *
+ * The weight exists so a retriever's ranking can be scored against a graded
+ * ideal, and so the placeholder seed (all weight 0) is visibly distinguishable
+ * from a real hosted snapshot (non-zero counts).
+ */
+export function relevanceWeight(row, query = {}) {
+  if (!shouldSurface(row, query)) return 0;
+  const seen = seenCountOf(row);
+  return seen >= RECURRENCE_CONFIRMED_AT ? seen + 1000 : seen;
+}
+
+/**
+ * Build the ground-truth set for a query from a list of stored rows.
+ *
+ * Returns the members as lightweight, METADATA-ONLY entries (no lesson body ever
+ * enters this structure) plus the ordered key list a metrics pass consumes.
+ *
+ * @param {object[]} rows  stored memories (mock rows, or `mine`'d hosted rows)
+ * @param {object}   query { repo?, scope?, origin_pr? }
+ * @returns {{ query: object, keys: string[],
+ *            entries: Array<{ scope, key, tags, origin_pr, seenCount,
+ *                             weight, recurrenceConfirmed }> }}
+ */
+export function buildGroundTruth(rows = [], query = {}) {
+  const entries = [];
+  for (const row of Array.isArray(rows) ? rows : []) {
+    if (!shouldSurface(row, query)) continue;
+    const seenCount = seenCountOf(row);
+    entries.push({
+      scope: row.scope ?? null,
+      key: row.key ?? null,
+      tags: Array.isArray(row.tags) ? [...row.tags] : [],
+      origin_pr: row.origin_pr ?? null,
+      seenCount,
+      weight: relevanceWeight(row, query),
+      recurrenceConfirmed: seenCount >= RECURRENCE_CONFIRMED_AT,
+    });
+  }
+  // Highest weight first, then key for a stable order — the ideal ranking a
+  // retriever is scored against.
+  entries.sort(
+    (a, b) => b.weight - a.weight || String(a.key).localeCompare(String(b.key)),
+  );
+  return {
+    query,
+    keys: entries.map((e) => e.key).filter((k) => typeof k === "string"),
+    entries,
+  };
+}

--- a/packages/evals/src/relevance-metrics.mjs
+++ b/packages/evals/src/relevance-metrics.mjs
@@ -1,0 +1,153 @@
+// The retrieval-relevance metrics: precision@k, recall@k, MRR.
+//
+// Pure and deterministic — takes a ranked list of retrieved keys and a set of
+// ground-truth keys, returns numbers. No store, no sandbox, no model, so the
+// whole thing is exercised by `node --test` in milliseconds (the package's
+// "everything below the model is a deterministic, tested function" split).
+//
+// These COMPLEMENT the live `claude -p` eval; they never gate it. The live eval
+// measures whether an injected lesson changes the agent's output. These measure
+// whether the RETRIEVER surfaces the right lessons in the first place — the
+// upstream half of the same question — against a ground truth pinned to the real
+// outcome signal (see `ground-truth.mjs`).
+
+/**
+ * The loud caveat that travels with every metrics object built on the bootstrap
+ * seed. It is embedded in the DATA, not just the README, so a `summary.json`
+ * read months later cannot be mistaken for a real baseline — the same reason the
+ * N=3 caveat lives in the arm summaries.
+ */
+export const BOOTSTRAP_WARNING =
+  "BOOTSTRAP PLACEHOLDER baseline (2-row seed derived from the in-repo mock). " +
+  "These numbers MUST NOT be used to gate downstream PRs (e.g. A1/A4) until " +
+  "`bin/mine-ground-truth.mjs` has been run against the hosted store and a real " +
+  "fixtures/ground-truth.real.json snapshot has been committed.";
+
+export const BASELINE_BOOTSTRAP = "bootstrap-seed";
+export const BASELINE_REAL = "real-hosted-snapshot";
+
+/** Coerce to a clean array of string keys, dropping non-strings. */
+function keyList(value) {
+  return (Array.isArray(value) ? value : []).filter((k) => typeof k === "string");
+}
+
+/** A normalized positive integer `k`, defaulting when absent/invalid. */
+function normalizeK(k, fallback) {
+  const n = Math.floor(Number(k));
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/**
+ * precision@k — of the top `k` retrieved keys, the fraction that are relevant.
+ *
+ * When fewer than `k` items were retrieved, the denominator is the number
+ * actually retrieved (not `k`): precision asks "how much of what I showed was
+ * right", and padding the denominator to `k` would punish a short-but-correct
+ * list. An empty retrieval scores 0.
+ */
+export function precisionAtK(ranked, groundTruthKeys, k) {
+  const items = keyList(ranked);
+  const truth = new Set(keyList(groundTruthKeys));
+  const kk = normalizeK(k, items.length || 1);
+  const top = items.slice(0, kk);
+  if (top.length === 0) return 0;
+  const hits = top.filter((key) => truth.has(key)).length;
+  return hits / top.length;
+}
+
+/**
+ * recall@k — of all relevant keys, the fraction that appear in the top `k`.
+ *
+ * The denominator is the ground-truth size. An empty ground truth is undefined
+ * recall; we return 1 (there was nothing to miss) so a query with no relevant
+ * items does not drag an average to 0 — callers that care can filter on
+ * `groundTruthSize === 0`.
+ */
+export function recallAtK(ranked, groundTruthKeys, k) {
+  const truth = new Set(keyList(groundTruthKeys));
+  if (truth.size === 0) return 1;
+  const items = keyList(ranked);
+  const kk = normalizeK(k, items.length || 1);
+  const top = items.slice(0, kk);
+  const found = top.filter((key) => truth.has(key)).length;
+  return found / truth.size;
+}
+
+/**
+ * Mean Reciprocal Rank for a SINGLE ranked list: 1 / (rank of the first relevant
+ * key), ranks 1-based. No relevant key in the list → 0.
+ *
+ * "Mean" is a misnomer for one query; `meanReciprocalRank` below averages this
+ * over many queries, which is the actual MRR.
+ */
+export function reciprocalRank(ranked, groundTruthKeys) {
+  const items = keyList(ranked);
+  const truth = new Set(keyList(groundTruthKeys));
+  for (let i = 0; i < items.length; i += 1) {
+    if (truth.has(items[i])) return 1 / (i + 1);
+  }
+  return 0;
+}
+
+/** MRR across many (ranked, groundTruth) query results. Empty → 0. */
+export function meanReciprocalRank(queryResults = []) {
+  const rows = Array.isArray(queryResults) ? queryResults : [];
+  if (rows.length === 0) return 0;
+  const sum = rows.reduce(
+    (acc, r) => acc + reciprocalRank(r?.ranked, r?.groundTruth),
+    0,
+  );
+  return sum / rows.length;
+}
+
+/**
+ * `mrr` — convenience alias for the single-list reciprocal rank, so a caller
+ * with one query reads `mrr(ranked, truth)` rather than wrapping it in an array.
+ * The multi-query average is `meanReciprocalRank`.
+ */
+export const mrr = reciprocalRank;
+
+/**
+ * Score one retrieval against one ground-truth set at a set of `k` values, and
+ * stamp the result with the baseline provenance + (for a seed) the loud caveat.
+ *
+ * @param {object}   args
+ * @param {string[]} args.ranked        retriever output, best-first
+ * @param {object}   args.groundTruth   a `buildGroundTruth` result (or `{ keys }`)
+ * @param {number[]} [args.ks]          k values to report (default [1, 3, 5])
+ * @param {string}   [args.baselineSource] BASELINE_BOOTSTRAP | BASELINE_REAL
+ * @returns {{ baseline: {source,rowCount,warning|null},
+ *            groundTruthSize: number,
+ *            precisionAtK: object, recallAtK: object, mrr: number }}
+ */
+export function scoreRanking({
+  ranked = [],
+  groundTruth = { keys: [] },
+  ks = [1, 3, 5],
+  baselineSource = BASELINE_BOOTSTRAP,
+} = {}) {
+  const truthKeys = keyList(groundTruth.keys);
+  const kValues = (Array.isArray(ks) ? ks : [1, 3, 5]).map((k) =>
+    normalizeK(k, 1),
+  );
+
+  const precision = {};
+  const recall = {};
+  for (const k of kValues) {
+    precision[k] = precisionAtK(ranked, truthKeys, k);
+    recall[k] = recallAtK(ranked, truthKeys, k);
+  }
+
+  const source = baselineSource === BASELINE_REAL ? BASELINE_REAL : BASELINE_BOOTSTRAP;
+  return {
+    baseline: {
+      source,
+      rowCount: truthKeys.length,
+      warning: source === BASELINE_BOOTSTRAP ? BOOTSTRAP_WARNING : null,
+    },
+    groundTruthSize: truthKeys.length,
+    precisionAtK: precision,
+    recallAtK: recall,
+    mrr: reciprocalRank(ranked, truthKeys),
+  };
+}

--- a/packages/evals/src/relevance-metrics.mjs
+++ b/packages/evals/src/relevance-metrics.mjs
@@ -31,10 +31,25 @@ function keyList(value) {
   return (Array.isArray(value) ? value : []).filter((k) => typeof k === "string");
 }
 
-/** A normalized positive integer `k`, defaulting when absent/invalid. */
+/**
+ * A normalized positive integer `k`.
+ *
+ * ABSENT (`undefined`/`null`) means "the caller did not pick a k" and takes the
+ * fallback. A PRESENT but unusable `k` — `"x"`, `0`, `-1`, `NaN` — is a caller
+ * MISTAKE and throws: silently rewriting it to the fallback made `ks: [1, "x"]`
+ * collapse to a single entry in `precisionAtK` instead of surfacing the bad
+ * input. A safe default makes an OMITTED input safe; it never makes a MALFORMED
+ * one correct.
+ */
 function normalizeK(k, fallback) {
+  if (k === undefined || k === null) return fallback;
   const n = Math.floor(Number(k));
-  return Number.isFinite(n) && n > 0 ? n : fallback;
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new TypeError(
+      `k must be a positive integer (or omitted); received ${JSON.stringify(k)}`,
+    );
+  }
+  return n;
 }
 
 /**

--- a/packages/evals/test/ground-truth.test.mjs
+++ b/packages/evals/test/ground-truth.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  shouldSurface,
+  buildGroundTruth,
+  relevanceWeight,
+  repoOfScope,
+  seenCountOf,
+  RECURRENCE_CONFIRMED_AT,
+} from "../src/ground-truth.mjs";
+
+// The two real outcome/relevance rows from the in-repo mock, as the store hands
+// them back. Copied here as the MINIMAL shape the predicate reads — the full
+// mock is exercised by relevance-integration.test.mjs, which imports MEMORY_ROWS
+// itself rather than restating it.
+const M05 = {
+  scope: "repo::mthines/lorekit",
+  key: "audit::one-vocabulary",
+  tags: ["audit", "loop::reviewer-comment-relevance"],
+  origin_pr: 311,
+};
+const M06 = {
+  scope: "repo::mthines/lorekit",
+  key: "rls::service-role-user-filter",
+  tags: ["security", "rls", "loop::review-outcomes"],
+  origin_pr: null,
+};
+// Non-outcome rows — must be rejected.
+const M03 = {
+  scope: "repo::mthines/lorekit",
+  key: "edge-parity::mirror-pattern",
+  tags: ["architecture"],
+};
+const M04 = {
+  scope: "repo::mthines/lorekit",
+  key: "scope-format::double-colon",
+  tags: ["scope", "validation"],
+};
+
+const QUERY = { repo: "mthines/lorekit" };
+
+test("AC-1(a): both outcome/relevance mock rows are selected for the repo query", () => {
+  assert.equal(shouldSurface(M05, QUERY), true);
+  assert.equal(shouldSurface(M06, QUERY), true);
+});
+
+test("AC-1(a): the null-origin_pr outcome row (m06) is kept, not dropped", () => {
+  // The spec's match is "origin_pr / repo scope matches" — a disjunction. m06 is
+  // a real loop::review-outcomes signal with origin_pr: null; requiring a PR
+  // would silently drop it. Locked so a future tightening to a conjunction fails.
+  assert.equal(M06.origin_pr, null);
+  assert.equal(shouldSurface(M06, QUERY), true);
+});
+
+test("AC-1(b): non-outcome rows are rejected", () => {
+  assert.equal(shouldSurface(M03, QUERY), false);
+  assert.equal(shouldSurface(M04, QUERY), false);
+});
+
+test("AC-1(c): membership is decided by the SHIPPED inferKindHost, not a re-encoded tag list", () => {
+  // FORBIDDEN PATTERN (the recurring mock-that-reimplements trap): if
+  // ground-truth.mjs ever replaced its `import { inferKindHost } from
+  // "@lorekit/schemas/tags"` with a LOCAL copy of the `loop::…` → bucket
+  // mapping, this predicate would keep passing against these fixtures while
+  // silently drifting from the product the day a bucket is added or renamed.
+  // The guard against that is structural, asserted by AC-1-reuse (a grep that
+  // fails if the literal tags reappear in the module) — proven to bite because
+  // the module contains NEITHER literal. Here we assert the BEHAVIOUR that pin
+  // protects: a bucket the resolver does not classify as review/reviewer is not
+  // ground truth, and a plain lesson bucket is not either.
+  const lessonRow = {
+    scope: "repo::mthines/lorekit",
+    key: "aw::x",
+    tags: ["loop::aw-lessons"], // resolves to host "aw" — not an outcome host
+  };
+  assert.equal(shouldSurface(lessonRow, QUERY), false);
+});
+
+test("repo mismatch rejects a real outcome row", () => {
+  assert.equal(shouldSurface(M05, { repo: "someone/else" }), false);
+});
+
+test("a scope query narrows the same way a repo query does", () => {
+  assert.equal(shouldSurface(M05, { scope: "repo::mthines/lorekit" }), true);
+  assert.equal(shouldSurface(M05, { scope: "repo::other/repo" }), false);
+});
+
+test("origin_pr pins narrow only when the row declares a PR", () => {
+  // m05 declares PR 311 → a mismatching pin drops it, a matching pin keeps it.
+  assert.equal(shouldSurface(M05, { repo: "mthines/lorekit", origin_pr: 999 }), false);
+  assert.equal(shouldSurface(M05, { repo: "mthines/lorekit", origin_pr: 311 }), true);
+  // m06 declares no PR → a pin never drops it.
+  assert.equal(shouldSurface(M06, { repo: "mthines/lorekit", origin_pr: 999 }), true);
+});
+
+test("repoOfScope handles repo:: and branch:: and rejects the rest", () => {
+  assert.equal(repoOfScope("repo::mthines/lorekit"), "mthines/lorekit");
+  assert.equal(repoOfScope("branch::mthines/lorekit::feat/x"), "mthines/lorekit");
+  assert.equal(repoOfScope("global"), null);
+  assert.equal(repoOfScope("project::agent-skills"), null);
+});
+
+test("seenCountOf reads either shape and never throws", () => {
+  assert.equal(seenCountOf({ seenCount: 5 }), 5);
+  assert.equal(seenCountOf({ seen_count: 4 }), 4);
+  assert.equal(seenCountOf({ seen_count: "7" }), 7);
+  assert.equal(seenCountOf({}), 0);
+  assert.equal(seenCountOf(null), 0);
+  assert.equal(seenCountOf({ seen_count: "not-a-number" }), 0);
+});
+
+test("relevanceWeight boosts recurrence-confirmed rows above unconfirmed ones", () => {
+  const confirmed = { ...M05, seenCount: RECURRENCE_CONFIRMED_AT };
+  const unconfirmed = { ...M06, seenCount: RECURRENCE_CONFIRMED_AT - 1 };
+  assert.ok(relevanceWeight(confirmed, QUERY) > relevanceWeight(unconfirmed, QUERY));
+  // A non-member always weighs 0.
+  assert.equal(relevanceWeight(M03, QUERY), 0);
+});
+
+test("buildGroundTruth returns metadata-only entries — never a lesson body", () => {
+  const gt = buildGroundTruth([M05, M06, M03, M04], QUERY);
+  assert.equal(gt.keys.length, 2);
+  assert.deepEqual(new Set(gt.keys), new Set([M05.key, M06.key]));
+  for (const entry of gt.entries) {
+    assert.equal("value" in entry, false);
+    assert.equal("body" in entry, false);
+    assert.deepEqual(
+      Object.keys(entry).sort(),
+      ["key", "origin_pr", "recurrenceConfirmed", "scope", "seenCount", "tags", "weight"],
+    );
+  }
+});

--- a/packages/evals/test/ground-truth.test.mjs
+++ b/packages/evals/test/ground-truth.test.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import { test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
   shouldSurface,
@@ -130,4 +133,35 @@ test("buildGroundTruth returns metadata-only entries — never a lesson body", (
       ["key", "origin_pr", "recurrenceConfirmed", "scope", "seenCount", "tags", "weight"],
     );
   }
+});
+
+test("AC-1-reuse: ground-truth.mjs re-encodes NO `loop::` literal and imports the shipped resolver", () => {
+  // The structural half of AC-1(c). That test proves the BEHAVIOUR (a non-outcome
+  // bucket is not ground truth); this one proves the MECHANISM — that membership
+  // is still decided by `@lorekit/schemas`' `inferKindHost` and not by a local
+  // copy of the `loop::…` → bucket mapping, which would keep passing against
+  // these fixtures while drifting from the product the day a bucket is added or
+  // renamed.
+  //
+  // The comparison runs on CODE, not on prose: the module's header comment
+  // legitimately names both loop tags while explaining why it must not encode
+  // them, so comments are stripped before the grep.
+  const source = fs.readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "src", "ground-truth.mjs"),
+    "utf8",
+  );
+  const code = source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+  assert.equal(
+    /loop::/.test(code),
+    false,
+    "ground-truth.mjs must not re-encode a `loop::` tag literal — the tag → bucket mapping is owned by @lorekit/schemas",
+  );
+  assert.match(
+    code,
+    /import\s*\{[^}]*\binferKindHost\b[^}]*\}\s*from\s*["']@lorekit\/schemas\/tags["']/,
+    "ground-truth.mjs must import inferKindHost from @lorekit/schemas/tags",
+  );
 });

--- a/packages/evals/test/ground-truth.test.mjs
+++ b/packages/evals/test/ground-truth.test.mjs
@@ -165,3 +165,32 @@ test("AC-1-reuse: ground-truth.mjs re-encodes NO `loop::` literal and imports th
     "ground-truth.mjs must import inferKindHost from @lorekit/schemas/tags",
   );
 });
+
+test("AC-1(d): a plain lessons bucket sharing an outcome HOST is not ground truth", () => {
+  // `inferKindHost` maps `loop::<host>-lessons` to that host, so
+  // `loop::reviewer-lessons` resolves to host "reviewer" exactly as
+  // `loop::reviewer-comment-relevance` does. A host-only membership check let an
+  // ordinary lessons row into the ground truth; the `kind` half (bus/signal, not
+  // lesson) is what keeps the two apart.
+  const reviewerLesson = {
+    scope: "repo::mthines/lorekit",
+    key: "reviewer::some-lesson",
+    tags: ["loop::reviewer-lessons"],
+    origin_pr: null,
+  };
+  const reviewLesson = {
+    scope: "repo::mthines/lorekit",
+    key: "review::some-lesson",
+    tags: ["loop::review-lessons"],
+    origin_pr: null,
+  };
+  assert.equal(shouldSurface(reviewerLesson, QUERY), false);
+  assert.equal(shouldSurface(reviewLesson, QUERY), false);
+  assert.equal(relevanceWeight(reviewerLesson, QUERY), 0);
+  // The two real outcome buckets still qualify.
+  assert.equal(shouldSurface(M05, QUERY), true);
+  assert.equal(shouldSurface(M06, QUERY), true);
+  // And they are excluded from a built ground truth.
+  const gt = buildGroundTruth([M05, M06, reviewerLesson, reviewLesson], QUERY);
+  assert.deepEqual(new Set(gt.keys), new Set([M05.key, M06.key]));
+});

--- a/packages/evals/test/ground-truth.test.mjs
+++ b/packages/evals/test/ground-truth.test.mjs
@@ -194,3 +194,36 @@ test("AC-1(d): a plain lessons bucket sharing an outcome HOST is not ground trut
   const gt = buildGroundTruth([M05, M06, reviewerLesson, reviewLesson], QUERY);
   assert.deepEqual(new Set(gt.keys), new Set([M05.key, M06.key]));
 });
+
+test("repo match is a real disjunction: scope OR origin_repo", () => {
+  // Documented as "the row's scope names the query repo, OR its origin_repo
+  // does". A `??` chain only consulted origin_repo when the scope named NO repo,
+  // so a row scoped elsewhere but originating here was dropped.
+  const scopedElsewhere = {
+    scope: "repo::someone/else",
+    key: "audit::from-here",
+    tags: ["loop::review-outcomes"],
+    origin_repo: "mthines/lorekit",
+    origin_pr: null,
+  };
+  assert.equal(shouldSurface(scopedElsewhere, QUERY), true);
+
+  // A global-scoped row still matches on origin_repo (the `??` case, unchanged).
+  assert.equal(
+    shouldSurface(
+      { scope: "global", key: "g", tags: ["loop::review-outcomes"], origin_repo: "mthines/lorekit" },
+      QUERY,
+    ),
+    true,
+  );
+
+  // And a row matching on NEITHER is still rejected.
+  assert.equal(
+    shouldSurface(
+      { scope: "repo::someone/else", key: "x", tags: ["loop::review-outcomes"], origin_repo: "third/party" },
+      QUERY,
+    ),
+    false,
+  );
+  assert.equal(shouldSurface({ ...scopedElsewhere, origin_repo: undefined }, QUERY), false);
+});

--- a/packages/evals/test/mine-ground-truth.test.mjs
+++ b/packages/evals/test/mine-ground-truth.test.mjs
@@ -307,3 +307,25 @@ test("AC-6: with the flag unset there is no service-role notice", async () => {
   }
   assert.equal(/cross-tenant/.test(errs.join("\n")), false);
 });
+
+test("AC-5: a zero-row mine refuses to write an EMPTY baseline", async () => {
+  // An empty ground truth scores recall 1 by design ("nothing to miss"), so an
+  // empty snapshot stamped `real-hosted-snapshot` would look perfect while
+  // measuring nothing — worse than the truncated snapshot the pagination walk
+  // prevents, and reachable by an ordinary wrong --scope.
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "mine-gt-"));
+  const out = path.join(dir, "ground-truth.real.json");
+  const errs = [];
+  const { remote, connection } = pagingRemote({});
+
+  const code = await main(["--confirm", "--out", out], {
+    log: () => {},
+    err: (m) => errs.push(String(m)),
+    deps: { resolveStores: () => ({ remote, connection }) },
+  });
+
+  assert.equal(code, 5);
+  assert.match(errs.join("\n"), /EMPTY baseline/);
+  assert.match(errs.join("\n"), /Nothing was written/);
+  assert.equal(fs.existsSync(out), false);
+});

--- a/packages/evals/test/mine-ground-truth.test.mjs
+++ b/packages/evals/test/mine-ground-truth.test.mjs
@@ -249,3 +249,16 @@ test("AC-6: main surfaces a bad flag as usage and never reaches the store", asyn
   assert.equal(code, 2);
   assert.match(errs.join("\n"), /--scope requires a value/);
 });
+
+test("AC-5: a string seen_count is mined as a number, not dropped to null", () => {
+  // The hosted projection hands `seen_count` back as a string on some paths;
+  // `seenCountOf` in src/ground-truth.mjs already accepts one, so redaction must
+  // not require a `number` and silently mine `null` (later weighted 0).
+  assert.equal(redactToMetadata({ seen_count: "7" }).seenCount, 7);
+  assert.equal(redactToMetadata({ seenCount: "3.9" }).seenCount, 3);
+  assert.equal(redactToMetadata({ seenCount: "-2" }).seenCount, 0);
+  // Absent still stays null — the placeholder tell, not a 0 count.
+  assert.equal(redactToMetadata({}).seenCount, null);
+  // Present but unparseable degrades to 0, exactly as seenCountOf does.
+  assert.equal(redactToMetadata({ seen_count: "not-a-number" }).seenCount, 0);
+});

--- a/packages/evals/test/mine-ground-truth.test.mjs
+++ b/packages/evals/test/mine-ground-truth.test.mjs
@@ -13,6 +13,7 @@ import {
   METADATA_FIELDS,
   OUTCOME_TAGS,
   PAGE_LIMIT,
+  SERVICE_ROLE_ENV,
 } from "../bin/mine-ground-truth.mjs";
 
 test("AC-5: redactToMetadata drops the lesson body and keeps only metadata", () => {
@@ -261,4 +262,48 @@ test("AC-5: a string seen_count is mined as a number, not dropped to null", () =
   assert.equal(redactToMetadata({}).seenCount, null);
   // Present but unparseable degrades to 0, exactly as seenCountOf does.
   assert.equal(redactToMetadata({ seen_count: "not-a-number" }).seenCount, 0);
+});
+
+test("AC-6: the service-role acknowledgement flag is READ, and says it did not widen the read", async () => {
+  // The flag used to be documented but never read, so setting it changed
+  // nothing and the operator could believe a cross-tenant mine had happened.
+  const errs = [];
+  const prior = process.env[SERVICE_ROLE_ENV];
+  process.env[SERVICE_ROLE_ENV] = "1";
+  try {
+    const code = await main(["--confirm"], {
+      log: () => {},
+      err: (m) => errs.push(String(m)),
+      // No usable remote → returns 3 before any query; the notice must already
+      // have been printed by then.
+      deps: {
+        resolveStores: () => ({ remote: { usable: () => false }, connection: {} }),
+      },
+    });
+    assert.equal(code, 3);
+  } finally {
+    if (prior === undefined) delete process.env[SERVICE_ROLE_ENV];
+    else process.env[SERVICE_ROLE_ENV] = prior;
+  }
+  const joined = errs.join("\n");
+  assert.match(joined, /does NOT implement a cross-tenant/);
+  assert.match(joined, /USER-SCOPED/);
+});
+
+test("AC-6: with the flag unset there is no service-role notice", async () => {
+  const errs = [];
+  const prior = process.env[SERVICE_ROLE_ENV];
+  delete process.env[SERVICE_ROLE_ENV];
+  try {
+    await main(["--confirm"], {
+      log: () => {},
+      err: (m) => errs.push(String(m)),
+      deps: {
+        resolveStores: () => ({ remote: { usable: () => false }, connection: {} }),
+      },
+    });
+  } finally {
+    if (prior !== undefined) process.env[SERVICE_ROLE_ENV] = prior;
+  }
+  assert.equal(/cross-tenant/.test(errs.join("\n")), false);
 });

--- a/packages/evals/test/mine-ground-truth.test.mjs
+++ b/packages/evals/test/mine-ground-truth.test.mjs
@@ -217,3 +217,35 @@ test("AC-5: a repeating cursor is refused rather than spun on", async () => {
   // Nothing was written.
   assert.equal(fs.existsSync(out), false);
 });
+
+test("AC-6: a value-taking flag never swallows the next flag or an empty value", () => {
+  // `--confirm --scope` must not leave scope undefined (which would mine EVERY
+  // scope), and `--scope --confirm` must not eat the confirm flag.
+  assert.throws(() => parseMineArgs(["--confirm", "--scope"]), /--scope requires a value/);
+  assert.throws(() => parseMineArgs(["--scope", "--confirm"]), /--scope requires a value/);
+  assert.throws(() => parseMineArgs(["--out"]), /--out requires a value/);
+  assert.throws(() => parseMineArgs(["--out", "--confirm"]), /--out requires a value/);
+  // Malformed (present but empty) is refused too, not just missing.
+  assert.throws(() => parseMineArgs(["--scope", "   "]), /non-empty/);
+  assert.throws(() => parseMineArgs(["--out", ""]), /--out requires a non-empty value/);
+  // The happy paths still parse.
+  assert.equal(parseMineArgs(["--scope", "repo::a/b", "--confirm"]).scope, "repo::a/b");
+  assert.equal(parseMineArgs(["--confirm", "--out", "/tmp/x.json"]).out, "/tmp/x.json");
+  // A typo'd flag is a usage error, never a silent widening.
+  assert.throws(() => parseMineArgs(["--scpoe", "repo::a/b"]), /unknown option/);
+});
+
+test("AC-6: main surfaces a bad flag as usage and never reaches the store", async () => {
+  const errs = [];
+  const code = await main(["--confirm", "--scope"], {
+    log: () => {},
+    err: (m) => errs.push(String(m)),
+    deps: {
+      resolveStores: () => {
+        throw new Error("resolveStores must not be reached on the usage path");
+      },
+    },
+  });
+  assert.equal(code, 2);
+  assert.match(errs.join("\n"), /--scope requires a value/);
+});

--- a/packages/evals/test/mine-ground-truth.test.mjs
+++ b/packages/evals/test/mine-ground-truth.test.mjs
@@ -1,4 +1,8 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 
 import {
@@ -8,6 +12,7 @@ import {
   main,
   METADATA_FIELDS,
   OUTCOME_TAGS,
+  PAGE_LIMIT,
 } from "../bin/mine-ground-truth.mjs";
 
 test("AC-5: redactToMetadata drops the lesson body and keeps only metadata", () => {
@@ -128,4 +133,87 @@ test("the outcome tags are exactly the two the spec names", () => {
     new Set(OUTCOME_TAGS),
     new Set(["loop::review-outcomes", "loop::reviewer-comment-relevance"]),
   );
+});
+
+// A remote whose `list` serves `rows` in pages of `PAGE_LIMIT`, reporting
+// `hasMore`/`nextCursor` exactly as the hosted store does.
+function pagingRemote(rowsByTag, { repeatCursor = false } = {}) {
+  const calls = [];
+  return {
+    calls,
+    remote: {
+      usable: () => true,
+      list: ({ tags, cursor }) => {
+        const tag = tags[0];
+        const rows = rowsByTag[tag] ?? [];
+        const offset = cursor ? Number(cursor) : 0;
+        const page = rows.slice(offset, offset + PAGE_LIMIT);
+        const next = offset + page.length;
+        calls.push({ tag, cursor: cursor ?? null });
+        return {
+          ok: true,
+          entries: page,
+          hasMore: next < rows.length,
+          nextCursor:
+            next < rows.length ? String(repeatCursor ? offset : next) : null,
+        };
+      },
+    },
+    connection: { endpoint: "https://example.test" },
+  };
+}
+
+const rowsFor = (tag, n, prefix) =>
+  Array.from({ length: n }, (_, i) => ({
+    scope: "repo::mthines/lorekit",
+    key: `${prefix}::${i}`,
+    tags: [tag],
+    origin_pr: null,
+    seenCount: i,
+    value: "a lesson body that must never be emitted",
+  }));
+
+test("AC-5: the mine walks EVERY page — a >PAGE_LIMIT tag is not silently truncated", async () => {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "mine-gt-"));
+  const out = path.join(dir, "ground-truth.real.json");
+  const { remote, connection, calls } = pagingRemote({
+    [OUTCOME_TAGS[0]]: rowsFor(OUTCOME_TAGS[0], PAGE_LIMIT + 42, "a"),
+    [OUTCOME_TAGS[1]]: rowsFor(OUTCOME_TAGS[1], 3, "b"),
+  });
+
+  const code = await main(["--confirm", "--out", out], {
+    log: () => {},
+    err: () => {},
+    deps: { resolveStores: () => ({ remote, connection }) },
+  });
+
+  assert.equal(code, 0);
+  const snapshot = JSON.parse(await fsp.readFile(out, "utf8"));
+  assert.equal(snapshot.entries.length, PAGE_LIMIT + 42 + 3);
+  // Two pages for the first tag, one for the second — the cursor was followed.
+  assert.equal(calls.filter((c) => c.tag === OUTCOME_TAGS[0]).length, 2);
+  assert.equal(calls.filter((c) => c.tag === OUTCOME_TAGS[1]).length, 1);
+  // Still metadata-only after paging.
+  for (const entry of snapshot.entries) assert.equal("value" in entry, false);
+});
+
+test("AC-5: a repeating cursor is refused rather than spun on", async () => {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "mine-gt-"));
+  const out = path.join(dir, "ground-truth.real.json");
+  const errs = [];
+  const { remote, connection } = pagingRemote(
+    { [OUTCOME_TAGS[0]]: rowsFor(OUTCOME_TAGS[0], PAGE_LIMIT + 1, "a") },
+    { repeatCursor: true },
+  );
+
+  const code = await main(["--confirm", "--out", out], {
+    log: () => {},
+    err: (m) => errs.push(String(m)),
+    deps: { resolveStores: () => ({ remote, connection }) },
+  });
+
+  assert.equal(code, 4);
+  assert.match(errs.join("\n"), /repeating cursor/);
+  // Nothing was written.
+  assert.equal(fs.existsSync(out), false);
 });

--- a/packages/evals/test/mine-ground-truth.test.mjs
+++ b/packages/evals/test/mine-ground-truth.test.mjs
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  redactToMetadata,
+  privacyPreflight,
+  parseMineArgs,
+  main,
+  METADATA_FIELDS,
+  OUTCOME_TAGS,
+} from "../bin/mine-ground-truth.mjs";
+
+test("AC-5: redactToMetadata drops the lesson body and keeps only metadata", () => {
+  const row = {
+    scope: "repo::mthines/lorekit",
+    key: "rls::service-role-user-filter",
+    value: "api_key auth uses the service-role client — every query MUST .eq(user_id, userId).",
+    tags: ["security", "rls", "loop::review-outcomes"],
+    origin_pr: null,
+    seenCount: 4,
+    created_at: "2026-01-01T00:00:00Z",
+  };
+  const out = redactToMetadata(row);
+  assert.deepEqual(Object.keys(out).sort(), [...METADATA_FIELDS].sort());
+  assert.equal("value" in out, false);
+  assert.equal("body" in out, false);
+  assert.equal("created_at" in out, false);
+  assert.equal(out.seenCount, 4);
+  assert.equal(out.scope, row.scope);
+});
+
+test("AC-5: redactToMetadata reads seen_count OR seenCount and floors it", () => {
+  assert.equal(redactToMetadata({ seen_count: 7 }).seenCount, 7);
+  assert.equal(redactToMetadata({ seenCount: 3.9 }).seenCount, 3);
+  assert.equal(redactToMetadata({}).seenCount, null);
+});
+
+test("AC-5: privacyPreflight passes clean metadata through unchanged", () => {
+  const entries = [
+    { scope: "repo::x/y", key: "a::b", tags: ["loop::review-outcomes"], origin_pr: 1, seenCount: 2 },
+  ];
+  assert.deepEqual(privacyPreflight(entries), entries);
+});
+
+test("AC-5: privacyPreflight throws when an entry still carries a body", () => {
+  assert.throws(
+    () => privacyPreflight([{ scope: "s", key: "k", tags: [], value: "leaked body" }]),
+    /must never be emitted/,
+  );
+  assert.throws(
+    () => privacyPreflight([{ scope: "s", key: "k", tags: [], body: "leaked body" }]),
+    /must never be emitted/,
+  );
+});
+
+test("AC-5: privacyPreflight throws on a non-metadata field", () => {
+  assert.throws(
+    () => privacyPreflight([{ scope: "s", key: "k", tags: [], origin_pr: 1, seenCount: 0, extra: "x" }]),
+    /non-metadata field/,
+  );
+});
+
+test("AC-5: privacyPreflight throws on a secret-shaped string", () => {
+  // A key that somehow embeds a token-shaped string is refused.
+  assert.throws(
+    () =>
+      privacyPreflight([
+        { scope: "s", key: "ghp_ABCDEFGHIJKLMNOPQRSTUV", tags: [], origin_pr: null, seenCount: 0 },
+      ]),
+    /secret\/PII-shaped/,
+  );
+});
+
+test("AC-6: parseMineArgs requires --confirm and rejects unknown flags", () => {
+  assert.equal(parseMineArgs([]).confirm, false);
+  assert.equal(parseMineArgs(["--confirm"]).confirm, true);
+  assert.equal(parseMineArgs(["--scope", "repo::a/b"]).scope, "repo::a/b");
+  assert.throws(() => parseMineArgs(["--nope"]), /unknown option/);
+});
+
+test("AC-6: main([]) refuses without --confirm, exits non-zero, and makes NO network call", async () => {
+  const out = [];
+  const errs = [];
+  // A deps.resolveStores that would THROW if the store were ever reached — the
+  // refusal must return before any store resolution, so this is never called.
+  const resolveStores = () => {
+    throw new Error("resolveStores must not be reached on the refusal path");
+  };
+  const code = await main([], {
+    log: (m) => out.push(String(m)),
+    err: (m) => errs.push(String(m)),
+    deps: { resolveStores },
+  });
+  assert.equal(code, 2);
+  const joined = errs.join("\n");
+  assert.match(joined, /--confirm/);
+  // The placeholder → real explanation is printed so the operator learns what
+  // running the script actually buys.
+  assert.match(joined, /Placeholder → real/);
+  assert.match(joined, /ground-truth\.real\.json/);
+  assert.match(joined, /MUST NOT/);
+});
+
+test("AC-6: --confirm with no usable remote connection refuses to write and makes no query", async () => {
+  const errs = [];
+  // A remote that is explicitly unusable — list() would throw if reached.
+  const resolveStores = () => ({
+    remote: {
+      usable: () => false,
+      list: () => {
+        throw new Error("remote.list must not be called when the connection is unusable");
+      },
+    },
+    connection: { endpoint: null },
+  });
+  const code = await main(["--confirm"], {
+    log: () => {},
+    err: (m) => errs.push(String(m)),
+    deps: { resolveStores },
+  });
+  assert.equal(code, 3);
+  assert.match(errs.join("\n"), /No usable remote connection/);
+  assert.match(errs.join("\n"), /Nothing was written/);
+});
+
+test("the outcome tags are exactly the two the spec names", () => {
+  assert.deepEqual(
+    new Set(OUTCOME_TAGS),
+    new Set(["loop::review-outcomes", "loop::reviewer-comment-relevance"]),
+  );
+});

--- a/packages/evals/test/relevance-docs.test.mjs
+++ b/packages/evals/test/relevance-docs.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (rel) => fs.readFileSync(path.join(ROOT, rel), "utf8");
+
+test("AC-8: README documents the definition, the placeholder seed, and the mine runbook", () => {
+  const readme = read("README.md");
+  // The loud placeholder caveat.
+  assert.match(readme, /BOOTSTRAP PLACEHOLDER/);
+  assert.match(readme, /MUST NOT/);
+  // The mine runbook and the real snapshot it produces.
+  assert.match(readme, /mine-ground-truth/);
+  assert.match(readme, /ground-truth\.real\.json/);
+  // The ground-truth definition is pinned to the outcome signal.
+  assert.match(readme, /precision@k/);
+  assert.match(readme, /recall@k/);
+  assert.match(readme, /MRR/);
+});
+
+test("AC-7-nowire: the mine script is NOT wired into any script/target/test that would run it", () => {
+  // If this ever fails, the script that must stay MANUAL has been auto-wired —
+  // which would let a CI run (or a `node --test`) hit the hosted network path.
+  const pkg = read("package.json");
+  const project = read("project.json");
+  assert.equal(
+    /mine-ground-truth/.test(pkg),
+    false,
+    "package.json must not reference mine-ground-truth",
+  );
+  assert.equal(
+    /mine-ground-truth/.test(project),
+    false,
+    "project.json must not reference mine-ground-truth",
+  );
+
+  // No test file IMPORTS the bin in a way that executes its network path. The
+  // one test that imports it (mine-ground-truth.test.mjs) only exercises the
+  // pure exports + the refusal paths (main([]) / unusable connection), never a
+  // real query — asserted by that suite. Here we guard that no OTHER test file
+  // IMPORTS it (matched on an actual import specifier, not a mere mention — this
+  // file names the script in its own assertions and must not match itself), and
+  // that the bin is not auto-run by a test glob.
+  const testDir = path.join(ROOT, "test");
+  const IMPORT_SPECIFIER = /from\s+["'][^"']*bin\/mine-ground-truth\.mjs["']/;
+  const importers = fs
+    .readdirSync(testDir)
+    .filter((f) => f.endsWith(".test.mjs"))
+    .filter((f) => IMPORT_SPECIFIER.test(read(path.join("test", f))));
+  assert.deepEqual(
+    importers,
+    ["mine-ground-truth.test.mjs"],
+    "only the dedicated mine test may import the mine script",
+  );
+});
+
+test("the mine script never calls process.exit and only auto-runs when invoked directly", () => {
+  const bin = read("bin/mine-ground-truth.mjs");
+  // No process.exit — returns exit codes so it stays testable (the package's
+  // run-eval.mjs convention).
+  assert.equal(/process\.exit\(/.test(bin), false);
+  // The direct-invocation guard is present, so importing it is side-effect free.
+  assert.match(bin, /fileURLToPath\(import\.meta\.url\) === path\.resolve\(process\.argv\[1\]\)/);
+});

--- a/packages/evals/test/relevance-integration.test.mjs
+++ b/packages/evals/test/relevance-integration.test.mjs
@@ -13,7 +13,13 @@ import {
 // re-implementation" invariant: the ground truth is derived from the same rows
 // the dashboard stories render, so a change to the mock's outcome/relevance rows
 // is caught here rather than silently diverging from a hand-maintained list.
-import { MEMORY_ROWS } from "../../web/src/mocks/memories.ts";
+//
+// Reached through the PACKAGE specifier, not a `../../web/…` relative path, and
+// declared as a devDependency in this package's package.json — the same
+// convention cross-package-imports.test.mjs uses for `@lorekit/core/src/scope.ts`.
+// The edge is real either way (the module pulls in `msw`); declaring it keeps it
+// visible to the workspace graph instead of smuggling it past the manifest.
+import { MEMORY_ROWS } from "@lorekit/web/src/mocks/memories.ts";
 
 const FIXTURES = path.join(
   path.dirname(fileURLToPath(import.meta.url)),

--- a/packages/evals/test/relevance-integration.test.mjs
+++ b/packages/evals/test/relevance-integration.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { buildGroundTruth } from "../src/ground-truth.mjs";
+import {
+  scoreRanking,
+  BASELINE_BOOTSTRAP,
+} from "../src/relevance-metrics.mjs";
+// Import the REAL mock, not a copy. This is the whole point of the "reuse, not
+// re-implementation" invariant: the ground truth is derived from the same rows
+// the dashboard stories render, so a change to the mock's outcome/relevance rows
+// is caught here rather than silently diverging from a hand-maintained list.
+import { MEMORY_ROWS } from "../../web/src/mocks/memories.ts";
+
+const FIXTURES = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "fixtures",
+);
+const SEED = JSON.parse(
+  fs.readFileSync(path.join(FIXTURES, "ground-truth.seed.json"), "utf8"),
+);
+
+const QUERY = { repo: "mthines/lorekit" };
+
+test("AC-3: ground truth derived from the real MEMORY_ROWS mock is exactly the 2 outcome rows", () => {
+  const gt = buildGroundTruth(MEMORY_ROWS, QUERY);
+  assert.equal(gt.keys.length, 2);
+  assert.deepEqual(
+    new Set(gt.keys),
+    new Set(["audit::one-vocabulary", "rls::service-role-user-filter"]),
+  );
+});
+
+test("AC-3: the committed seed fixture matches what the mock derives (no drift)", () => {
+  // The seed is a frozen snapshot of the mock's outcome rows. If someone edits
+  // the mock's outcome/relevance rows without refreshing the seed, this fails —
+  // keeping ONE source of truth without a fragile cross-package import in the
+  // hot path (the seed is what the harness actually reads by default).
+  const gt = buildGroundTruth(MEMORY_ROWS, QUERY);
+  const derivedKeys = new Set(gt.keys);
+  const seedKeys = new Set(SEED.entries.map((e) => e.key));
+  assert.deepEqual(seedKeys, derivedKeys);
+  // Every seed entry is metadata-only and matches the mock's scope/tags/pr.
+  for (const seedEntry of SEED.entries) {
+    const mockRow = MEMORY_ROWS.find((r) => r.key === seedEntry.key);
+    assert.ok(mockRow, `seed key ${seedEntry.key} exists in the mock`);
+    assert.equal(seedEntry.scope, mockRow.scope);
+    assert.deepEqual(seedEntry.tags, mockRow.tags);
+    assert.equal(seedEntry.origin_pr, mockRow.origin_pr);
+    assert.equal("value" in seedEntry, false);
+  }
+});
+
+test("AC-3: scoring a ranking against the bootstrap ground truth carries the placeholder baseline", () => {
+  const gt = buildGroundTruth(MEMORY_ROWS, QUERY);
+
+  // A retriever that ranks the two true rows first among the repo's rows.
+  const repoRows = MEMORY_ROWS.filter((r) => r.scope === "repo::mthines/lorekit");
+  const ranked = [
+    ...gt.keys,
+    ...repoRows.map((r) => r.key).filter((k) => !gt.keys.includes(k)),
+  ];
+
+  const score = scoreRanking({
+    ranked,
+    groundTruth: gt,
+    ks: [1, 2, 5],
+    baselineSource: BASELINE_BOOTSTRAP,
+  });
+
+  // Both true rows ranked at the top → a perfect score on this tiny corpus.
+  assert.equal(score.mrr, 1);
+  assert.equal(score.precisionAtK[2], 1);
+  assert.equal(score.recallAtK[2], 1);
+
+  // The load-bearing assertion for R2/R8: the baseline is loudly a placeholder.
+  assert.equal(score.baseline.source, "bootstrap-seed");
+  assert.equal(score.baseline.rowCount, 2);
+  assert.match(score.baseline.warning, /BOOTSTRAP PLACEHOLDER/);
+  assert.match(score.baseline.warning, /MUST NOT/);
+});

--- a/packages/evals/test/relevance-metrics.test.mjs
+++ b/packages/evals/test/relevance-metrics.test.mjs
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  precisionAtK,
+  recallAtK,
+  reciprocalRank,
+  meanReciprocalRank,
+  mrr,
+  scoreRanking,
+  BASELINE_BOOTSTRAP,
+  BASELINE_REAL,
+  BOOTSTRAP_WARNING,
+} from "../src/relevance-metrics.mjs";
+
+// A single-relevant scenario with the true item at rank 2 — the canonical
+// worked example the plan pins: mrr = 1/2, precision@1 = 0, recall@2 = 1.
+const RANKED = ["wrong-a", "right", "wrong-b", "wrong-c"];
+const TRUTH = ["right"];
+
+test("AC-2: reciprocal rank of a rank-2 hit is 0.5", () => {
+  assert.equal(reciprocalRank(RANKED, TRUTH), 0.5);
+  assert.equal(mrr(RANKED, TRUTH), 0.5);
+});
+
+test("AC-2: precision@1 is 0 when the top item is wrong", () => {
+  assert.equal(precisionAtK(RANKED, TRUTH, 1), 0);
+});
+
+test("AC-2: precision@2 is 0.5 (one of two top items relevant)", () => {
+  assert.equal(precisionAtK(RANKED, TRUTH, 2), 0.5);
+});
+
+test("AC-2: recall@1 is 0, recall@2 is 1 for a single-relevant set", () => {
+  assert.equal(recallAtK(RANKED, TRUTH, 1), 0);
+  assert.equal(recallAtK(RANKED, TRUTH, 2), 1);
+});
+
+test("AC-2: a perfect ranking scores 1 across the board", () => {
+  const ranked = ["a", "b", "c"];
+  const truth = ["a", "b"];
+  assert.equal(reciprocalRank(ranked, truth), 1);
+  assert.equal(precisionAtK(ranked, truth, 2), 1);
+  assert.equal(recallAtK(ranked, truth, 2), 1);
+});
+
+test("AC-2: a miss scores 0 reciprocal rank and 0 recall", () => {
+  assert.equal(reciprocalRank(["x", "y"], ["z"]), 0);
+  assert.equal(recallAtK(["x", "y"], ["z"], 5), 0);
+  assert.equal(precisionAtK(["x", "y"], ["z"], 5), 0);
+});
+
+test("precision@k denominator is the retrieved count when fewer than k retrieved", () => {
+  // Two retrieved, both relevant, k=5 → precision is 2/2 = 1, not 2/5.
+  assert.equal(precisionAtK(["a", "b"], ["a", "b", "c"], 5), 1);
+});
+
+test("recall of an empty ground truth is 1 (nothing to miss)", () => {
+  assert.equal(recallAtK(["a"], [], 3), 1);
+});
+
+test("empty retrieval scores 0 precision and 0 reciprocal rank", () => {
+  assert.equal(precisionAtK([], ["a"], 3), 0);
+  assert.equal(reciprocalRank([], ["a"]), 0);
+});
+
+test("meanReciprocalRank averages per-query reciprocal ranks", () => {
+  const results = [
+    { ranked: ["a", "b"], groundTruth: ["a"] }, // rr = 1
+    { ranked: ["x", "y"], groundTruth: ["y"] }, // rr = 1/2
+  ];
+  assert.equal(meanReciprocalRank(results), 0.75);
+  assert.equal(meanReciprocalRank([]), 0);
+});
+
+test("AC-2: scoreRanking rolls up p@k / r@k / mrr and stamps the bootstrap warning", () => {
+  const score = scoreRanking({
+    ranked: RANKED,
+    groundTruth: { keys: TRUTH },
+    ks: [1, 2],
+    baselineSource: BASELINE_BOOTSTRAP,
+  });
+  assert.equal(score.mrr, 0.5);
+  assert.equal(score.precisionAtK[1], 0);
+  assert.equal(score.precisionAtK[2], 0.5);
+  assert.equal(score.recallAtK[1], 0);
+  assert.equal(score.recallAtK[2], 1);
+  assert.equal(score.groundTruthSize, 1);
+  assert.equal(score.baseline.source, BASELINE_BOOTSTRAP);
+  assert.equal(score.baseline.rowCount, 1);
+  // The loud caveat travels with the DATA, not just the README.
+  assert.match(score.baseline.warning, /BOOTSTRAP PLACEHOLDER/);
+  assert.match(score.baseline.warning, /MUST NOT/);
+  assert.equal(score.baseline.warning, BOOTSTRAP_WARNING);
+});
+
+test("scoreRanking on a real snapshot carries NO placeholder warning", () => {
+  const score = scoreRanking({
+    ranked: RANKED,
+    groundTruth: { keys: TRUTH },
+    baselineSource: BASELINE_REAL,
+  });
+  assert.equal(score.baseline.source, BASELINE_REAL);
+  assert.equal(score.baseline.warning, null);
+});

--- a/packages/evals/test/relevance-metrics.test.mjs
+++ b/packages/evals/test/relevance-metrics.test.mjs
@@ -103,3 +103,24 @@ test("scoreRanking on a real snapshot carries NO placeholder warning", () => {
   assert.equal(score.baseline.source, BASELINE_REAL);
   assert.equal(score.baseline.warning, null);
 });
+
+test("a MALFORMED k is surfaced, not silently rewritten to a default", () => {
+  // `ks: [1, "x"]` used to collapse to a single entry — the bad input vanished
+  // into the fallback instead of failing loudly.
+  assert.throws(
+    () => scoreRanking({ ranked: RANKED, groundTruth: { keys: TRUTH }, ks: [1, "x"] }),
+    /k must be a positive integer/,
+  );
+  assert.throws(() => precisionAtK(RANKED, TRUTH, "x"), /k must be a positive integer/);
+  assert.throws(() => precisionAtK(RANKED, TRUTH, 0), /k must be a positive integer/);
+  assert.throws(() => recallAtK(RANKED, TRUTH, -1), /k must be a positive integer/);
+  assert.throws(() => recallAtK(RANKED, TRUTH, NaN), /k must be a positive integer/);
+});
+
+test("an OMITTED k still takes the documented default", () => {
+  // Absent is not malformed: precision with no k scores the whole retrieval.
+  assert.equal(precisionAtK(RANKED, TRUTH), 0.25);
+  assert.equal(recallAtK(RANKED, TRUTH, null), 1);
+  const score = scoreRanking({ ranked: RANKED, groundTruth: { keys: TRUTH } });
+  assert.deepEqual(Object.keys(score.precisionAtK), ["1", "3", "5"]);
+});

--- a/packages/web/eslint.config.mjs
+++ b/packages/web/eslint.config.mjs
@@ -126,6 +126,9 @@ export default [
   {
     // `storybook-static/**` is the Storybook build artifact (gitignored); the
     // MSW worker is a generated vendor file — neither should be linted.
+    // `**/next-env.d.ts` is a NEW ignore, not a re-scoping: it is a Next.js
+    // *generated* declaration file (rewritten on every build, gitignored), so
+    // linting it only ever reports on code nobody edits.
     //
     // Globs are `**/`-prefixed because `@nx/eslint:lint` runs ESLint from the
     // workspace root and passes this config via `--config`; flat-config global

--- a/packages/web/eslint.config.mjs
+++ b/packages/web/eslint.config.mjs
@@ -126,11 +126,21 @@ export default [
   {
     // `storybook-static/**` is the Storybook build artifact (gitignored); the
     // MSW worker is a generated vendor file — neither should be linted.
+    //
+    // Globs are `**/`-prefixed because `@nx/eslint:lint` runs ESLint from the
+    // workspace root and passes this config via `--config`; flat-config global
+    // `ignores` resolve relative to that cwd, so a bare `.next/**` matches the
+    // repo-root `.next`, never `packages/web/.next`. The `**/` prefix makes the
+    // ignore match the package's build output regardless of the base directory,
+    // which is what keeps Next.js-generated `.next/types/*.d.ts` (whose `{}`
+    // ParamMap entries trip `@typescript-eslint/no-empty-object-type`) out of
+    // the lint set.
     ignores: [
-      '.next/**',
-      'node_modules/**',
-      'storybook-static/**',
-      'public/mockServiceWorker.js',
+      '**/.next/**',
+      '**/next-env.d.ts',
+      '**/node_modules/**',
+      '**/storybook-static/**',
+      '**/public/mockServiceWorker.js',
     ],
   },
 ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,10 @@ importers:
       '@lorekit/schemas':
         specifier: workspace:*
         version: link:../schemas
+    devDependencies:
+      '@lorekit/web':
+        specifier: workspace:*
+        version: link:../web
 
   packages/mcp-core:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@lorekit/core':
         specifier: workspace:*
         version: link:../mcp-core
+      '@lorekit/schemas':
+        specifier: workspace:*
+        version: link:../schemas
 
   packages/mcp-core:
     dependencies:


### PR DESCRIPTION
## What

Adds a **retrieval-relevance evaluation harness** to `@lorekit/evals` that scores whether LoreKit surfaces the *right* lessons for a query — pure **precision@k / recall@k / MRR** against a ground-truth set. This is the upstream half of the question the live `claude -p` arms measure downstream, and it **complements, never gates** them (`node --test` only, no model, no network, no CI gate).

## Ground truth is pinned to the real outcome signal, in code

A lesson "should surface" for a query iff the **shipped** `inferKindHost` (`@lorekit/schemas`) resolves its tags to an outcome/relevance bucket — `loop::review-outcomes` (`host: review`) or `loop::reviewer-comment-relevance` (`host: reviewer`) — and its repo-scope matches, weighted by `seen_count` (`>= 3` = recurrence-confirmed). It is **not** a hand-authored label list: `src/ground-truth.mjs` imports the canonical resolver and never re-encodes the `loop::…` literals (a grep guard `AC-1-reuse` fails if they reappear — the recurring "mock that reimplements the thing under test" trap).

## ⚠️ The committed baseline is a 2-row BOOTSTRAP PLACEHOLDER

`fixtures/ground-truth.seed.json` is a **bootstrap placeholder**, not a real baseline. It holds the only two outcome/relevance-tagged rows that already exist in-repo (metadata-only, from `packages/web/src/mocks/memories.ts` rows m05/m06). Every metrics object it produces carries a loud `baseline.warning`:

> **These numbers MUST NOT be used to gate downstream PRs (e.g. A1/A4)** until `bin/mine-ground-truth.mjs` has run against the hosted store and a real `fixtures/ground-truth.real.json` snapshot is committed.

### Placeholder baseline numbers (best-case ranking on the 2-row seed)

| metric | @1 | @3 | @5 |
| --- | --- | --- | --- |
| precision@k | 1.00 | 0.67 | 0.40 |
| recall@k | 0.50 | 1.00 | 1.00 |

MRR = 1.0 · ground-truth size = 2 · `baseline.source = bootstrap-seed`

These are **placeholder** figures from a 2-row seed with `seenCount: 0` (the mock carries no `seen_count`). **Do not gate anything on them.**

## The `mine` script (committed, NOT run this change)

`bin/mine-ground-truth.mjs` is a **manual, one-shot** service-role/remote miner that freezes a **metadata-only** `fixtures/ground-truth.real.json` (scope, key, tags, origin_pr, seenCount — **never** the lesson body) after a privacy pre-flight. It:

- is wired into **no** CI job, npm script, nx target or `node --test` file (`AC-7-nowire` keeps it so);
- **refuses** to touch the network without `--confirm` **and** a usable remote connection (`AC-6` proves `main([])` exits non-zero with zero network calls);
- was **not run here** — no hosted access this change. Running it and committing its output is the step, and the only step, that turns the placeholder baseline into a real one (see the README runbook).

## Tests

`cd packages/evals && node --test test/*.test.mjs` → **147/147 green**, fast + deterministic. New suites: `ground-truth`, `relevance-metrics`, `relevance-integration` (imports the real `MEMORY_ROWS` mock + a seed drift-check), `mine-ground-truth`, `relevance-docs`.

## CI fix included in this branch

`packages/web/eslint.config.mjs` — the flat-config global `ignores` are resolved from the workspace root by `@nx/eslint:lint`, so the bare globs matched the repo-root paths rather than the package's. They are now `**/`-prefixed, and `**/next-env.d.ts` is ignored as a Next.js generated, gitignored declaration file.

## Review follow-ups (all resolved)

- Added the `AC-1-reuse` grep guard the module and README cite — it did not previously exist.
- `bin/mine-ground-truth.mjs` now walks `remote.list` pagination (`hasMore` / `nextCursor`) and refuses to write a truncated snapshot.
- `--scope` / `--out` reject a missing or empty value instead of consuming the next flag.
- `@lorekit/web` is declared as a devDependency so the mock import no longer crosses an undeclared graph edge.
- A string `seen_count` is mined as a number (reuses `seenCountOf`) instead of `null`.
- A malformed `k` is surfaced rather than silently defaulted to 1.

## Note on CI

The `web:build` check may show red: `main` currently fails to build `web` on an unrelated `@/components/ui/Combobox` type error, and CI's `nx affected` (a lockfile change from the new `@lorekit/schemas` dep) drags that build in. **That failure predates this branch and is not caused by this change** — the evals test command that proves this work is green.

## Base for A1

Branch: `feat/evals-retrieval-relevance-metrics` — use this as the base for the A1 work.

