### PR TITLE
feat(mcp): add order=rank mode to hosted edge memory.list toolList

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -139,7 +139,7 @@ Read a single lesson by scope + key.
 
 ## memory.list
 
-List all lessons for a scope, newest first.
+List all lessons for a scope — newest first by default, or best-first with `order: "rank"`.
 
 ```json
 {
@@ -148,7 +148,8 @@ List all lessons for a scope, newest first.
     "arguments": {
       "scope": "global",
       "tags": ["skill::aw"],
-      "limit": 20
+      "limit": 20,
+      "order": "rank"
     }
   }
 }
@@ -159,8 +160,14 @@ List all lessons for a scope, newest first.
 | `scope` | required | Scope to list |
 | `tags` | `[]` | Filter — only return lessons with at least one of these tags |
 | `limit` | `50` | Max results (cap: 100) |
+| `cursor` | | Opaque cursor from a previous response's `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` |
+| `order` | `recency` | `recency` — `updated_at` desc with cursor pagination. `rank` — salience + recency scoring over a bounded candidate window, returned as a single top-N page |
 
-**Returns:** `{ "entries": [{ "key", "value", "tags", "updated_at" }] }`
+**Returns:** `{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }`
+
+- `recency` (default): pass `nextCursor` back as `cursor` to read the next page.
+- `rank`: a single bounded top-N page — `hasMore` is always `false` and `nextCursor` always `null`.
+  Raise `limit` (cap 100) rather than paginating.
 
 ---
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -168,6 +168,9 @@ List all lessons for a scope — newest first by default, or best-first with `or
 - `recency` (default): pass `nextCursor` back as `cursor` to read the next page.
 - `rank`: a single bounded top-N page — `hasMore` is always `false` and `nextCursor` always `null`.
   Raise `limit` (cap 100) rather than paginating.
+  Ranking scores at most the **200 most recently updated** rows in the scope (a bounded candidate
+  window); in a scope with more than 200 active lessons the ranking is over that recency window,
+  not the whole scope, and `hasMore: false` reflects the page — not that the scope is exhausted.
 
 ---
 

--- a/packages/mcp-core/src/list-rank-order.spec.ts
+++ b/packages/mcp-core/src/list-rank-order.spec.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { rankLessons } from './lesson-rank.js';
+
+/**
+ * AC-3: When ranking is applied over a candidate set whose recency order and
+ * rank order differ (an older row with a higher seen_count), the real edge
+ * rankLessons order shall differ from the raw updated_at desc order.
+ *
+ * This spec exercises the REAL edge `rankLessons` (imported from
+ * `lesson-rank.ts`, the file mirrored into `supabase/functions/_shared/`).
+ * It does NOT re-encode an expected list — the assertion is structural:
+ * "ranked order != recency order on this fixture".
+ *
+ * MENTAL REVERT CHECK: if you remove the rankLessons call and return candidates
+ * in their original updated_at desc order, the first key would be 'newer-low'
+ * (index 0 in the recency list), but the ranked first key should be
+ * 'older-high' (high seen_count wins despite being older). The test below
+ * verifies exactly this divergence — a revert to recency order flips it red.
+ */
+
+describe('toolList order=rank: ranked order diverges from recency order', () => {
+  const NOW = Date.parse('2026-08-01T00:00:00.000Z');
+  const daysAgo = (n: number) => new Date(NOW - n * 86400000).toISOString();
+
+  /**
+   * A fixture designed so recency order and rank order MUST differ:
+   * - 'newer-low'  is the freshest (0 days old) but has seen_count = 0 → low salience.
+   * - 'older-high' is older (60 days old) but has seen_count = 9 → high salience.
+   *
+   * At DEFAULT_RANK_WEIGHTS (recency:1, salience:1, relevance:1 → equal thirds),
+   * the salience boost of 'older-high' (seen_count 9 >> 0) outweighs its
+   * recency penalty vs 'newer-low' at 60 days old (still above 0 due to
+   * finite half-life), so rankLessons places 'older-high' first.
+   */
+  const candidates = [
+    { id: '1', key: 'newer-low', scope: 'global', value: 'v', tags: [], updated_at: daysAgo(0), seen_count: 0 },
+    { id: '2', key: 'older-high', scope: 'global', value: 'v', tags: [], updated_at: daysAgo(60), seen_count: 9 },
+  ];
+
+  it('recency order (input order) puts newer-low first', () => {
+    // Sanity-check: the input is already in updated_at desc order.
+    expect(candidates[0].key).toBe('newer-low');
+    expect(candidates[1].key).toBe('older-high');
+  });
+
+  it('rank order (real rankLessons) puts older-high first — proving ranked != recency', () => {
+    const ranked = rankLessons(candidates, { now: NOW });
+    expect(ranked.length).toBe(2);
+
+    // The older-but-high-seen_count row must rank first. If this assertion
+    // fails, either rankLessons changed semantics or the fixture no longer
+    // creates the divergence (both are detectable regressions).
+    expect(ranked[0].entry.key).toBe('older-high');
+    expect(ranked[1].entry.key).toBe('newer-low');
+
+    // Extra guard: scores confirm the ranking is meaningful, not a tie.
+    expect(ranked[0].score).toBeGreaterThan(ranked[1].score);
+  });
+
+  it('the ranked order differs from the updated_at desc order', () => {
+    const recencyKeys = candidates.map((c) => c.key); // updated_at desc
+    const rankedKeys = rankLessons(candidates, { now: NOW }).map((r) => r.entry.key);
+
+    // This is the central AC-3 assertion: the two orderings must NOT be
+    // identical. A mental revert (returning candidates in recency order)
+    // would yield ['newer-low', 'older-high'] for both, making this fail.
+    expect(rankedKeys).not.toEqual(recencyKeys);
+  });
+});

--- a/packages/mcp-core/src/list-rank-order.spec.ts
+++ b/packages/mcp-core/src/list-rank-order.spec.ts
@@ -11,11 +11,15 @@ import { rankLessons } from './lesson-rank.js';
  * It does NOT re-encode an expected list — the assertion is structural:
  * "ranked order != recency order on this fixture".
  *
- * MENTAL REVERT CHECK: if you remove the rankLessons call and return candidates
- * in their original updated_at desc order, the first key would be 'newer-low'
- * (index 0 in the recency list), but the ranked first key should be
- * 'older-high' (high seen_count wins despite being older). The test below
- * verifies exactly this divergence — a revert to recency order flips it red.
+ * SCOPE — read this before trusting the spec as a gate. It exercises
+ * `rankLessons` only, which this PR does not modify. It therefore proves the
+ * PREMISE the ranked `toolList` branch rests on — that ranked order really
+ * does diverge from recency order on a realistic fixture — and it goes red if
+ * `rankLessons` ever loses that property or the fixture stops creating the
+ * divergence. It does NOT execute the edge `toolList` ranked branch, so
+ * reverting that branch (dropping `order=rank` from `supabase/functions/mcp/
+ * tools.ts`) would leave this spec green. Coverage of the branch itself lives
+ * with the edge function, not here.
  */
 
 describe('toolList order=rank: ranked order diverges from recency order', () => {
@@ -62,8 +66,8 @@ describe('toolList order=rank: ranked order diverges from recency order', () => 
     const rankedKeys = rankLessons(candidates, { now: NOW }).map((r) => r.entry.key);
 
     // This is the central AC-3 assertion: the two orderings must NOT be
-    // identical. A mental revert (returning candidates in recency order)
-    // would yield ['newer-low', 'older-high'] for both, making this fail.
+    // identical. If `rankLessons` were reduced to a pass-through of its input,
+    // both lists would read ['newer-low', 'older-high'] and this would fail.
     expect(rankedKeys).not.toEqual(recencyKeys);
   });
 });

--- a/packages/schemas/src/memory.spec.ts
+++ b/packages/schemas/src/memory.spec.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   DeleteMemoryQuerySchema,
+  MemoryListSchema,
   MemoryWriteSchema,
   ListMemoriesQuerySchema,
   PurgeMemoriesBodySchema,
@@ -221,5 +222,33 @@ describe('ReadActivityResponseSchema', () => {
     // The metric is additive, which is the whole reason a per-scope filter can
     // replace a companion "per-scope total" RPC: the cells sum to the headline.
     expect(parsed.buckets.reduce((n, b) => n + b.count, 0)).toBe(10);
+  });
+});
+
+// ── MemoryListSchema.order (AC-2) ────────────────────────────────────────────
+
+describe('MemoryListSchema order', () => {
+  it('defaults to recency when order is omitted', () => {
+    const parsed = MemoryListSchema.parse({ scope: 'global' });
+    expect(parsed.order).toBe('recency');
+  });
+
+  it('accepts order: recency explicitly', () => {
+    expect(MemoryListSchema.parse({ scope: 'global', order: 'recency' }).order).toBe('recency');
+  });
+
+  it('accepts order: rank', () => {
+    expect(MemoryListSchema.parse({ scope: 'global', order: 'rank' }).order).toBe('rank');
+  });
+
+  it.each(['newest', 'desc', 'relevance', '', 'RANK'])('rejects an invalid order value: %j', (order) => {
+    expect(MemoryListSchema.safeParse({ scope: 'global', order }).success).toBe(false);
+  });
+
+  it('does not affect other fields — limit still defaults to 50', () => {
+    const parsed = MemoryListSchema.parse({ scope: 'global', order: 'rank' });
+    expect(parsed.limit).toBe(50);
+    expect(parsed.cursor).toBeUndefined();
+    expect(parsed.tags).toBeUndefined();
   });
 });

--- a/packages/schemas/src/memory.ts
+++ b/packages/schemas/src/memory.ts
@@ -46,7 +46,7 @@ export const MemoryWriteSchema = z.object({
 export type MemoryWrite = z.infer<typeof MemoryWriteSchema>;
 
 export const MemoryReadSchema = z.object({ scope: ScopeSchema, key: z.string().min(1).max(512) });
-export const MemoryListSchema = z.object({ scope: ScopeSchema, tags: z.array(z.string()).optional(), limit: z.number().int().min(1).max(100).optional().default(50), cursor: z.string().optional() });
+export const MemoryListSchema = z.object({ scope: ScopeSchema, tags: z.array(z.string()).optional(), limit: z.number().int().min(1).max(100).optional().default(50), cursor: z.string().optional(), order: z.enum(['recency', 'rank']).optional().default('recency') });
 export const MemoryDeleteSchema = z.object({ scope: ScopeSchema, key: z.string().min(1).max(512), force: z.boolean().optional().default(false) });
 export const MemorySearchSchema = z.object({ q: z.string().min(1), scopes: z.array(RawScopeSchema).optional(), tags: z.array(z.string()).optional(), limit: z.number().int().min(1).max(100).optional().default(20), cursor: z.string().optional() });
 export const MemoryArchiveSchema = z.object({ scope: ScopeSchema, key: z.string().min(1).max(512) });

--- a/packages/schemas/src/tool-catalog.ts
+++ b/packages/schemas/src/tool-catalog.ts
@@ -185,10 +185,11 @@ export const MCP_TOOLS: readonly McpToolDoc[] = [
         scope,
         tags: { type: 'array', items: { type: 'string' }, description: 'Filter to entries carrying ANY of these labels (OR).' },
         limit,
-        cursor: { type: 'string', description: 'Opaque cursor from a previous response\'s `nextCursor`. Omit to start from the first page.' },
+        cursor: { type: 'string', description: 'Opaque cursor from a previous response\'s `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` (ranked mode returns a single bounded page; `nextCursor` will be null).' },
+        order: { type: 'string', enum: ['recency', 'rank'], default: 'recency', description: 'recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor).' },
       },
     },
-    returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest first. Pass `nextCursor` back as `cursor` to retrieve the next page.',
+    returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or best-first by salience+recency (rank mode). Pass `nextCursor` back as `cursor` to paginate (recency only; `nextCursor` is always null in rank mode).',
   },
   {
     name: 'memory.delete',

--- a/packages/schemas/src/tool-catalog.ts
+++ b/packages/schemas/src/tool-catalog.ts
@@ -185,11 +185,11 @@ export const MCP_TOOLS: readonly McpToolDoc[] = [
         scope,
         tags: { type: 'array', items: { type: 'string' }, description: 'Filter to entries carrying ANY of these labels (OR).' },
         limit,
-        cursor: { type: 'string', description: 'Opaque cursor from a previous response\'s `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` (ranked mode returns a single bounded page; `nextCursor` will be null).' },
+        cursor: { type: 'string', description: 'Opaque cursor from a previous response\'s `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` (ranked mode returns a single bounded page; `hasMore` is always false and `nextCursor` always null).' },
         order: { type: 'string', enum: ['recency', 'rank'], default: 'recency', description: 'recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor).' },
       },
     },
-    returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or best-first by salience+recency (rank mode). Pass `nextCursor` back as `cursor` to paginate (recency only; `nextCursor` is always null in rank mode).',
+    returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or best-first by salience+recency (rank mode). Pass `nextCursor` back as `cursor` to paginate — recency mode only. Rank mode is a single bounded top-N page: `hasMore` is always false and `nextCursor` always null.',
   },
   {
     name: 'memory.delete',

--- a/packages/web/public/llms.txt
+++ b/packages/web/public/llms.txt
@@ -205,11 +205,12 @@ List lessons for a scope.
 | `scope` | ✓ | string | Canonical scope string, e.g. `repo::mthines/lorekit`. |
 | `tags` |  | array | Filter to entries carrying ANY of these labels (OR). _(array of string)_ |
 | `limit` |  | integer | Maximum entries to return. _(1–100, default `50`)_ |
-| `cursor` |  | string | Opaque cursor from a previous response's `nextCursor`. Omit to start from the first page. |
+| `cursor` |  | string | Opaque cursor from a previous response's `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` (ranked mode returns a single bounded page; `hasMore` is always false and `nextCursor` always null). |
+| `order` |  | string | recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor). _(default `recency`)_ |
 
 Requires **read** permission.
 
-Returns: `{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest first. Pass `nextCursor` back as `cursor` to retrieve the next page.
+Returns: `{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or best-first by salience+recency (rank mode). Pass `nextCursor` back as `cursor` to paginate — recency mode only. Rank mode is a single bounded top-N page: `hasMore` is always false and `nextCursor` always null.
 
 ---
 

--- a/supabase/functions/_shared/schemas/memory.ts
+++ b/supabase/functions/_shared/schemas/memory.ts
@@ -51,7 +51,7 @@ export const MemoryWriteSchema = z.object({
 export type MemoryWrite = z.infer<typeof MemoryWriteSchema>;
 
 export const MemoryReadSchema = z.object({ scope: ScopeSchema, key: z.string().min(1).max(512) });
-export const MemoryListSchema = z.object({ scope: ScopeSchema, tags: z.array(z.string()).optional(), limit: z.number().int().min(1).max(100).optional().default(50), cursor: z.string().optional() });
+export const MemoryListSchema = z.object({ scope: ScopeSchema, tags: z.array(z.string()).optional(), limit: z.number().int().min(1).max(100).optional().default(50), cursor: z.string().optional(), order: z.enum(['recency', 'rank']).optional().default('recency') });
 export const MemoryDeleteSchema = z.object({ scope: ScopeSchema, key: z.string().min(1).max(512), force: z.boolean().optional().default(false) });
 export const MemorySearchSchema = z.object({ q: z.string().min(1), scopes: z.array(RawScopeSchema).optional(), tags: z.array(z.string()).optional(), limit: z.number().int().min(1).max(100).optional().default(20), cursor: z.string().optional() });
 export const MemoryArchiveSchema = z.object({ scope: ScopeSchema, key: z.string().min(1).max(512) });

--- a/supabase/functions/_shared/schemas/tool-catalog.ts
+++ b/supabase/functions/_shared/schemas/tool-catalog.ts
@@ -190,10 +190,11 @@ export const MCP_TOOLS: readonly McpToolDoc[] = [
         scope,
         tags: { type: 'array', items: { type: 'string' }, description: 'Filter to entries carrying ANY of these labels (OR).' },
         limit,
-        cursor: { type: 'string', description: 'Opaque cursor from a previous response\'s `nextCursor`. Omit to start from the first page.' },
+        cursor: { type: 'string', description: 'Opaque cursor from a previous response\'s `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` (ranked mode returns a single bounded page; `nextCursor` will be null).' },
+        order: { type: 'string', enum: ['recency', 'rank'], default: 'recency', description: 'recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor).' },
       },
     },
-    returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest first. Pass `nextCursor` back as `cursor` to retrieve the next page.',
+    returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or best-first by salience+recency (rank mode). Pass `nextCursor` back as `cursor` to paginate (recency only; `nextCursor` is always null in rank mode).',
   },
   {
     name: 'memory.delete',

--- a/supabase/functions/_shared/schemas/tool-catalog.ts
+++ b/supabase/functions/_shared/schemas/tool-catalog.ts
@@ -190,11 +190,11 @@ export const MCP_TOOLS: readonly McpToolDoc[] = [
         scope,
         tags: { type: 'array', items: { type: 'string' }, description: 'Filter to entries carrying ANY of these labels (OR).' },
         limit,
-        cursor: { type: 'string', description: 'Opaque cursor from a previous response\'s `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` (ranked mode returns a single bounded page; `nextCursor` will be null).' },
+        cursor: { type: 'string', description: 'Opaque cursor from a previous response\'s `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` (ranked mode returns a single bounded page; `hasMore` is always false and `nextCursor` always null).' },
         order: { type: 'string', enum: ['recency', 'rank'], default: 'recency', description: 'recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor).' },
       },
     },
-    returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or best-first by salience+recency (rank mode). Pass `nextCursor` back as `cursor` to paginate (recency only; `nextCursor` is always null in rank mode).',
+    returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or best-first by salience+recency (rank mode). Pass `nextCursor` back as `cursor` to paginate — recency mode only. Rank mode is a single bounded top-N page: `hasMore` is always false and `nextCursor` always null.',
   },
   {
     name: 'memory.delete',

--- a/supabase/functions/mcp/tools.ts
+++ b/supabase/functions/mcp/tools.ts
@@ -24,9 +24,22 @@ import { recordAudit } from '../_shared/audit.ts';
 import { applyTenantScope } from './tenant-scope.ts';
 import { decodeCursor, buildPage } from './cursor.ts';
 import { resolveKindHost } from '../_shared/schemas/tags.ts';
+import { rankLessons } from '../_shared/lesson-rank.ts';
+import type { RankableLesson } from '../_shared/lesson-rank.ts';
 
 export const MAX_VALUE_BYTES = 65_536;
 export const PURGE_RETENTION_DAYS_DEFAULT = 30;
+
+/**
+ * How many rows the ranked path fetches before scoring. Mirrors the same
+ * constant in `memories/handlers/relevant.ts` — see its docblock for the
+ * rationale and the honest "recency-windowed ranking" caveat.
+ *
+ * Bounded because the cost is real (every candidate is fetched and mostly
+ * discarded). 200 is well above any `limit` this tool accepts (max 100) while
+ * staying one cheap indexed read.
+ */
+const CANDIDATE_LIMIT = 200;
 
 // deno-lint-ignore no-explicit-any
 export type Params = Record<string, any>;
@@ -207,9 +220,62 @@ export async function toolList(
   const scope = validateScope(rawScope);
   const pageLimit = Math.min(limit, 100);
 
+  // Any value other than 'rank' falls through to the recency path (D3/D7).
+  const ranked = params.order === 'rank';
+
   span.setAttributes({ 'lorekit.scope': scope });
 
   const tracedDb = createTracedClient(db, span);
+
+  if (ranked) {
+    // ── Ranked path (D1/D2/D4/D8) ─────────────────────────────────────────
+    // Mirrors `memories/handlers/relevant.ts`: fetch a bounded candidate window
+    // (updated_at desc), rank in TypeScript via the shared edge rankLessons,
+    // return a bounded top-N page. No cursor decode (D7 — cursor is ignored).
+    // seen_count is selected here and dropped from the wire response (D4).
+    let rankQuery = tracedDb
+      .from('memories')
+      .select('id,key,value,tags,updated_at,seen_count')
+      .eq('scope', scope)
+      .is('archived_at', null)
+      .or('expires_at.is.null,expires_at.gt.now()')
+      .order('updated_at', { ascending: false })
+      .order('id', { ascending: false })
+      .limit(CANDIDATE_LIMIT);
+    if (userId) rankQuery = applyTenantScope(rankQuery, userId, await memberOrgIds(db, userId));
+    if (tags?.length) rankQuery = rankQuery.overlaps('tags', tags);
+    const { data: rankData, error: rankError } = await rankQuery;
+    if (rankError) throw new Error(rankError.message);
+
+    const candidates: (RankableLesson & { id: string; key: string; value: string; tags: string[]; updated_at: string | null })[] = (rankData ?? []).map(
+      // deno-lint-ignore no-explicit-any
+      (r: any) => ({
+        id: r.id,
+        key: r.key,
+        value: r.value,
+        tags: r.tags,
+        updated_at: r.updated_at,
+        seen_count: r.seen_count,
+      }),
+    );
+
+    const rankedLessons = rankLessons(candidates, { now: Date.now() });
+    const page = rankedLessons.slice(0, pageLimit);
+    const hasMore = rankedLessons.length > pageLimit;
+
+    const entries = page.map(({ entry }) => ({
+      id: entry.id,
+      key: entry.key,
+      value: entry.value,
+      tags: entry.tags,
+      updated_at: entry.updated_at,
+    }));
+
+    span.setAttributes({ 'lorekit.result.count': entries.length });
+    return { entries, hasMore, nextCursor: null };
+  }
+
+  // ── Recency path (default) — UNCHANGED ──────────────────────────────────
   let query = tracedDb
     .from('memories')
     .select('id,key,value,tags,updated_at')

--- a/supabase/functions/mcp/tools.ts
+++ b/supabase/functions/mcp/tools.ts
@@ -261,7 +261,6 @@ export async function toolList(
 
     const rankedLessons = rankLessons(candidates, { now: Date.now() });
     const page = rankedLessons.slice(0, pageLimit);
-    const hasMore = rankedLessons.length > pageLimit;
 
     const entries = page.map(({ entry }) => ({
       id: entry.id,
@@ -272,7 +271,16 @@ export async function toolList(
     }));
 
     span.setAttributes({ 'lorekit.result.count': entries.length });
-    return { entries, hasMore, nextCursor: null };
+    // `hasMore` is FALSE here by contract, not by accident. Everywhere else in
+    // this codebase `hasMore: true` means "there is another page, and
+    // `nextCursor` is how you reach it" (`cursor.ts` buildPage,
+    // `_shared/api/paginate.ts`). Ranked mode has no cursor, so a `true` would
+    // promise a page no caller can ever fetch. A ranked read is a single
+    // bounded top-N over a CANDIDATE_LIMIT window — the same shape as
+    // `memories/handlers/relevant.ts`, which likewise never advertises
+    // pagination. Truncation is inherent to the mode and documented on the
+    // tool, not signalled per response.
+    return { entries, hasMore: false, nextCursor: null };
   }
 
   // ── Recency path (default) — UNCHANGED ──────────────────────────────────

--- a/supabase/functions/mcp/tools.ts
+++ b/supabase/functions/mcp/tools.ts
@@ -13,7 +13,7 @@
  */
 
 import { createClient } from 'npm:@supabase/supabase-js@2';
-import { validateScope } from '../_shared/scope.ts';
+import { validateScope, UserInputError } from '../_shared/scope.ts';
 import { createTracedClient, type Span } from '../_shared/otel.ts';
 import { translateCapError } from './limits.ts';
 import { translateOrgPermissionError } from './org-permissions.ts';
@@ -220,7 +220,14 @@ export async function toolList(
   const scope = validateScope(rawScope);
   const pageLimit = Math.min(limit, 100);
 
-  // Any value other than 'rank' falls through to the recency path (D3/D7).
+  // Validate `order` against the same closed set the catalog `enum` and
+  // `MemoryListSchema` accept ('recency' | 'rank'). A present-but-invalid value
+  // (e.g. `"Rank"`) must be REJECTED, not silently coerced to recency — a quiet
+  // fallthrough would mask a caller typo and diverge from the schema contract.
+  // `undefined` means "unspecified" and defaults to recency (D3).
+  if (params.order !== undefined && params.order !== 'recency' && params.order !== 'rank') {
+    throw new UserInputError(`Invalid order "${params.order}": expected "recency" or "rank"`);
+  }
   const ranked = params.order === 'rank';
 
   span.setAttributes({ 'lorekit.scope': scope });
@@ -270,7 +277,14 @@ export async function toolList(
       updated_at: entry.updated_at,
     }));
 
-    span.setAttributes({ 'lorekit.result.count': entries.length });
+    // `candidate_count` saturates at CANDIDATE_LIMIT — mirrors the observability
+    // `memories/handlers/relevant.ts` exposes so a truncated window is visible in
+    // telemetry (a `candidate_count === CANDIDATE_LIMIT` read may have ranked over
+    // a windowed subset). `result.count` is the post-`limit` page size.
+    span.setAttributes({
+      'lorekit.result.count': entries.length,
+      'lorekit.candidate_count': candidates.length,
+    });
     // `hasMore` is FALSE here by contract, not by accident. Everywhere else in
     // this codebase `hasMore: true` means "there is another page, and
     // `nextCursor` is how you reach it" (`cursor.ts` buildPage,


### PR DESCRIPTION
## Summary

- Adds a backward-compatible `order` param (`recency` | `rank`, default `recency`) to the hosted edge `toolList` in `supabase/functions/mcp/tools.ts`, so callers (primarily `pr-reviewer` Step 1.0) can opt into relevance-ranked lesson retrieval.
- Ranked mode fetches a bounded 200-row candidate window (`CANDIDATE_LIMIT`, mirroring `relevant.ts`), ranks in TypeScript via the existing shared edge `rankLessons`, and returns a bounded top-N page — **no seek cursor**.
- Default recency path (`decodeCursor`/`buildPage`/`updated_at desc` select) is **byte-for-byte unchanged**.

## Pagination contract

**Ranked mode paginates via bounded top-N (no cursor).** When `order=rank`:
- A `CANDIDATE_LIMIT=200` bounded window is fetched in `updated_at desc` order.
- `rankLessons` reorders in TypeScript (set-relative salience + recency).
- The best `limit` rows are returned; **`hasMore` is always `false` and `nextCursor` always `null`.**
  Everywhere else in this codebase (`mcp/cursor.ts` `buildPage`, `_shared/api/paginate.ts`) a `true`
  `hasMore` implies a reachable `nextCursor`, so ranked mode must not claim pages no caller can fetch.
  Truncation at `CANDIDATE_LIMIT` is inherent to the mode and documented on the tool, not signalled
  per response — the same stance as `memories/handlers/relevant.ts`, which advertises no pagination at all.
- A `cursor` param supplied alongside `order=rank` is **ignored** (D7 — documented behavior; ignoring follows the house style of defensive param reading).
- A present-but-invalid `order` (e.g. `"Rank"`, `"newest"`) is **rejected** with a `UserInputError` (client 4xx, not a span ERROR), matching the `MemoryListSchema` / catalog `enum` contract. Only an omitted `order` falls back to recency.
- Ranked reads set `lorekit.candidate_count` on the span (alongside `lorekit.result.count`), so a read that saturated the `CANDIDATE_LIMIT` window is observable in telemetry — mirroring `relevant.ts`.

## Docs surfaces

- `packages/schemas/src/tool-catalog.ts` + its `supabase/functions/_shared/schemas/` mirror — `order` argument and the ranked-mode returns contract.
- `packages/web/public/llms.txt` — regenerated with `generate:llms`; `render.spec.ts`'s byte-equality drift guard is green.
- `docs/mcp-tools.md` — `order` and `cursor` rows, the full `hasMore`/`nextCursor` returns line, and a note that ranked mode scores only the bounded 200-row recency window (not the whole scope).

## Verification

- `pnpm nx test schemas` (146 tests) green — includes `render.spec.ts` (19), the `llms.txt` byte-equality drift guard `CLAUDE.md:167` names. This is the guard CI runs; a `mcp-core`-only run does not cover it.
- `pnpm nx test mcp-core` (1009 tests) green — includes `tool-catalog-parity`, `edge-schema-parity` (edge `_shared` mirrors verified unmodified), `edge-parity`, `lesson-rank-parity`, `rest-tool-name`, and `list-rank-order.spec.ts` (the ranking-logic premise the ranked branch rests on).
- `packages/schemas/src/memory.spec.ts` — `MemoryListSchema.order` accepts `recency`/`rank` and rejects invalid values (`'RANK'`, `'newest'`, …).

## Ranked-branch coverage — honest scope

The **ranking logic** (`rankLessons`) is unit-covered by `list-rank-order.spec.ts`, and the **`order` schema** (accept/reject) by `memory.spec.ts`. The **edge `toolList` ranked branch wiring itself** (DB window fetch → `rankLessons` → top-N page) is **not** executed by any in-repo test:

- It imports Deno-only specifiers (`npm:@supabase/supabase-js`), so it cannot be imported under the vitest (Node) suites the way `list-rank-order.spec.ts` imports `rankLessons`.
- The CI `integration` job's stdio-transport smoke exercises `memory.list` in **recency** mode only, and via the CLI's REST `/memories` store — which is a different handler than the MCP edge `toolList` and does not forward `order`. So it does **not** exercise the ranked branch. (The earlier body claim that it did was inaccurate and has been removed.)

Adding executed coverage for the branch would require either a Deno test harness (no `deno test` CI job exists for these functions) or the stdio path to forward `order` (the CLI's `MEMORY_TOOL_DEFS` schema and remote-store `list()` omit it today — hosted MCP is the only intended caller for now). Both are out of scope for this PR and tracked as follow-ups.

## Consideration #1 deferral

The suppression-priority lane (finding-keyed rank boost) is **deferred to a B-chain PR** (D5). `memory.list` carries no query term so it cannot key priority to a specific finding; the clean affordance is `memory.search`/`relevant`, which already rank.

## Base

Base is **`main`** — the stacked base PR (`feat/evals-retrieval-relevance-metrics`, #449) has merged. This branch remains the base for the next A-layer PR in the "LoreKit retrieval relevance" stack.

## Test plan

- [x] `pnpm nx test schemas` → 146 green, incl. `render.spec.ts` `llms.txt` drift guard (AC-1)
- [x] `pnpm nx test mcp-core` → 1009 green, incl. `tool-catalog-parity` + `edge-schema-parity` + `list-rank-order.spec.ts` (AC-2/AC-3)
- [x] `git diff origin/main -- supabase/functions/mcp/tools.ts | grep -E '^-' | grep -E 'decodeCursor|buildPage|updated_at'` → no output (recency path unchanged)
- [x] `git diff --name-only origin/main -- pnpm-lock.yaml` → no output (no lockfile churn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
