### PR TITLE
feat(rank): outcome factor + cold-start prior in lesson scorer

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -161,7 +161,7 @@ List all lessons for a scope — newest first by default, or best-first with `or
 | `tags` | `[]` | Filter — only return lessons with at least one of these tags |
 | `limit` | `50` | Max results (cap: 100) |
 | `cursor` | | Opaque cursor from a previous response's `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` |
-| `order` | `recency` | `recency` — `updated_at` desc with cursor pagination. `rank` — salience + recency scoring over a bounded candidate window, returned as a single top-N page |
+| `order` | `recency` | `recency` — `updated_at` desc with cursor pagination. `rank` — four-factor scoring (recency, salience, relevance, outcome) over a bounded candidate window, returned as a single top-N page |
 
 **Returns:** `{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }`
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -161,7 +161,7 @@ List all lessons for a scope — newest first by default, or best-first with `or
 | `tags` | `[]` | Filter — only return lessons with at least one of these tags |
 | `limit` | `50` | Max results (cap: 100) |
 | `cursor` | | Opaque cursor from a previous response's `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` |
-| `order` | `recency` | `recency` — `updated_at` desc with cursor pagination. `rank` — four-factor scoring (recency, salience, relevance, outcome) over a bounded candidate window, returned as a single top-N page |
+| `order` | `recency` | `recency` — `updated_at` desc with cursor pagination. `rank` — scores recency, salience, and outcome over a bounded candidate window, returned as a single top-N page. (The scorer's fourth factor, relevance, needs a query string; `memory.list` supplies none, so relevance is a constant 0 here and only contributes on the search/`q` path.) |
 
 **Returns:** `{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }`
 

--- a/packages/cli/src/lessons-pure.mjs
+++ b/packages/cli/src/lessons-pure.mjs
@@ -225,11 +225,12 @@ export function resolveScopeKeyArgs(positionals = [], options = {}) {
 //               when no terms are supplied, which is the SessionStart case: it
 //               then contributes the same constant to every candidate and the
 //               ordering is recency + salience alone.
-//   outcome   — applied/resolution history in [0,1]. A lesson that was carried
-//               to a PR or tagged on an outcome bus ranks up; one never applied
-//               sinks. A cold new lesson with no history gets the
-//               COLD_START_OUTCOME_PRIOR (0.5) so it ranks on recency and
-//               relevance instead of being penalised for lacking history.
+//   outcome   — applied/resolution history in [0,1]. The factor only ever
+//               LIFTS: a lesson tagged on an outcome bus scores 1.0 and one
+//               carried to a PR 0.75, while a lesson with no history gets the
+//               COLD_START_OUTCOME_PRIOR (0.5) — the neutral floor, never 0.
+//               So a proven lesson ranks up; an unproven one is not penalised
+//               for lacking history and rides on recency and relevance.
 //
 // PURE AND TOTAL, with one scoped exception. `now` is a PARAMETER: the
 // arithmetic never reads the clock, every factor is a function of the value
@@ -440,7 +441,6 @@ export function scoreLesson(entry, {
 } = {}) {
   return scoreWithTerms(entry, distinctTerms(terms), { now, weights, maxSeenCount, halfLifeDays });
 }
-
 
 // `scoreLesson` with the query already normalised. `rankLessons` calls this so
 // the whole ranking normalises the query once; `scoreLesson` normalises and

--- a/packages/cli/src/lessons-pure.mjs
+++ b/packages/cli/src/lessons-pure.mjs
@@ -212,7 +212,7 @@ export function resolveScopeKeyArgs(positionals = [], options = {}) {
 // takes every slot, evicting the durable lessons that have been re-learned a
 // dozen times. Recency is a signal, not the ranking.
 //
-// The score is a weighted sum of three factors, each normalised to [0,1]:
+// The score is a weighted sum of four factors, each normalised to [0,1]:
 //
 //   recency   — exponential decay on age. Half-life, not a cliff: a lesson does
 //               not stop mattering on a particular day.
@@ -225,6 +225,11 @@ export function resolveScopeKeyArgs(positionals = [], options = {}) {
 //               when no terms are supplied, which is the SessionStart case: it
 //               then contributes the same constant to every candidate and the
 //               ordering is recency + salience alone.
+//   outcome   — applied/resolution history in [0,1]. A lesson that was carried
+//               to a PR or tagged on an outcome bus ranks up; one never applied
+//               sinks. A cold new lesson with no history gets the
+//               COLD_START_OUTCOME_PRIOR (0.5) so it ranks on recency and
+//               relevance instead of being penalised for lacking history.
 //
 // PURE AND TOTAL, with one scoped exception. `now` is a PARAMETER: the
 // arithmetic never reads the clock, every factor is a function of the value
@@ -243,7 +248,7 @@ export function resolveScopeKeyArgs(positionals = [], options = {}) {
 // nothing — a year-old lesson that has recurred 30 times still deserves a slot.
 export const RECENCY_HALF_LIFE_DAYS = 14;
 
-// Equal thirds. Deliberately not tuned: with no corpus to tune against, an
+// Equal quarters. Deliberately not tuned: with no corpus to tune against, an
 // invented weighting is a guess wearing a decimal point. They are a parameter
 // so a caller can experiment, and so a future PR can change them with evidence.
 //
@@ -253,7 +258,21 @@ export const RECENCY_HALF_LIFE_DAYS = 14;
 // recursion (a real `RangeError`, raised inside a hook the header promises will
 // never throw). Freezing makes the corruption a `TypeError` at the assignment,
 // in the caller's own frame, instead of a stack overflow three layers down.
-export const DEFAULT_RANK_WEIGHTS = Object.freeze({ recency: 1, salience: 1, relevance: 1 });
+export const DEFAULT_RANK_WEIGHTS = Object.freeze({ recency: 1, salience: 1, relevance: 1, outcome: 1 });
+
+/**
+ * The cold-start prior for the outcome factor. A new lesson with no applied /
+ * resolution history gets this value rather than 0. The rationale: scoring
+ * absent outcome at 0 would sink every new lesson below stale ones purely for
+ * lacking outcome history (outcome-lag). 0.5 is the neutral midpoint of [0,1]
+ * — a cold lesson contributes an average outcome term, so it ranks on
+ * recency and relevance instead of being penalised for being new.
+ *
+ * This is the ONE deliberate asymmetry vs `normalizeRelevance` (which returns
+ * 0 for absent / unreadable input). Mirrored byte-identically in
+ * `packages/mcp-core/src/lesson-rank.ts` and its edge twin.
+ */
+export const COLD_START_OUTCOME_PRIOR = 0.5;
 
 // Two scores closer than this are the same score. Sized well below any
 // difference the factors can produce meaningfully (a one-second age gap moves a
@@ -380,6 +399,21 @@ function distinctTerms(terms) {
 }
 
 /**
+ * Normalize an outcome value into [0,1]. Absent or unreadable input returns
+ * `COLD_START_OUTCOME_PRIOR` — the deliberate asymmetry vs `normalizeRelevance`
+ * (which returns 0 for absent input). A present value is clamped to [0,1].
+ *
+ * The cold-start prior ensures a new lesson with no outcome history is not
+ * penalised during outcome-lag — it contributes an average outcome term and
+ * ranks on recency + relevance instead.
+ */
+export function normalizeOutcome(value) {
+  const n = typeof value === 'string' ? Number(value) : value;
+  if (typeof n !== 'number' || !Number.isFinite(n)) return COLD_START_OUTCOME_PRIOR;
+  return Math.min(1, Math.max(0, n));
+}
+
+/**
  * Score one lesson in [0,1].
  *
  * `maxSeenCount` belongs to the candidate SET, so this is normally reached
@@ -407,6 +441,7 @@ export function scoreLesson(entry, {
   return scoreWithTerms(entry, distinctTerms(terms), { now, weights, maxSeenCount, halfLifeDays });
 }
 
+
 // `scoreLesson` with the query already normalised. `rankLessons` calls this so
 // the whole ranking normalises the query once; `scoreLesson` normalises and
 // delegates, so no caller has to know a normalised set exists.
@@ -415,21 +450,24 @@ function scoreWithTerms(entry, termSet, { now, weights, maxSeenCount, halfLifeDa
     recency: numberOr(weights?.recency, DEFAULT_RANK_WEIGHTS.recency),
     salience: numberOr(weights?.salience, DEFAULT_RANK_WEIGHTS.salience),
     relevance: numberOr(weights?.relevance, DEFAULT_RANK_WEIGHTS.relevance),
+    outcome: numberOr(weights?.outcome, DEFAULT_RANK_WEIGHTS.outcome),
   };
-  let total = w.recency + w.salience + w.relevance;
+  let total = w.recency + w.salience + w.relevance + w.outcome;
   if (!(total > 0)) {
     w = {
       recency: numberOr(DEFAULT_RANK_WEIGHTS.recency, 0),
       salience: numberOr(DEFAULT_RANK_WEIGHTS.salience, 0),
       relevance: numberOr(DEFAULT_RANK_WEIGHTS.relevance, 0),
+      outcome: numberOr(DEFAULT_RANK_WEIGHTS.outcome, 0),
     };
-    total = w.recency + w.salience + w.relevance;
+    total = w.recency + w.salience + w.relevance + w.outcome;
   }
   if (!(total > 0)) return 0;
   const recency = recencyFactor(entry?.updatedAt ?? entry?.updated_at ?? entry?.updated, now, halfLifeDays);
   const salience = salienceFactor(seenCountFrom(entry), maxSeenCount);
   const relevance = relevanceFromTerms(entry, termSet);
-  return (w.recency * recency + w.salience * salience + w.relevance * relevance) / total;
+  const outcome = normalizeOutcome(entry?.outcome);
+  return (w.recency * recency + w.salience * salience + w.relevance * relevance + w.outcome * outcome) / total;
 }
 
 // A non-negative finite number, or the fallback. Guards a caller passing a

--- a/packages/cli/test/unit.test.mjs
+++ b/packages/cli/test/unit.test.mjs
@@ -1749,14 +1749,30 @@ describe('scoreLesson factors', () => {
     const keys = ranked.map((e) => e.key);
     assert.equal(keys[0], 'cold-new', 'cold new row must rank first — prior is not 0');
 
-    // Mental revert: if prior were 0 the cold row would get outcome:0 just like
-    // the old row, so the ordering would depend solely on recency (cold-new would
-    // still win, but the test demonstrates the prior's role).
-    // Setting both to outcome:0.0 makes the cold-new still win on recency —
-    // but the point is that a COLD row should not be penalised for absent history.
-    // Assert the prior equals COLD_START_OUTCOME_PRIOR (not 0):
-    assert.ok(COLD_START_OUTCOME_PRIOR > 0, 'COLD_START_OUTCOME_PRIOR must be greater than 0');
-    assert.ok(COLD_START_OUTCOME_PRIOR <= 1, 'COLD_START_OUTCOME_PRIOR must be at most 1');
+    // The load-bearing check: hold recency, salience and relevance EQUAL between
+    // the two rows so the ONLY difference is outcome. The cold row (absent
+    // outcome → prior) must still outrank an explicit `outcome: 0` row — that
+    // ordering can only come from the prior being > 0. Zeroing the prior would
+    // tie the two, so this assertion fails the moment the prior degrades.
+    const coldSameAge = { key: 'cold', updatedAt: daysAgo(3), seenCount: 5 };
+    const zeroSameAge = { key: 'zero', updatedAt: daysAgo(3), seenCount: 5, outcome: 0.0 };
+    const tieRank = rankLessons([zeroSameAge, coldSameAge], { now: NOW });
+    assert.equal(tieRank[0].key, 'cold', 'cold (prior) must outrank an equally-recent outcome:0 row');
+
+    // Score the pair against the same population (maxSeenCount) rankLessons uses,
+    // so the strict-greater is on the ranking's own arithmetic, not a re-derived
+    // one. The gap is exactly the prior contribution: COLD_START_OUTCOME_PRIOR/4.
+    const opts = { now: NOW, maxSeenCount: 5 };
+    const coldScore = scoreLesson(coldSameAge, opts);
+    const zeroScore = scoreLesson(zeroSameAge, opts);
+    assert.ok(
+      coldScore > zeroScore,
+      'the prior must produce a strictly higher score, not a tie broken by key order',
+    );
+    assert.ok(
+      Math.abs((coldScore - zeroScore) - COLD_START_OUTCOME_PRIOR / 4) < 1e-9,
+      'the score gap is exactly the prior spread over the four equal weights',
+    );
   });
 });
 

--- a/packages/cli/test/unit.test.mjs
+++ b/packages/cli/test/unit.test.mjs
@@ -14,7 +14,7 @@ import {
 } from '../src/lessons-view.mjs';
 import {
   rankLessons, scoreLesson, recencyFactor, salienceFactor, relevanceFactor,
-  RECENCY_HALF_LIFE_DAYS, DEFAULT_RANK_WEIGHTS,
+  normalizeOutcome, RECENCY_HALF_LIFE_DAYS, DEFAULT_RANK_WEIGHTS, COLD_START_OUTCOME_PRIOR,
 } from '../src/lessons-pure.mjs';
 import { MEMORY_TOOL_DEFS } from '../src/mcp-server.mjs';
 
@@ -1674,12 +1674,12 @@ describe('scoreLesson factors', () => {
       TypeError,
       'a write must fail in the caller frame, not three layers down the stack',
     );
-    assert.deepEqual({ ...DEFAULT_RANK_WEIGHTS }, { recency: 1, salience: 1, relevance: 1 });
+    assert.deepEqual({ ...DEFAULT_RANK_WEIGHTS }, { recency: 1, salience: 1, relevance: 1, outcome: 1 });
 
     // Belt and braces: the fallback substitutes once instead of recursing, so
     // totality no longer depends on the export having gone unmutated.
     const entry = { key: 'k', value: '', seenCount: 1, updatedAt: daysAgo(1) };
-    const zeroed = { recency: 0, salience: 0, relevance: 0 };
+    const zeroed = { recency: 0, salience: 0, relevance: 0, outcome: 0 };
     assert.equal(
       scoreLesson(entry, { now: NOW, weights: zeroed }),
       scoreLesson(entry, { now: NOW }),
@@ -1696,6 +1696,67 @@ describe('scoreLesson factors', () => {
       const s = scoreLesson(entry, { now: NOW, terms: ['timeout'], maxSeenCount });
       assert.ok(s >= 0 && s <= 1, `score ${s} out of range for maxSeenCount ${String(maxSeenCount)}`);
     }
+  });
+
+  // ── AC-3: normalizeOutcome cold-start prior ──────────────────────────────
+  test('normalizeOutcome returns COLD_START_OUTCOME_PRIOR for absent/unreadable input', () => {
+    // The deliberate asymmetry vs normalizeRelevance (which returns 0 for absent
+    // input). A cold lesson should rank on recency + relevance, not be penalised.
+    for (const absent of [null, undefined, NaN, 'nope', {}]) {
+      assert.equal(
+        normalizeOutcome(absent),
+        COLD_START_OUTCOME_PRIOR,
+        `normalizeOutcome(${String(absent)}) should return COLD_START_OUTCOME_PRIOR`,
+      );
+    }
+  });
+
+  test('normalizeOutcome clamps a present value into [0,1]', () => {
+    assert.equal(normalizeOutcome(2), 1, 'clamped to 1');
+    assert.equal(normalizeOutcome(-1), 0, 'clamped to 0');
+    assert.ok(Math.abs(normalizeOutcome(0.5) - 0.5) < 1e-15, 'identity at midpoint');
+    assert.ok(Math.abs(normalizeOutcome('0.5') - 0.5) < 1e-15, 'string coercion');
+  });
+
+  // ── AC-1: outcome-positive outranks outcome-negative ────────────────────
+  test('outcome-positive row outranks outcome-negative row at equal recency+salience (real rankLessons)', () => {
+    // Two rows identical in everything except outcome. The outcome factor must
+    // be load-bearing: dropping it (setting outcome:0 weight) removes the
+    // ordering (both score identically).
+    const shared = { seenCount: 5, updatedAt: daysAgo(3) };
+    const positive = { ...shared, key: 'positive', outcome: 1.0 };
+    const negative = { ...shared, key: 'negative', outcome: 0.0 };
+    const ranked = rankLessons([negative, positive], { now: NOW });
+    const keys = ranked.map((e) => e.key);
+    assert.equal(keys.indexOf('positive'), 0, 'outcome-positive must rank first');
+    assert.equal(keys.indexOf('negative'), 1, 'outcome-negative must rank second');
+
+    // Mental revert: without the outcome weight the rows tie (same recency+salience),
+    // meaning outcome IS the load-bearing differentiator.
+    const rankNoOutcome = rankLessons([negative, positive], { now: NOW, weights: { recency: 1, salience: 1, relevance: 1, outcome: 0 } });
+    const bucketsNoOutcome = rankNoOutcome.map((r) => Math.round(r.score / 1e-9));
+    assert.equal(bucketsNoOutcome[0], bucketsNoOutcome[1], 'without outcome weight, the rows tie');
+  });
+
+  // ── AC-2: cold-start prior — cold new row outranks old low-relevance row ─
+  test('cold new row outranks old low-relevance row (cold-start prior not zero, real rankLessons)', () => {
+    // A cold recent row (no outcome data, recent, relevance match) versus an old
+    // low-relevance stale row. The cold row should still win via recency and the
+    // non-zero cold-start prior.
+    const coldNew = { key: 'cold-new', updatedAt: daysAgo(1), seenCount: 1, terms: ['timeout'] };
+    const oldStale = { key: 'old-stale', updatedAt: daysAgo(90), seenCount: 1, outcome: 0.0, terms: ['timeout'] };
+    const ranked = rankLessons([oldStale, coldNew], { now: NOW });
+    const keys = ranked.map((e) => e.key);
+    assert.equal(keys[0], 'cold-new', 'cold new row must rank first — prior is not 0');
+
+    // Mental revert: if prior were 0 the cold row would get outcome:0 just like
+    // the old row, so the ordering would depend solely on recency (cold-new would
+    // still win, but the test demonstrates the prior's role).
+    // Setting both to outcome:0.0 makes the cold-new still win on recency —
+    // but the point is that a COLD row should not be penalised for absent history.
+    // Assert the prior equals COLD_START_OUTCOME_PRIOR (not 0):
+    assert.ok(COLD_START_OUTCOME_PRIOR > 0, 'COLD_START_OUTCOME_PRIOR must be greater than 0');
+    assert.ok(COLD_START_OUTCOME_PRIOR <= 1, 'COLD_START_OUTCOME_PRIOR must be at most 1');
   });
 });
 

--- a/packages/mcp-core/src/edge-parity.spec.ts
+++ b/packages/mcp-core/src/edge-parity.spec.ts
@@ -80,6 +80,11 @@ const MIRRORS: ReadonlyArray<readonly [string, string]> = [
   // cross-LANGUAGE twin that no byte comparison can cover — the CLI's
   // `lessons-pure.mjs` — guarded behaviourally by `lesson-rank-parity.spec.ts`.
   ['lesson-rank.ts', '_shared/lesson-rank.ts'],
+  // The tags/origin_pr → outcome-factor mapping the ranked reads feed the
+  // scorer. Mirrored because BOTH ranked edge paths derive it —
+  // memories/handlers/relevant.ts and mcp/tools.ts (order=rank) — and neither
+  // can cross-import mcp-core; hoisted out of both so the two cannot drift.
+  ['outcome-signal.ts', '_shared/outcome-signal.ts'],
   // Two rules lifted OUT of Deno-only files so vitest can assert them:
   // rest-audit-actor.ts is `auditUserId` (was inline in _shared/api/auth.ts),
   // rest-response-outcome.ts is the status→usage_events.outcome

--- a/packages/mcp-core/src/lesson-rank-parity.spec.ts
+++ b/packages/mcp-core/src/lesson-rank-parity.spec.ts
@@ -5,9 +5,11 @@ import {
   scoreLesson as scoreTs,
   recencyFactor as recencyTs,
   salienceFactor as salienceTs,
+  normalizeOutcome as normalizeOutcomeTs,
   RECENCY_HALF_LIFE_DAYS as HALF_LIFE_TS,
   DEFAULT_RANK_WEIGHTS as WEIGHTS_TS,
   SCORE_EPSILON as EPSILON_TS,
+  COLD_START_OUTCOME_PRIOR,
 } from './lesson-rank.js';
 
 /**
@@ -37,9 +39,11 @@ const cli = await import(/* @vite-ignore */ `file://${cliModulePath}`) as {
   scoreLesson: (entry: unknown, opts?: Record<string, unknown>) => number;
   recencyFactor: (updatedAt: unknown, now: unknown, halfLifeDays?: number) => number;
   salienceFactor: (seen: unknown, max: unknown) => number;
+  normalizeOutcome: (value: unknown) => number;
   RECENCY_HALF_LIFE_DAYS: number;
-  DEFAULT_RANK_WEIGHTS: { recency: number; salience: number; relevance: number };
+  DEFAULT_RANK_WEIGHTS: { recency: number; salience: number; relevance: number; outcome: number };
   SCORE_EPSILON: number;
+  COLD_START_OUTCOME_PRIOR: number;
 };
 
 const NOW = Date.parse('2026-08-01T00:00:00.000Z');
@@ -175,7 +179,9 @@ describe('lesson-rank: the server-only relevance input', () => {
   it('clamps an out-of-range or unusable relevance', () => {
     const at = (relevance: unknown) => scoreTs(
       { scope: 'g', key: 'k', relevance: relevance as number },
-      { now: NOW, weights: { recency: 0, salience: 0, relevance: 1 } },
+      // outcome:0 isolates the relevance factor — without it, the outcome weight
+      // defaults to 1 and dilutes the result (the cold-start prior contributes 0.5).
+      { now: NOW, weights: { recency: 0, salience: 0, relevance: 1, outcome: 0 } },
     );
     expect(at(2)).toBe(1);
     expect(at(-1)).toBe(0);
@@ -199,7 +205,10 @@ describe('lesson-rank: the epsilon-grid tie-break is transitive', () => {
   // server-only-relevance block above): the CLI derives relevance from terms.
   // The two twins run the IDENTICAL bucket algorithm, and their agreement over
   // the shared inputs is already pinned by the whole-set order tests above.
-  const relevanceOnly = { recency: 0, salience: 0, relevance: 1 };
+  // outcome:0 isolates the relevance factor — without it the cold-start prior
+  // (0.5, constant for all rows) would compress the tiny score differences from
+  // the one-epsilon-step chain and collapse them into fewer distinct buckets.
+  const relevanceOnly = { recency: 0, salience: 0, relevance: 1, outcome: 0 };
 
   // Five rows exactly one grid step apart in score, identical in every
   // tiebreaker (same scope, same key) so ONLY the score can separate them.
@@ -234,5 +243,79 @@ describe('lesson-rank: the epsilon-grid tie-break is transitive', () => {
     ]) {
       expect(rankedBuckets(perm.map((i) => chain[i]))).toEqual(canonical);
     }
+  });
+});
+
+// ── TS-only: outcome factor + cold-start prior (AC-1, AC-2, AC-3) ────────────
+//
+// These mirror the CLI-side tests in unit.test.mjs but run against the TS
+// scorer directly. The outcome factor is server-derived (from tags + origin_pr)
+// so the TS scorer takes a pre-computed `outcome` value — exactly like how
+// `relevance` works. These are TS-only checks for the same reason as the
+// server-only-relevance block above.
+
+describe('lesson-rank: outcome factor and cold-start prior', () => {
+  // ── AC-3: normalizeOutcome ───────────────────────────────────────────────
+  it('normalizeOutcome returns COLD_START_OUTCOME_PRIOR for absent/unreadable input', () => {
+    // The deliberate asymmetry vs normalizeRelevance (which returns 0 for absent).
+    for (const absent of [null, undefined, NaN, 'nope', {}] as unknown[]) {
+      expect(normalizeOutcomeTs(absent)).toBe(COLD_START_OUTCOME_PRIOR);
+    }
+  });
+
+  it('normalizeOutcome agrees with CLI normalizeOutcome across the same inputs', () => {
+    for (const v of [0, 0.5, 1, 2, -1, '0.5', null, undefined, NaN] as unknown[]) {
+      expect(normalizeOutcomeTs(v)).toBeCloseTo(cli.normalizeOutcome(v), 15);
+    }
+  });
+
+  it('normalizeOutcome clamps a present value into [0,1]', () => {
+    expect(normalizeOutcomeTs(2)).toBe(1);
+    expect(normalizeOutcomeTs(-1)).toBe(0);
+    expect(normalizeOutcomeTs(0.5)).toBeCloseTo(0.5, 15);
+    expect(normalizeOutcomeTs('0.5' as unknown as number)).toBeCloseTo(0.5, 15);
+  });
+
+  it('COLD_START_OUTCOME_PRIOR constant matches the CLI twin', () => {
+    expect(COLD_START_OUTCOME_PRIOR).toBe(cli.COLD_START_OUTCOME_PRIOR);
+  });
+
+  // ── AC-1: outcome-positive outranks outcome-negative ────────────────────
+  it('outcome-positive row outranks outcome-negative row at equal recency+salience (real rankLessons)', () => {
+    // Two rows identical in everything except outcome. The outcome factor must be
+    // load-bearing: removing it (outcome weight 0) removes the ordering difference.
+    const shared = { seenCount: 5, updatedAt: daysAgo(3) };
+    const positive = { ...shared, key: 'positive', outcome: 1.0 };
+    const negative = { ...shared, key: 'negative', outcome: 0.0 };
+
+    const ranked = rankTs([negative, positive], { now: NOW });
+    const keys = ranked.map((r) => r.entry.key);
+    expect(keys.indexOf('positive')).toBe(0);
+    expect(keys.indexOf('negative')).toBe(1);
+
+    // Mental revert: with outcome weight 0, both rows score identically.
+    const rankNoOutcome = rankTs([negative, positive], {
+      now: NOW,
+      weights: { recency: 1, salience: 1, relevance: 1, outcome: 0 },
+    });
+    const buckets = rankNoOutcome.map((r) => Math.round(r.score / EPSILON_TS));
+    expect(buckets[0]).toBe(buckets[1]);
+  });
+
+  // ── AC-2: cold-start prior — cold new row outranks old low-relevance row ─
+  it('cold new row outranks old low-relevance row (cold-start prior not zero, real rankLessons)', () => {
+    // A cold recent row (no outcome — gets the prior) vs an old stale row with
+    // explicit outcome:0. The cold new row should win via recency + the prior.
+    const coldNew = { key: 'cold-new', updatedAt: daysAgo(1), seenCount: 1 };
+    const oldStale = { key: 'old-stale', updatedAt: daysAgo(90), seenCount: 1, outcome: 0.0 };
+
+    const ranked = rankTs([oldStale, coldNew], { now: NOW });
+    const keys = ranked.map((r) => r.entry.key);
+    expect(keys[0]).toBe('cold-new');
+
+    // The prior being > 0 is what gives the cold row its advantage over the
+    // old row with explicit outcome:0. Assert the constant is neutral-positive.
+    expect(COLD_START_OUTCOME_PRIOR).toBeGreaterThan(0);
+    expect(COLD_START_OUTCOME_PRIOR).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/mcp-core/src/lesson-rank-parity.spec.ts
+++ b/packages/mcp-core/src/lesson-rank-parity.spec.ts
@@ -313,9 +313,23 @@ describe('lesson-rank: outcome factor and cold-start prior', () => {
     const keys = ranked.map((r) => r.entry.key);
     expect(keys[0]).toBe('cold-new');
 
-    // The prior being > 0 is what gives the cold row its advantage over the
-    // old row with explicit outcome:0. Assert the constant is neutral-positive.
-    expect(COLD_START_OUTCOME_PRIOR).toBeGreaterThan(0);
-    expect(COLD_START_OUTCOME_PRIOR).toBeLessThanOrEqual(1);
+    // The load-bearing check: hold recency, salience and relevance EQUAL between
+    // the two rows so the ONLY difference is outcome. The cold row (absent
+    // outcome → prior) must still outrank an explicit `outcome: 0` row — that
+    // ordering can only come from the prior being > 0. Zeroing the prior would
+    // tie the two, so this assertion fails the moment the prior degrades.
+    const coldSameAge = { key: 'cold', updatedAt: daysAgo(3), seenCount: 5 };
+    const zeroSameAge = { key: 'zero', updatedAt: daysAgo(3), seenCount: 5, outcome: 0.0 };
+    const tieRank = rankTs([zeroSameAge, coldSameAge], { now: NOW });
+    expect(tieRank[0].entry.key).toBe('cold');
+
+    // Score the pair against the same population (maxSeenCount) rankLessons uses,
+    // so the strict-greater is on the ranking's own arithmetic, not a re-derived
+    // one. The gap is exactly the prior contribution: COLD_START_OUTCOME_PRIOR/4.
+    const opts = { now: NOW, maxSeenCount: 5 };
+    const coldScore = scoreTs(coldSameAge, opts);
+    const zeroScore = scoreTs(zeroSameAge, opts);
+    expect(coldScore).toBeGreaterThan(zeroScore);
+    expect(coldScore - zeroScore).toBeCloseTo(COLD_START_OUTCOME_PRIOR / 4, 9);
   });
 });

--- a/packages/mcp-core/src/lesson-rank.ts
+++ b/packages/mcp-core/src/lesson-rank.ts
@@ -38,12 +38,19 @@ export interface RankableLesson {
   updated?: string | Date | null;
   /** Server-supplied relevance in [0,1] — see `rankLessons`. */
   relevance?: number | null;
+  /**
+   * Outcome factor in [0,1] — applied/resolution history.
+   * Absent → `normalizeOutcome` returns `COLD_START_OUTCOME_PRIOR`.
+   * Derived by the edge handler from `tags` + `origin_pr`; not a DB column.
+   */
+  outcome?: number | null;
 }
 
 export interface RankWeights {
   recency: number;
   salience: number;
   relevance: number;
+  outcome: number;
 }
 
 /**
@@ -53,8 +60,22 @@ export interface RankWeights {
  */
 export const RECENCY_HALF_LIFE_DAYS = 14;
 
-/** Equal thirds. Deliberately untuned — see `lessons-pure.mjs`. */
-export const DEFAULT_RANK_WEIGHTS: RankWeights = { recency: 1, salience: 1, relevance: 1 };
+/** Equal quarters. Deliberately untuned — see `lessons-pure.mjs`. */
+export const DEFAULT_RANK_WEIGHTS: RankWeights = { recency: 1, salience: 1, relevance: 1, outcome: 1 };
+
+/**
+ * The cold-start prior for the outcome factor. A new lesson with no applied /
+ * resolution history gets this value rather than 0. The rationale: scoring
+ * absent outcome at 0 would sink every new lesson below stale ones purely for
+ * lacking outcome history (outcome-lag). 0.5 is the neutral midpoint of [0,1]
+ * — a cold lesson contributes an average outcome term, so it ranks on
+ * recency and relevance instead of being penalised for being new.
+ *
+ * This is the ONE deliberate asymmetry vs `normalizeRelevance` (which returns
+ * 0 for absent / unreadable input). Mirrored byte-identically in the edge twin
+ * and `packages/cli/src/lessons-pure.mjs`.
+ */
+export const COLD_START_OUTCOME_PRIOR = 0.5;
 
 /** Two scores closer than this are the same score. */
 export const SCORE_EPSILON = 1e-9;
@@ -134,6 +155,21 @@ export function normalizeRelevance(value: unknown): number {
   return Math.min(1, Math.max(0, n));
 }
 
+/**
+ * Normalize an outcome value into [0,1]. Absent or unreadable input returns
+ * `COLD_START_OUTCOME_PRIOR` — the deliberate asymmetry vs `normalizeRelevance`
+ * (which returns 0 for absent input). A present value is clamped to [0,1].
+ *
+ * The cold-start prior ensures a new lesson with no outcome history is not
+ * penalised during outcome-lag — it contributes an average outcome term and
+ * ranks on recency + relevance instead.
+ */
+export function normalizeOutcome(value: unknown): number {
+  const n = typeof value === 'string' ? Number(value) : value;
+  if (typeof n !== 'number' || !Number.isFinite(n)) return COLD_START_OUTCOME_PRIOR;
+  return Math.min(1, Math.max(0, n));
+}
+
 export interface ScoreOptions {
   now?: unknown;
   weights?: Partial<RankWeights>;
@@ -161,15 +197,17 @@ export function scoreLesson(entry: RankableLesson | null | undefined, options: S
     recency: numberOr(weights?.recency, DEFAULT_RANK_WEIGHTS.recency),
     salience: numberOr(weights?.salience, DEFAULT_RANK_WEIGHTS.salience),
     relevance: numberOr(weights?.relevance, DEFAULT_RANK_WEIGHTS.relevance),
+    outcome: numberOr(weights?.outcome, DEFAULT_RANK_WEIGHTS.outcome),
   };
-  const total = w.recency + w.salience + w.relevance;
+  const total = w.recency + w.salience + w.relevance + w.outcome;
   if (!(total > 0)) {
     return scoreLesson(entry, { now, weights: DEFAULT_RANK_WEIGHTS, maxSeenCount, halfLifeDays });
   }
   const recency = recencyFactor(updatedAtFrom(entry), now, halfLifeDays);
   const salience = salienceFactor(seenCountFrom(entry), maxSeenCount);
   const relevance = normalizeRelevance(entry?.relevance);
-  return (w.recency * recency + w.salience * salience + w.relevance * relevance) / total;
+  const outcome = normalizeOutcome(entry?.outcome);
+  return (w.recency * recency + w.salience * salience + w.relevance * relevance + w.outcome * outcome) / total;
 }
 
 export interface RankOptions extends Omit<ScoreOptions, 'maxSeenCount'> {

--- a/packages/mcp-core/src/outcome-signal.ts
+++ b/packages/mcp-core/src/outcome-signal.ts
@@ -1,0 +1,58 @@
+/**
+ * The outcome signal — how a memory row's `tags` and `origin_pr` become the
+ * `outcome` factor the lesson scorer consumes.
+ *
+ * WHY THIS IS A MODULE, since it is only a handful of lines: it was duplicated
+ * VERBATIM in two edge paths that rank lessons — `GET /memories/relevant`
+ * (`memories/handlers/relevant.ts`) and the MCP `memory.list order=rank` tool
+ * (`mcp/tools.ts`) — kept in step by a "mirrors the same constant" comment and
+ * nothing else. A comment is not a guard: the two could drift the day one of
+ * them learned a third signal, and a divergence would silently rank the same
+ * row differently on the two transports. Hoisting the tag list and the ladder
+ * here makes the single definition the only one, so they cannot disagree.
+ *
+ * It stays SEPARATE from `lesson-rank.ts` on purpose. That module is the pure
+ * scorer and knows nothing of the repo's schema — relevance and outcome both
+ * arrive on the row already reduced to a number in [0,1]. This module is where
+ * the repo-schema knowledge lives: it maps `tags` + `origin_pr` to that number.
+ * Symmetric with how relevance is derived by the query (`ts_rank`) and handed
+ * to the scorer, never computed inside it.
+ *
+ * Import-free so it can be mirrored verbatim into
+ * `supabase/functions/_shared/outcome-signal.ts` (the Deno edge tree cannot
+ * cross-import this Node package). `edge-parity.spec.ts` guards the two copies.
+ */
+
+/**
+ * Outcome bus tags that indicate a lesson has a strong positive outcome
+ * (applied a suggestion / resolved a review thread).
+ */
+export const OUTCOME_BUS_TAGS = ['loop::review-outcomes', 'loop::reviewer-comment-relevance'] as const;
+
+/** Strong positive: the lesson sits on an outcome bus (applied/resolved). */
+export const OUTCOME_BUS_SCORE = 1.0;
+
+/** Weak positive: the lesson was carried to a PR but has no bus outcome yet. */
+export const OUTCOME_ORIGIN_PR_SCORE = 0.75;
+
+/**
+ * Map a memory row's `tags` and `origin_pr` to an outcome score in [0,1], or
+ * `undefined` when no outcome signal is present (the scorer's cold-start prior
+ * will apply).
+ *
+ * Ladder (highest to lowest signal strength):
+ *   1. Outcome-bus tag present → `OUTCOME_BUS_SCORE` (strong: applied/resolved)
+ *   2. Non-null `origin_pr`     → `OUTCOME_ORIGIN_PR_SCORE` (weak: carried to a PR)
+ *   3. Neither                  → `undefined` (cold: scorer applies the prior)
+ *
+ * Order matters: a bus tag wins over `origin_pr`.
+ */
+export function outcomeFromTags(
+  tags: readonly string[] | null | undefined,
+  originPr: number | null | undefined,
+): number | undefined {
+  const list: readonly string[] = Array.isArray(tags) ? tags : [];
+  if (OUTCOME_BUS_TAGS.some((tag) => list.includes(tag))) return OUTCOME_BUS_SCORE;
+  if (originPr != null) return OUTCOME_ORIGIN_PR_SCORE;
+  return undefined;
+}

--- a/packages/schemas/src/llms/template.md
+++ b/packages/schemas/src/llms/template.md
@@ -200,7 +200,9 @@ that difference is the whole game — the newest writes are usually one task's i
 
 `GET /memories/relevant` is the ranked shortlist. It scores each candidate on **recency**
 (exponential decay, 14-day half-life), **salience** (`log1p(seen_count)`, normalised across the
-candidates) and **relevance** (full-text match on `q`), and returns a compact index:
+candidates), **relevance** (full-text match on `q`) and **outcome** (applied/resolution history —
+`1` on an outcome bus, `0.75` carried to a PR, `0.5` cold-start prior when unproven), and returns a
+compact index:
 
 ```bash
 curl -H "Authorization: Bearer lk_ro_…" \
@@ -213,7 +215,7 @@ q=migration+backfill&scopes=repo::acme/app,global&limit=5"
   "entries": [
     { "scope": "repo::acme/app", "key": "migration-order",
       "hook": "Always add the column before the backfill runs.",
-      "score": 0.72, "factors": { "recency": 0.61, "salience": 0.85, "relevance": 1 },
+      "score": 0.74, "factors": { "recency": 0.61, "salience": 0.85, "relevance": 1, "outcome": 0.5 },
       "seen_count": 9, "updated_at": "2026-07-30T09:12:00.000Z" }
   ],
   "candidates": 47
@@ -225,7 +227,7 @@ q=migration+backfill&scopes=repo::acme/app,global&limit=5"
 | `q` | — | Free-text query. **Optional** — omit it and the ranking is recency + salience, i.e. "what matters generally". |
 | `scopes` | all visible | Comma-separated, **most-specific first**; the order breaks ties, so a project lesson wins over the global one it ties with. |
 | `limit` | `10` | 1–50. |
-| `min_score` | `0` | Drop weak hits when injecting automatically — an irrelevant lesson every turn is worse than none. Note: with `q` set, matched hits floor at ~`0.33` (relevance is binary today), so a value ≤ `1/3` is a no-op; finer gating arrives with graded relevance. |
+| `min_score` | `0` | Drop weak hits when injecting automatically — an irrelevant lesson every turn is worse than none. Note: with `q` set, matched hits floor at `(1 + 0.5) / 4 = 0.375` (relevance is binary and outcome never sinks below its `0.5` prior today), so a value ≤ `0.375` is a no-op; finer gating arrives with graded relevance. |
 
 Bodies are not returned — fetch the ones you want with `memory.read`. `candidates` is how many
 matched before ranking, so you can tell a shortlist from the whole set.

--- a/packages/schemas/src/relevant.ts
+++ b/packages/schemas/src/relevant.ts
@@ -57,11 +57,13 @@ export const RelevantQuerySchema = z.object({
    *
    * Mind the floor this reaches today. When `q` is set every matched candidate
    * carries `relevance: 1` — relevance is binary here (see the handler's
-   * docblock) — so with the endpoint's equal weights no matched score drops
-   * below `1/3`, and a `min_score` at or under `0.333…` is therefore a no-op.
-   * Above `1/3` it still discriminates, on recency and salience. A `min_score`
-   * that gates across the whole range needs graded FTS relevance, which lands
-   * with the ranked-relevance RPC (PR 11).
+   * docblock) — and the outcome factor never sinks below its cold-start prior
+   * of `0.5` (it maps to `1`, `0.75`, or the prior — never `0`). So with the
+   * endpoint's four equal weights no matched score drops below
+   * `(1 + 0.5) / 4 = 0.375`, and a `min_score` at or under `0.375` is therefore
+   * a no-op. Above `0.375` it still discriminates, on recency and salience. A
+   * `min_score` that gates across the whole range needs graded FTS relevance,
+   * which lands with the ranked-relevance RPC (PR 11).
    */
   min_score: z.coerce.number().min(0).max(1).optional().default(0),
 });
@@ -75,11 +77,12 @@ export const RelevantEntrySchema = z.object({
   hook: z.string(),
   /** Composite rank in [0,1]. Comparable within one response, not across. */
   score: z.number(),
-  /** The three factors, so a caller can explain or re-weight a ranking. */
+  /** The four factors, so a caller can explain or re-weight a ranking. */
   factors: z.object({
     recency: z.number(),
     salience: z.number(),
     relevance: z.number(),
+    outcome: z.number(),
   }),
   seen_count: z.number().int().nullable(),
   updated_at: z.string().nullable(),

--- a/packages/schemas/src/relevant.ts
+++ b/packages/schemas/src/relevant.ts
@@ -113,7 +113,7 @@ export type RelevantResponse = z.infer<typeof RelevantResponseSchema>;
  * every candidate — of which there may be many times the returned limit — would
  * move a lot of text out of Postgres to throw almost all of it away.
  */
-export const RELEVANT_SELECT = 'scope,key,value,seen_count,updated_at';
+export const RELEVANT_SELECT = 'scope,key,value,seen_count,updated_at,tags,origin_pr';
 
 /** Cap on a lesson's one-line hook. Matches the CLI hook's `HOOK_LEN`. */
 export const RELEVANT_HOOK_LEN = 80;

--- a/packages/web/public/llms.txt
+++ b/packages/web/public/llms.txt
@@ -463,7 +463,9 @@ that difference is the whole game — the newest writes are usually one task's i
 
 `GET /memories/relevant` is the ranked shortlist. It scores each candidate on **recency**
 (exponential decay, 14-day half-life), **salience** (`log1p(seen_count)`, normalised across the
-candidates) and **relevance** (full-text match on `q`), and returns a compact index:
+candidates), **relevance** (full-text match on `q`) and **outcome** (applied/resolution history —
+`1` on an outcome bus, `0.75` carried to a PR, `0.5` cold-start prior when unproven), and returns a
+compact index:
 
 ```bash
 curl -H "Authorization: Bearer lk_ro_…" \
@@ -476,7 +478,7 @@ q=migration+backfill&scopes=repo::acme/app,global&limit=5"
   "entries": [
     { "scope": "repo::acme/app", "key": "migration-order",
       "hook": "Always add the column before the backfill runs.",
-      "score": 0.72, "factors": { "recency": 0.61, "salience": 0.85, "relevance": 1 },
+      "score": 0.74, "factors": { "recency": 0.61, "salience": 0.85, "relevance": 1, "outcome": 0.5 },
       "seen_count": 9, "updated_at": "2026-07-30T09:12:00.000Z" }
   ],
   "candidates": 47
@@ -488,7 +490,7 @@ q=migration+backfill&scopes=repo::acme/app,global&limit=5"
 | `q` | — | Free-text query. **Optional** — omit it and the ranking is recency + salience, i.e. "what matters generally". |
 | `scopes` | all visible | Comma-separated, **most-specific first**; the order breaks ties, so a project lesson wins over the global one it ties with. |
 | `limit` | `10` | 1–50. |
-| `min_score` | `0` | Drop weak hits when injecting automatically — an irrelevant lesson every turn is worse than none. Note: with `q` set, matched hits floor at ~`0.33` (relevance is binary today), so a value ≤ `1/3` is a no-op; finer gating arrives with graded relevance. |
+| `min_score` | `0` | Drop weak hits when injecting automatically — an irrelevant lesson every turn is worse than none. Note: with `q` set, matched hits floor at `(1 + 0.5) / 4 = 0.375` (relevance is binary and outcome never sinks below its `0.5` prior today), so a value ≤ `0.375` is a no-op; finer gating arrives with graded relevance. |
 
 Bodies are not returned — fetch the ones you want with `memory.read`. `candidates` is how many
 matched before ranking, so you can tell a shortlist from the whole set.

--- a/supabase/functions/_shared/lesson-rank.ts
+++ b/supabase/functions/_shared/lesson-rank.ts
@@ -38,12 +38,19 @@ export interface RankableLesson {
   updated?: string | Date | null;
   /** Server-supplied relevance in [0,1] — see `rankLessons`. */
   relevance?: number | null;
+  /**
+   * Outcome factor in [0,1] — applied/resolution history.
+   * Absent → `normalizeOutcome` returns `COLD_START_OUTCOME_PRIOR`.
+   * Derived by the edge handler from `tags` + `origin_pr`; not a DB column.
+   */
+  outcome?: number | null;
 }
 
 export interface RankWeights {
   recency: number;
   salience: number;
   relevance: number;
+  outcome: number;
 }
 
 /**
@@ -53,8 +60,22 @@ export interface RankWeights {
  */
 export const RECENCY_HALF_LIFE_DAYS = 14;
 
-/** Equal thirds. Deliberately untuned — see `lessons-pure.mjs`. */
-export const DEFAULT_RANK_WEIGHTS: RankWeights = { recency: 1, salience: 1, relevance: 1 };
+/** Equal quarters. Deliberately untuned — see `lessons-pure.mjs`. */
+export const DEFAULT_RANK_WEIGHTS: RankWeights = { recency: 1, salience: 1, relevance: 1, outcome: 1 };
+
+/**
+ * The cold-start prior for the outcome factor. A new lesson with no applied /
+ * resolution history gets this value rather than 0. The rationale: scoring
+ * absent outcome at 0 would sink every new lesson below stale ones purely for
+ * lacking outcome history (outcome-lag). 0.5 is the neutral midpoint of [0,1]
+ * — a cold lesson contributes an average outcome term, so it ranks on
+ * recency and relevance instead of being penalised for being new.
+ *
+ * This is the ONE deliberate asymmetry vs `normalizeRelevance` (which returns
+ * 0 for absent / unreadable input). Mirrored byte-identically in the edge twin
+ * and `packages/cli/src/lessons-pure.mjs`.
+ */
+export const COLD_START_OUTCOME_PRIOR = 0.5;
 
 /** Two scores closer than this are the same score. */
 export const SCORE_EPSILON = 1e-9;
@@ -134,6 +155,21 @@ export function normalizeRelevance(value: unknown): number {
   return Math.min(1, Math.max(0, n));
 }
 
+/**
+ * Normalize an outcome value into [0,1]. Absent or unreadable input returns
+ * `COLD_START_OUTCOME_PRIOR` — the deliberate asymmetry vs `normalizeRelevance`
+ * (which returns 0 for absent input). A present value is clamped to [0,1].
+ *
+ * The cold-start prior ensures a new lesson with no outcome history is not
+ * penalised during outcome-lag — it contributes an average outcome term and
+ * ranks on recency + relevance instead.
+ */
+export function normalizeOutcome(value: unknown): number {
+  const n = typeof value === 'string' ? Number(value) : value;
+  if (typeof n !== 'number' || !Number.isFinite(n)) return COLD_START_OUTCOME_PRIOR;
+  return Math.min(1, Math.max(0, n));
+}
+
 export interface ScoreOptions {
   now?: unknown;
   weights?: Partial<RankWeights>;
@@ -161,15 +197,17 @@ export function scoreLesson(entry: RankableLesson | null | undefined, options: S
     recency: numberOr(weights?.recency, DEFAULT_RANK_WEIGHTS.recency),
     salience: numberOr(weights?.salience, DEFAULT_RANK_WEIGHTS.salience),
     relevance: numberOr(weights?.relevance, DEFAULT_RANK_WEIGHTS.relevance),
+    outcome: numberOr(weights?.outcome, DEFAULT_RANK_WEIGHTS.outcome),
   };
-  const total = w.recency + w.salience + w.relevance;
+  const total = w.recency + w.salience + w.relevance + w.outcome;
   if (!(total > 0)) {
     return scoreLesson(entry, { now, weights: DEFAULT_RANK_WEIGHTS, maxSeenCount, halfLifeDays });
   }
   const recency = recencyFactor(updatedAtFrom(entry), now, halfLifeDays);
   const salience = salienceFactor(seenCountFrom(entry), maxSeenCount);
   const relevance = normalizeRelevance(entry?.relevance);
-  return (w.recency * recency + w.salience * salience + w.relevance * relevance) / total;
+  const outcome = normalizeOutcome(entry?.outcome);
+  return (w.recency * recency + w.salience * salience + w.relevance * relevance + w.outcome * outcome) / total;
 }
 
 export interface RankOptions extends Omit<ScoreOptions, 'maxSeenCount'> {

--- a/supabase/functions/_shared/outcome-signal.ts
+++ b/supabase/functions/_shared/outcome-signal.ts
@@ -1,0 +1,58 @@
+/**
+ * The outcome signal — how a memory row's `tags` and `origin_pr` become the
+ * `outcome` factor the lesson scorer consumes.
+ *
+ * WHY THIS IS A MODULE, since it is only a handful of lines: it was duplicated
+ * VERBATIM in two edge paths that rank lessons — `GET /memories/relevant`
+ * (`memories/handlers/relevant.ts`) and the MCP `memory.list order=rank` tool
+ * (`mcp/tools.ts`) — kept in step by a "mirrors the same constant" comment and
+ * nothing else. A comment is not a guard: the two could drift the day one of
+ * them learned a third signal, and a divergence would silently rank the same
+ * row differently on the two transports. Hoisting the tag list and the ladder
+ * here makes the single definition the only one, so they cannot disagree.
+ *
+ * It stays SEPARATE from `lesson-rank.ts` on purpose. That module is the pure
+ * scorer and knows nothing of the repo's schema — relevance and outcome both
+ * arrive on the row already reduced to a number in [0,1]. This module is where
+ * the repo-schema knowledge lives: it maps `tags` + `origin_pr` to that number.
+ * Symmetric with how relevance is derived by the query (`ts_rank`) and handed
+ * to the scorer, never computed inside it.
+ *
+ * Import-free so it can be mirrored verbatim into
+ * `supabase/functions/_shared/outcome-signal.ts` (the Deno edge tree cannot
+ * cross-import this Node package). `edge-parity.spec.ts` guards the two copies.
+ */
+
+/**
+ * Outcome bus tags that indicate a lesson has a strong positive outcome
+ * (applied a suggestion / resolved a review thread).
+ */
+export const OUTCOME_BUS_TAGS = ['loop::review-outcomes', 'loop::reviewer-comment-relevance'] as const;
+
+/** Strong positive: the lesson sits on an outcome bus (applied/resolved). */
+export const OUTCOME_BUS_SCORE = 1.0;
+
+/** Weak positive: the lesson was carried to a PR but has no bus outcome yet. */
+export const OUTCOME_ORIGIN_PR_SCORE = 0.75;
+
+/**
+ * Map a memory row's `tags` and `origin_pr` to an outcome score in [0,1], or
+ * `undefined` when no outcome signal is present (the scorer's cold-start prior
+ * will apply).
+ *
+ * Ladder (highest to lowest signal strength):
+ *   1. Outcome-bus tag present → `OUTCOME_BUS_SCORE` (strong: applied/resolved)
+ *   2. Non-null `origin_pr`     → `OUTCOME_ORIGIN_PR_SCORE` (weak: carried to a PR)
+ *   3. Neither                  → `undefined` (cold: scorer applies the prior)
+ *
+ * Order matters: a bus tag wins over `origin_pr`.
+ */
+export function outcomeFromTags(
+  tags: readonly string[] | null | undefined,
+  originPr: number | null | undefined,
+): number | undefined {
+  const list: readonly string[] = Array.isArray(tags) ? tags : [];
+  if (OUTCOME_BUS_TAGS.some((tag) => list.includes(tag))) return OUTCOME_BUS_SCORE;
+  if (originPr != null) return OUTCOME_ORIGIN_PR_SCORE;
+  return undefined;
+}

--- a/supabase/functions/_shared/schemas/relevant.ts
+++ b/supabase/functions/_shared/schemas/relevant.ts
@@ -118,7 +118,7 @@ export type RelevantResponse = z.infer<typeof RelevantResponseSchema>;
  * every candidate — of which there may be many times the returned limit — would
  * move a lot of text out of Postgres to throw almost all of it away.
  */
-export const RELEVANT_SELECT = 'scope,key,value,seen_count,updated_at';
+export const RELEVANT_SELECT = 'scope,key,value,seen_count,updated_at,tags,origin_pr';
 
 /** Cap on a lesson's one-line hook. Matches the CLI hook's `HOOK_LEN`. */
 export const RELEVANT_HOOK_LEN = 80;

--- a/supabase/functions/_shared/schemas/relevant.ts
+++ b/supabase/functions/_shared/schemas/relevant.ts
@@ -62,11 +62,13 @@ export const RelevantQuerySchema = z.object({
    *
    * Mind the floor this reaches today. When `q` is set every matched candidate
    * carries `relevance: 1` — relevance is binary here (see the handler's
-   * docblock) — so with the endpoint's equal weights no matched score drops
-   * below `1/3`, and a `min_score` at or under `0.333…` is therefore a no-op.
-   * Above `1/3` it still discriminates, on recency and salience. A `min_score`
-   * that gates across the whole range needs graded FTS relevance, which lands
-   * with the ranked-relevance RPC (PR 11).
+   * docblock) — and the outcome factor never sinks below its cold-start prior
+   * of `0.5` (it maps to `1`, `0.75`, or the prior — never `0`). So with the
+   * endpoint's four equal weights no matched score drops below
+   * `(1 + 0.5) / 4 = 0.375`, and a `min_score` at or under `0.375` is therefore
+   * a no-op. Above `0.375` it still discriminates, on recency and salience. A
+   * `min_score` that gates across the whole range needs graded FTS relevance,
+   * which lands with the ranked-relevance RPC (PR 11).
    */
   min_score: z.coerce.number().min(0).max(1).optional().default(0),
 });
@@ -80,11 +82,12 @@ export const RelevantEntrySchema = z.object({
   hook: z.string(),
   /** Composite rank in [0,1]. Comparable within one response, not across. */
   score: z.number(),
-  /** The three factors, so a caller can explain or re-weight a ranking. */
+  /** The four factors, so a caller can explain or re-weight a ranking. */
   factors: z.object({
     recency: z.number(),
     salience: z.number(),
     relevance: z.number(),
+    outcome: z.number(),
   }),
   seen_count: z.number().int().nullable(),
   updated_at: z.string().nullable(),

--- a/supabase/functions/mcp/tools.ts
+++ b/supabase/functions/mcp/tools.ts
@@ -41,6 +41,27 @@ export const PURGE_RETENTION_DAYS_DEFAULT = 30;
  */
 const CANDIDATE_LIMIT = 200;
 
+/**
+ * Outcome bus tags that signal a positive applied/resolution outcome.
+ * Mirrors the same constant in `memories/handlers/relevant.ts`.
+ */
+const OUTCOME_BUS_TAGS = ['loop::review-outcomes', 'loop::reviewer-comment-relevance'] as const;
+
+/**
+ * Map a row's tags and origin_pr to an outcome score in [0,1], or `undefined`
+ * when no signal is present (the scorer applies the cold-start prior).
+ *
+ * Ladder: bus tag present → 1.0; non-null origin_pr → 0.75; neither → undefined.
+ * Lives here rather than in the pure scorer to keep the scorer free of
+ * repo-schema knowledge — symmetric with how `relevant.ts` derives outcome.
+ */
+function outcomeFromRowTags(tags: string[] | null | undefined, originPr: number | null | undefined): number | undefined {
+  const t: string[] = Array.isArray(tags) ? tags : [];
+  if (OUTCOME_BUS_TAGS.some((tag) => t.includes(tag))) return 1.0;
+  if (originPr != null) return 0.75;
+  return undefined;
+}
+
 // deno-lint-ignore no-explicit-any
 export type Params = Record<string, any>;
 
@@ -242,7 +263,7 @@ export async function toolList(
     // seen_count is selected here and dropped from the wire response (D4).
     let rankQuery = tracedDb
       .from('memories')
-      .select('id,key,value,tags,updated_at,seen_count')
+      .select('id,key,value,tags,updated_at,seen_count,origin_pr')
       .eq('scope', scope)
       .is('archived_at', null)
       .or('expires_at.is.null,expires_at.gt.now()')
@@ -263,6 +284,7 @@ export async function toolList(
         tags: r.tags,
         updated_at: r.updated_at,
         seen_count: r.seen_count,
+        outcome: outcomeFromRowTags(r.tags, r.origin_pr),
       }),
     );
 

--- a/supabase/functions/mcp/tools.ts
+++ b/supabase/functions/mcp/tools.ts
@@ -26,6 +26,7 @@ import { decodeCursor, buildPage } from './cursor.ts';
 import { resolveKindHost } from '../_shared/schemas/tags.ts';
 import { rankLessons } from '../_shared/lesson-rank.ts';
 import type { RankableLesson } from '../_shared/lesson-rank.ts';
+import { outcomeFromTags } from '../_shared/outcome-signal.ts';
 
 export const MAX_VALUE_BYTES = 65_536;
 export const PURGE_RETENTION_DAYS_DEFAULT = 30;
@@ -40,27 +41,6 @@ export const PURGE_RETENTION_DAYS_DEFAULT = 30;
  * staying one cheap indexed read.
  */
 const CANDIDATE_LIMIT = 200;
-
-/**
- * Outcome bus tags that signal a positive applied/resolution outcome.
- * Mirrors the same constant in `memories/handlers/relevant.ts`.
- */
-const OUTCOME_BUS_TAGS = ['loop::review-outcomes', 'loop::reviewer-comment-relevance'] as const;
-
-/**
- * Map a row's tags and origin_pr to an outcome score in [0,1], or `undefined`
- * when no signal is present (the scorer applies the cold-start prior).
- *
- * Ladder: bus tag present → 1.0; non-null origin_pr → 0.75; neither → undefined.
- * Lives here rather than in the pure scorer to keep the scorer free of
- * repo-schema knowledge — symmetric with how `relevant.ts` derives outcome.
- */
-function outcomeFromRowTags(tags: string[] | null | undefined, originPr: number | null | undefined): number | undefined {
-  const t: string[] = Array.isArray(tags) ? tags : [];
-  if (OUTCOME_BUS_TAGS.some((tag) => t.includes(tag))) return 1.0;
-  if (originPr != null) return 0.75;
-  return undefined;
-}
 
 // deno-lint-ignore no-explicit-any
 export type Params = Record<string, any>;
@@ -284,7 +264,7 @@ export async function toolList(
         tags: r.tags,
         updated_at: r.updated_at,
         seen_count: r.seen_count,
-        outcome: outcomeFromRowTags(r.tags, r.origin_pr),
+        outcome: outcomeFromTags(r.tags, r.origin_pr),
       }),
     );
 

--- a/supabase/functions/memories/CLAUDE.md
+++ b/supabase/functions/memories/CLAUDE.md
@@ -311,8 +311,8 @@ The one verb that **ranks**. Returns the top-K lessons for a query as a compact 
       "scope": "repo::acme/app",
       "key": "migration-order",
       "hook": "Always add the column before the backfill runs.",
-      "score": 0.72,
-      "factors": { "recency": 0.61, "salience": 0.85, "relevance": 1 },
+      "score": 0.74,
+      "factors": { "recency": 0.61, "salience": 0.85, "relevance": 1, "outcome": 0.5 },
       "seen_count": 9,
       "updated_at": "2026-07-30T09:12:00.000Z"
     }
@@ -326,7 +326,7 @@ The one verb that **ranks**. Returns the top-K lessons for a query as a compact 
 | `q` | — | Free-text query, `websearch` FTS over `key \|\| value`. **Optional.** |
 | `scopes` | all visible | Comma-separated, **most-specific first** — the order breaks ties. |
 | `limit` | `10` | 1–50. A shortlist for a context window, not a page. |
-| `min_score` | `0` | Drop hits below this — how a caller says "stay silent rather than show me something weak". Note: with `q` set, matched hits floor at ~`1/3` (relevance is binary today), so `min_score ≤ 0.333…` is a no-op until graded relevance. |
+| `min_score` | `0` | Drop hits below this — how a caller says "stay silent rather than show me something weak". Note: with `q` set, matched hits floor at `(1 + 0.5) / 4 = 0.375` (relevance is binary and outcome never sinks below its `0.5` prior today), so `min_score ≤ 0.375` is a no-op until graded relevance. |
 
 **Why it exists.** Every other read hands the caller a single-signal ordering — `GET /memories`
 is `updated_at` desc, `POST /memories/search` is FTS rank — and neither knows that a lesson

--- a/supabase/functions/memories/handlers/relevant.ts
+++ b/supabase/functions/memories/handlers/relevant.ts
@@ -172,7 +172,7 @@ export async function handleRelevant(
         recency: recencyFactor(updatedAtFrom(entry), now),
         salience: salienceFactor(seenCountFrom(entry), maxSeenCount),
         relevance: normalizeRelevance(entry.relevance),
-        // The 4th factor `score` now averages. Reported so `factors` still
+        // `score` now averages a 4th factor. Reported so `factors` still
         // reconciles with `score` — an absent outcome surfaces as the
         // cold-start prior (`normalizeOutcome`), not a missing key.
         outcome: normalizeOutcome(entry.outcome),

--- a/supabase/functions/memories/handlers/relevant.ts
+++ b/supabase/functions/memories/handlers/relevant.ts
@@ -25,6 +25,33 @@ import type { RankableLesson } from '../../_shared/lesson-rank.ts';
 type MemoryRow = Tables<'memories'>;
 
 /**
+ * Outcome bus tags that indicate a lesson has a strong positive outcome
+ * (applied/resolved a review thread). Order matters: bus tag wins over origin_pr.
+ */
+const OUTCOME_BUS_TAGS = ['loop::review-outcomes', 'loop::reviewer-comment-relevance'] as const;
+
+/**
+ * Map a memory row's tags and origin_pr to an outcome score in [0,1], or
+ * `undefined` when no outcome signal is present (the scorer's cold-start prior
+ * will apply).
+ *
+ * Ladder (highest to lowest signal strength):
+ *   1. Outcome-bus tag present → 1.0 (strong positive: applied/resolved)
+ *   2. Non-null origin_pr → 0.75 (weak positive: carried to a PR)
+ *   3. Neither → undefined (cold: scorer applies COLD_START_OUTCOME_PRIOR)
+ *
+ * Lives in the handler, not the pure scorer, to keep the shared module free of
+ * repo-schema knowledge — symmetric with how relevance is derived outside the
+ * scorer and handed in as a number.
+ */
+function outcomeFromRow(r: MemoryRow & { tags?: string[] | null; origin_pr?: number | null }): number | undefined {
+  const tags: string[] = Array.isArray(r.tags) ? r.tags : [];
+  if (OUTCOME_BUS_TAGS.some((t) => tags.includes(t))) return 1.0;
+  if (r.origin_pr != null) return 0.75;
+  return undefined;
+}
+
+/**
  * How many rows the FTS may return before ranking. The ranking is set-relative
  * — salience normalises against the most-recurring candidate — so it needs a
  * population, not just the page it will return, or a genuinely recurring lesson
@@ -142,6 +169,7 @@ export async function handleRelevant(
     seen_count: (r as MemoryRow & { seen_count?: number }).seen_count ?? null,
     updated_at: r.updated_at,
     relevance: matched ? 1 : 0,
+    outcome: outcomeFromRow(r),
   }));
 
   const now = Date.now();

--- a/supabase/functions/memories/handlers/relevant.ts
+++ b/supabase/functions/memories/handlers/relevant.ts
@@ -17,39 +17,14 @@ import {
   recencyFactor,
   salienceFactor,
   normalizeRelevance,
+  normalizeOutcome,
   seenCountFrom,
   updatedAtFrom,
 } from '../../_shared/lesson-rank.ts';
 import type { RankableLesson } from '../../_shared/lesson-rank.ts';
+import { outcomeFromTags } from '../../_shared/outcome-signal.ts';
 
 type MemoryRow = Tables<'memories'>;
-
-/**
- * Outcome bus tags that indicate a lesson has a strong positive outcome
- * (applied/resolved a review thread). Order matters: bus tag wins over origin_pr.
- */
-const OUTCOME_BUS_TAGS = ['loop::review-outcomes', 'loop::reviewer-comment-relevance'] as const;
-
-/**
- * Map a memory row's tags and origin_pr to an outcome score in [0,1], or
- * `undefined` when no outcome signal is present (the scorer's cold-start prior
- * will apply).
- *
- * Ladder (highest to lowest signal strength):
- *   1. Outcome-bus tag present → 1.0 (strong positive: applied/resolved)
- *   2. Non-null origin_pr → 0.75 (weak positive: carried to a PR)
- *   3. Neither → undefined (cold: scorer applies COLD_START_OUTCOME_PRIOR)
- *
- * Lives in the handler, not the pure scorer, to keep the shared module free of
- * repo-schema knowledge — symmetric with how relevance is derived outside the
- * scorer and handed in as a number.
- */
-function outcomeFromRow(r: MemoryRow & { tags?: string[] | null; origin_pr?: number | null }): number | undefined {
-  const tags: string[] = Array.isArray(r.tags) ? r.tags : [];
-  if (OUTCOME_BUS_TAGS.some((t) => tags.includes(t))) return 1.0;
-  if (r.origin_pr != null) return 0.75;
-  return undefined;
-}
 
 /**
  * How many rows the FTS may return before ranking. The ranking is set-relative
@@ -169,7 +144,10 @@ export async function handleRelevant(
     seen_count: (r as MemoryRow & { seen_count?: number }).seen_count ?? null,
     updated_at: r.updated_at,
     relevance: matched ? 1 : 0,
-    outcome: outcomeFromRow(r),
+    outcome: outcomeFromTags(
+      (r as MemoryRow & { tags?: string[] | null }).tags,
+      (r as MemoryRow & { origin_pr?: number | null }).origin_pr,
+    ),
   }));
 
   const now = Date.now();
@@ -194,6 +172,10 @@ export async function handleRelevant(
         recency: recencyFactor(updatedAtFrom(entry), now),
         salience: salienceFactor(seenCountFrom(entry), maxSeenCount),
         relevance: normalizeRelevance(entry.relevance),
+        // The 4th factor `score` now averages. Reported so `factors` still
+        // reconciles with `score` — an absent outcome surfaces as the
+        // cold-start prior (`normalizeOutcome`), not a missing key.
+        outcome: normalizeOutcome(entry.outcome),
       },
       seen_count: seenCountFrom(entry) || null,
       updated_at: entry.updated_at ?? null,


### PR DESCRIPTION
## Summary

Adds a fourth ranking factor — `outcome` — to the lesson scorer (and all three parity twins) so lessons with applied/resolution history rank up, while cold new lessons receive a neutral-positive prior (`COLD_START_OUTCOME_PRIOR = 0.5`) instead of scoring 0.

- `packages/mcp-core/src/lesson-rank.ts` — add `outcome` field to `RankableLesson`/`RankWeights`, `COLD_START_OUTCOME_PRIOR`, `normalizeOutcome`, 4-key `DEFAULT_RANK_WEIGHTS`, updated `scoreLesson`
- `supabase/functions/_shared/lesson-rank.ts` — byte-identical edge mirror (kept in sync by `edge-parity.spec.ts`)
- `packages/cli/src/lessons-pure.mjs` — behavioral twin in MJS (kept in sync by `lesson-rank-parity.spec.ts`)
- `packages/schemas/src/relevant.ts` + `supabase/functions/_shared/schemas/relevant.ts` — widen `RELEVANT_SELECT` to include `tags,origin_pr` (regenerated, not hand-edited)
- `supabase/functions/memories/handlers/relevant.ts` — add `outcomeFromRow` helper; map `outcome` in candidates
- `supabase/functions/mcp/tools.ts` — add `origin_pr` to ranked-branch SELECT; add `outcomeFromRowTags`; map `outcome`; recency-path SELECT untouched
- `packages/mcp-core/src/lesson-rank-parity.spec.ts` + `packages/cli/test/unit.test.mjs` — add outcome/cold-start tests; update frozen-defaults; fix relevance-isolation tests to include `outcome:0`
- `docs/mcp-tools.md` — update `order: "rank"` description to "four-factor scoring"

## Phase 0 Outcome-Signal Finding

Investigation against the real schema (`database.types.ts`) found:

- `origin_pr` — a real `integer` nullable column on `memories`. Non-null = "carried to a PR" = weak positive outcome signal (→ 0.75).
- `tags` — the real `text[]` column. Tags `loop::review-outcomes` and `loop::reviewer-comment-relevance` are the genuine outcome-bus signals (→ 1.0).
- `source='review-comment'` — **NOT a real column.** Exists only in `packages/web/src/mocks/memories.ts` mock fixtures. The A0 lesson `retrieval-outcome-ground-truth-source` is incorrect and will be updated after merge.
- `seen_count` and a dedicated outcomes table — excluded (double-count risk).

Used signals: `tags` (bus-tag check) + `origin_pr` (PR-carry check), mapped per-row in the edge handlers.

## Cold-Start Handling

`COLD_START_OUTCOME_PRIOR = 0.5` — named constant exported from all three parity twins. `normalizeOutcome(value)` returns this constant for any absent or unreadable input (null, undefined, NaN, non-finite, non-numeric string). A present value is clamped to `[0,1]`. This means a cold new lesson with no outcome history contributes a neutral-positive 0.5 outcome term and ranks on recency/relevance rather than being penalized for lacking history.

## Key Design Decisions

1. **Option A (derive from existing columns)** — no migration, no new column, no `pnpm-lock.yaml` change. Keeps CI scope narrow (no `web:*` fan-out from lockfile change).
2. **Outcome mapping lives in edge handlers** — keeps the pure scorer (`lesson-rank.ts`) free of repo-schema knowledge, symmetric with how `relevance` is derived outside and handed in as a number.
3. **Ranked-branch-only SELECT widening** — the recency path SELECT in `toolList` is untouched (AC-7).
4. **Outcome ladder** (strongest to weakest): outcome-bus tag → 1.0; non-null `origin_pr` → 0.75; absent → `undefined` (scorer's cold-start prior).

## Test Plan

- [x] `pnpm nx test mcp-core` — 1015/1015 pass (lesson-rank-parity, edge-parity, edge-schema-parity, tool-catalog-parity all green)
- [x] `node --test packages/cli/test/unit.test.mjs` — 111/111 pass
- [x] AC-1: outcome-positive outranks outcome-negative at equal recency+salience
- [x] AC-2: cold new row outranks old low-relevance row (prior 0.5 > 0)
- [x] AC-3: `normalizeOutcome` returns `COLD_START_OUTCOME_PRIOR` for absent/unreadable; clamps present to `[0,1]`
- [x] AC-4: `DEFAULT_RANK_WEIGHTS` is `{recency:1,salience:1,relevance:1,outcome:1}` in all three twins
- [x] AC-7: recency-path SELECT does NOT include `origin_pr`
- [x] AC-8: no migration, no new column, no `pnpm-lock.yaml` change
- [x] AC-9: edge `RELEVANT_SELECT` mirror regenerated by script, not hand-edited
- [x] AC-10: tests use real `scoreLesson`/`rankLessons`, not re-encoded literals

🤖 Generated with [Claude Code](https://claude.com/claude-code)