### PR TITLE
feat: MMR read-time diversification of ranked lesson reads

### DIFF
--- a/packages/cli/src/lessons-pure.mjs
+++ b/packages/cli/src/lessons-pure.mjs
@@ -488,6 +488,73 @@ function seenCountFrom(entry) {
 }
 
 /**
+ * MMR λ (lambda) — weight given to relevance vs diversity in the MMR objective.
+ * At 0.7 the selector favours relevance, with 0.3 of the budget for diversity.
+ * Anchored to Carbonell & Goldstein (1998), the original MMR paper.
+ * Mirrored byte-identically in the edge twin and `packages/mcp-core/src/lesson-rank.ts`.
+ */
+export const MMR_LAMBDA = 0.7;
+
+/**
+ * Word/token Jaccard similarity on the lesson `value`.
+ *
+ * Tokenises by case-folding and splitting on non-alphanumeric characters,
+ * deduplicating into a Set, then returning |A∩B| / |A∪B|. Both-empty → 0.
+ * Dependency-free and deterministic so it mirrors byte-identically across
+ * TS, Deno, and the `.mjs` twin.
+ */
+function jaccardSimilarity(a, b) {
+  const tokenize = (v) => {
+    const tokens = String(v ?? '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+    return new Set(tokens);
+  };
+  const setA = tokenize(a);
+  const setB = tokenize(b);
+  if (setA.size === 0 && setB.size === 0) return 0;
+  let intersection = 0;
+  for (const t of setA) if (setB.has(t)) intersection += 1;
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+/**
+ * Select the top-K lessons from a ranked list using Maximal Marginal Relevance
+ * (Carbonell & Goldstein, 1998).
+ *
+ * Accepts bare entries (the shape `rankLessons` returns in the `.mjs` twin)
+ * plus a parallel `scores` array (required for the MMR relevance term).
+ * Greedy MMR: seed with index 0 (highest-ranked), then at each step pick
+ * the unselected candidate that maximises
+ *   λ·score(i) − (1−λ)·max_{j∈selected} jaccardSimilarity(value_i, value_j)
+ * Ties break by input order (first-wins) for determinism.
+ *
+ * Always-on for ranked mode — no optional param needed. The recency wire path is
+ * never affected.
+ */
+export function selectDiverse(entries, k, { lambda = MMR_LAMBDA, scores = [] } = {}) {
+  if (!Array.isArray(entries) || entries.length === 0 || k <= 0) return [];
+  const selected = [];
+  const selectedScores = [];
+  const remaining = entries.map((e, i) => ({ entry: e, score: scores[i] ?? 0, origIdx: i }));
+  while (selected.length < k && remaining.length > 0) {
+    let bestIdx = 0;
+    let bestMmr = -Infinity;
+    for (let i = 0; i < remaining.length; i++) {
+      const candidate = remaining[i];
+      const maxSim = selected.length === 0
+        ? 0
+        : Math.max(...selected.map((s) => jaccardSimilarity(candidate.entry?.value, s?.value)));
+      const mmr = lambda * candidate.score - (1 - lambda) * maxSim;
+      if (mmr > bestMmr) { bestMmr = mmr; bestIdx = i; }
+    }
+    selected.push(remaining[bestIdx].entry);
+    selectedScores.push(remaining[bestIdx].score);
+    remaining.splice(bestIdx, 1);
+  }
+  return selected;
+}
+
+/**
  * Rank lessons best-first, returning a NEW array — the input is never reordered
  * in place, because callers hold it (`fetchLessons` builds it from the
  * precedence resolution and `tree` renders the same objects).

--- a/packages/cli/src/lessons-pure.mjs
+++ b/packages/cli/src/lessons-pure.mjs
@@ -496,20 +496,30 @@ function seenCountFrom(entry) {
 export const MMR_LAMBDA = 0.7;
 
 /**
- * Word/token Jaccard similarity on the lesson `value`.
+ * Tokenise a lesson `value` into a deduplicated Set: case-fold, split on
+ * non-alphanumeric characters, drop empties. Dependency-free and deterministic
+ * so it mirrors the TS/Deno twin's `tokenizeValue`.
  *
- * Tokenises by case-folding and splitting on non-alphanumeric characters,
- * deduplicating into a Set, then returning |A∩B| / |A∪B|. Both-empty → 0.
- * Dependency-free and deterministic so it mirrors byte-identically across
- * TS, Deno, and the `.mjs` twin.
+ * PERF: `selectDiverse` calls this ONCE per candidate before the MMR loop and
+ * caches the result. `jaccardSimilarity` takes the cached Sets, so the O(k²)
+ * pairwise comparisons inside the loop cost no tokenisation. Do NOT re-introduce
+ * a `tokenize(value)` call inside the loop: that regresses the hot path to
+ * O(n·k²) tokenisations (measured 34s CPU at n=200/k=100 with 1.5KB values).
  */
-function jaccardSimilarity(a, b) {
-  const tokenize = (v) => {
-    const tokens = String(v ?? '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
-    return new Set(tokens);
-  };
-  const setA = tokenize(a);
-  const setB = tokenize(b);
+function tokenizeValue(v) {
+  const tokens = String(v ?? '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  return new Set(tokens);
+}
+
+/**
+ * Word/token Jaccard similarity between two PRE-TOKENISED value Sets:
+ * |A∩B| / |A∪B|. Both-empty → 0.
+ *
+ * Takes Sets rather than raw values on purpose — the caller tokenises each
+ * candidate once (see `tokenizeValue`) so this stays allocation-free on the
+ * O(k²) hot path.
+ */
+function jaccardSimilarity(setA, setB) {
   if (setA.size === 0 && setB.size === 0) return 0;
   let intersection = 0;
   for (const t of setA) if (setB.has(t)) intersection += 1;
@@ -522,36 +532,67 @@ function jaccardSimilarity(a, b) {
  * (Carbonell & Goldstein, 1998).
  *
  * Accepts bare entries (the shape `rankLessons` returns in the `.mjs` twin)
- * plus a parallel `scores` array (required for the MMR relevance term).
+ * plus a parallel `scores` array — REQUIRED, one score per entry. This is the
+ * MMR relevance term; there is no meaningful default. A missing `scores`, a
+ * non-array, or a length that does not match `entries` throws rather than
+ * silently defaulting to 0 for every entry (which would degrade selection to
+ * pure diversity and quietly discard the ranking). The TS twin cannot hit this
+ * footgun — it reads the score off each `{ entry, score }` input.
+ *
  * Greedy MMR: seed with index 0 (highest-ranked), then at each step pick
  * the unselected candidate that maximises
- *   λ·score(i) − (1−λ)·max_{j∈selected} jaccardSimilarity(value_i, value_j)
+ *   λ·quantise(score(i)) − (1−λ)·max_{j∈selected} jaccardSimilarity(value_i, value_j)
  * Ties break by input order (first-wins) for determinism.
+ *
+ * SCORE QUANTISATION: the relevance term uses the score SNAPPED onto the
+ * `SCORE_EPSILON` grid — the exact grid `rankLessons` buckets on for its
+ * scope-precedence tie-break. Two scores within `SCORE_EPSILON` land in the same
+ * bucket, so the MMR objective sees them as equal and the input order (which
+ * `rankLessons` already sorted by scope precedence, then key) decides. Comparing
+ * the RAW score would let a 1e-10 float difference override scope precedence.
+ *
+ * PERF: each candidate's `value` is tokenised ONCE up front so the O(k²)
+ * pairwise Jaccard comparisons inside the loop do no tokenisation — O(n)
+ * tokenisations total, not O(n·k²). See `tokenizeValue`.
  *
  * Always-on for ranked mode — no optional param needed. The recency wire path is
  * never affected.
  */
-export function selectDiverse(entries, k, { lambda = MMR_LAMBDA, scores = [] } = {}) {
+export function selectDiverse(entries, k, { lambda = MMR_LAMBDA, scores } = {}) {
   if (!Array.isArray(entries) || entries.length === 0 || k <= 0) return [];
+  if (!Array.isArray(scores) || scores.length !== entries.length) {
+    throw new TypeError(
+      `selectDiverse: \`scores\` must be an array with one score per entry `
+        + `(got ${Array.isArray(scores) ? `length ${scores.length}` : typeof scores} `
+        + `for ${entries.length} entries)`,
+    );
+  }
   const selected = [];
-  const selectedScores = [];
-  const remaining = entries.map((e, i) => ({ entry: e, score: scores[i] ?? 0, origIdx: i }));
+  // Pre-tokenise every candidate ONCE and snap its score onto the SCORE_EPSILON
+  // grid up front. The loop below reads these caches — it never tokenises or
+  // re-quantises. See the docblock (PERF + SCORE QUANTISATION).
+  const remaining = entries.map((e, i) => ({
+    entry: e,
+    tokens: tokenizeValue(e?.value),
+    qScore: Math.round((scores[i] ?? 0) / SCORE_EPSILON) * SCORE_EPSILON,
+  }));
   while (selected.length < k && remaining.length > 0) {
     let bestIdx = 0;
     let bestMmr = -Infinity;
     for (let i = 0; i < remaining.length; i++) {
       const candidate = remaining[i];
-      const maxSim = selected.length === 0
-        ? 0
-        : Math.max(...selected.map((s) => jaccardSimilarity(candidate.entry?.value, s?.value)));
-      const mmr = lambda * candidate.score - (1 - lambda) * maxSim;
+      let maxSim = 0;
+      for (const s of selected) {
+        const sim = jaccardSimilarity(candidate.tokens, s.tokens);
+        if (sim > maxSim) maxSim = sim;
+      }
+      const mmr = lambda * candidate.qScore - (1 - lambda) * maxSim;
       if (mmr > bestMmr) { bestMmr = mmr; bestIdx = i; }
     }
-    selected.push(remaining[bestIdx].entry);
-    selectedScores.push(remaining[bestIdx].score);
+    selected.push(remaining[bestIdx]);
     remaining.splice(bestIdx, 1);
   }
-  return selected;
+  return selected.map((s) => s.entry);
 }
 
 /**

--- a/packages/cli/src/lessons-pure.mjs
+++ b/packages/cli/src/lessons-pure.mjs
@@ -551,14 +551,30 @@ function jaccardSimilarity(setA, setB) {
  * `rankLessons` already sorted by scope precedence, then key) decides. Comparing
  * the RAW score would let a 1e-10 float difference override scope precedence.
  *
- * PERF: each candidate's `value` is tokenised ONCE up front so the O(k²)
- * pairwise Jaccard comparisons inside the loop do no tokenisation — O(n)
- * tokenisations total, not O(n·k²). See `tokenizeValue`.
+ * PERF — the algorithm is O(n·k), and BOTH factors that could regress it to
+ * O(n·k²) are held down explicitly:
+ *   1. TOKENISE axis: each candidate's `value` is tokenised ONCE up front (the
+ *      `tokens` field) so the pairwise Jaccard comparisons never tokenise —
+ *      O(n) tokenisations total. See `tokenizeValue`.
+ *   2. INTERSECTION axis: each remaining candidate carries a RUNNING `maxSim`
+ *      (its greatest Jaccard similarity to anything selected so far). The
+ *      objective reads that cached scalar — it does NOT loop over `selected`.
+ *      After each pick we update `maxSim` for the still-remaining candidates
+ *      against the ONE just-selected entry only. That is k picks × n candidates
+ *      = O(n·k) Jaccard intersections total, not O(n·k²).
+ * Re-introducing either an in-loop `tokenizeValue` call OR an inner
+ * `for (… of selected)` maxSim recomputation silently restores O(n·k²) —
+ * measured 2.6s CPU at n=200/k=100 vs 58ms for the running form. Don't.
  *
  * Always-on for ranked mode — no optional param needed. The recency wire path is
  * never affected.
  */
-export function selectDiverse(entries, k, { lambda = MMR_LAMBDA, scores } = {}) {
+export function selectDiverse(entries, k, { lambda: lambdaOpt, scores } = {}) {
+  // Match the TS twin: fall back to MMR_LAMBDA unless `lambda` is a FINITE
+  // number. A bare destructuring default only catches `undefined`, so
+  // `{ lambda: NaN }` would otherwise poison every MMR objective here while the
+  // TS twin quietly used MMR_LAMBDA — a silent cross-twin divergence.
+  const lambda = typeof lambdaOpt === 'number' && Number.isFinite(lambdaOpt) ? lambdaOpt : MMR_LAMBDA;
   if (!Array.isArray(entries) || entries.length === 0 || k <= 0) return [];
   if (!Array.isArray(scores) || scores.length !== entries.length) {
     throw new TypeError(
@@ -569,30 +585,34 @@ export function selectDiverse(entries, k, { lambda = MMR_LAMBDA, scores } = {}) 
   }
   const selected = [];
   // Pre-tokenise every candidate ONCE and snap its score onto the SCORE_EPSILON
-  // grid up front. The loop below reads these caches — it never tokenises or
-  // re-quantises. See the docblock (PERF + SCORE QUANTISATION).
+  // grid up front. `maxSim` is the running greatest Jaccard similarity to any
+  // already-selected entry — 0 while nothing is selected. The loop below reads
+  // these caches; it never tokenises, re-quantises, or rescans `selected`.
   const remaining = entries.map((e, i) => ({
     entry: e,
     tokens: tokenizeValue(e?.value),
     qScore: Math.round((scores[i] ?? 0) / SCORE_EPSILON) * SCORE_EPSILON,
+    maxSim: 0,
   }));
   while (selected.length < k && remaining.length > 0) {
     let bestIdx = 0;
     let bestMmr = -Infinity;
     for (let i = 0; i < remaining.length; i++) {
       const candidate = remaining[i];
-      let maxSim = 0;
-      for (const s of selected) {
-        const sim = jaccardSimilarity(candidate.tokens, s.tokens);
-        if (sim > maxSim) maxSim = sim;
-      }
-      const mmr = lambda * candidate.qScore - (1 - lambda) * maxSim;
+      // Reads the cached running maxSim — no inner scan over `selected`.
+      const mmr = lambda * candidate.qScore - (1 - lambda) * candidate.maxSim;
       if (mmr > bestMmr) { bestMmr = mmr; bestIdx = i; }
     }
-    selected.push(remaining[bestIdx]);
-    remaining.splice(bestIdx, 1);
+    const [justSelected] = remaining.splice(bestIdx, 1);
+    selected.push(justSelected.entry);
+    // Fold the just-selected entry into every remaining candidate's running
+    // maxSim — one Jaccard per remaining candidate per pick, so O(n·k) total.
+    for (const candidate of remaining) {
+      const sim = jaccardSimilarity(candidate.tokens, justSelected.tokens);
+      if (sim > candidate.maxSim) candidate.maxSim = sim;
+    }
   }
-  return selected.map((s) => s.entry);
+  return selected;
 }
 
 /**

--- a/packages/mcp-core/src/lesson-rank-parity.spec.ts
+++ b/packages/mcp-core/src/lesson-rank-parity.spec.ts
@@ -276,11 +276,11 @@ describe('selectDiverse parity: TS ↔ .mjs produce the same diverse selection',
     { scope: 'global', key: 'D', seenCount: 0, updatedAt: daysAgo(4),  relevance: 1, outcome: 1, value: 'database schema migration rollback strategy index creation' },
   ];
   const K = 3;
-  // Isolation weights: zeroing salience so seenCount=0 for all doesn't matter;
-  // zeroing recency ensures only relevance+outcome drive the raw rank (all equal).
-  // To GET a diverge, we DO want recency to differentiate raw rank (A>B>C>D) so
-  // the raw order would be [A,B,C] but MMR picks [A,D,B] or similar.
-  // Use default weights so recency drives raw rank.
+  // Default weights (no zeroing) so recency differentiates the raw rank
+  // A>B>C>D — the raw top-3 is [A,B,C], but MMR picks [A,D,B] or similar because
+  // D's low similarity to A promotes it over the near-duplicate B. relevance=1
+  // and outcome=1 on all four equalise those factors; seenCount=0 on all four
+  // means salience is 0 for everyone regardless of its weight.
   const rankOpts = { now: NOW };
 
   it('TS and .mjs agree on the selected scope::key order (R9 diverge fixture)', () => {

--- a/packages/mcp-core/src/lesson-rank-parity.spec.ts
+++ b/packages/mcp-core/src/lesson-rank-parity.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { join } from 'node:path';
 import {
   rankLessons as rankTs,
+  selectDiverse as selectDiverseTs,
   scoreLesson as scoreTs,
   recencyFactor as recencyTs,
   salienceFactor as salienceTs,
@@ -35,7 +36,8 @@ import {
 // loaded by URL at runtime rather than as a typed import.
 const cliModulePath = join(import.meta.dirname, '../../cli/src/lessons-pure.mjs');
 const cli = await import(/* @vite-ignore */ `file://${cliModulePath}`) as {
-  rankLessons: (entries: unknown[], opts?: Record<string, unknown>) => { key?: string }[];
+  rankLessons: (entries: unknown[], opts?: Record<string, unknown>) => { key?: string; scope?: string; value?: string }[];
+  selectDiverse: (entries: unknown[], k: number, opts?: { lambda?: number; scores?: number[] }) => { key?: string; scope?: string }[];
   scoreLesson: (entry: unknown, opts?: Record<string, unknown>) => number;
   recencyFactor: (updatedAt: unknown, now: unknown, halfLifeDays?: number) => number;
   salienceFactor: (seen: unknown, max: unknown) => number;
@@ -44,6 +46,7 @@ const cli = await import(/* @vite-ignore */ `file://${cliModulePath}`) as {
   DEFAULT_RANK_WEIGHTS: { recency: number; salience: number; relevance: number; outcome: number };
   SCORE_EPSILON: number;
   COLD_START_OUTCOME_PRIOR: number;
+  MMR_LAMBDA: number;
 };
 
 const NOW = Date.parse('2026-08-01T00:00:00.000Z');
@@ -243,6 +246,81 @@ describe('lesson-rank: the epsilon-grid tie-break is transitive', () => {
     ]) {
       expect(rankedBuckets(perm.map((i) => chain[i]))).toEqual(canonical);
     }
+  });
+});
+
+// ── selectDiverse parity: TS and .mjs produce the same selected scope::key order ─
+//
+// This block exercises `selectDiverse` across both twins and asserts:
+//  1. TS and .mjs select the same scope::key order over the shared fixture.
+//  2. The selected order DIVERGES from the raw-rank order — proving the fixture
+//     exercises MMR (not just a pass-through of rank order).
+//
+// Fixture design: three near-duplicate high-score lessons (similar value text)
+// plus one distinct lesson ranked lower by recency. MMR should prefer the
+// distinct lesson over the 2nd near-duplicate because its maxSim to already-
+// selected entries is low, boosting its MMR score over a 3rd near-dup.
+// Isolation: relevance=1 and outcome=1 on all four to equalize those factors;
+// recency differentiates raw rank order. weights zeroed on salience so the
+// seenCount doesn't interfere.
+
+describe('selectDiverse parity: TS ↔ .mjs produce the same diverse selection', () => {
+  // Four entries: A/B/C share the same "caching timeout retry" vocabulary (near-dups);
+  // D has "database schema migration" vocabulary (distinct). Under MMR, after
+  // selecting A (highest raw rank), the next pick favours D over B because sim(D,A)
+  // is near-zero while sim(B,A) is high — so D enters the top-3 ahead of B.
+  const divergeFixtures = [
+    { scope: 'global', key: 'A', seenCount: 0, updatedAt: daysAgo(1),  relevance: 1, outcome: 1, value: 'caching timeout retry exponential backoff caching timeout retry' },
+    { scope: 'global', key: 'B', seenCount: 0, updatedAt: daysAgo(2),  relevance: 1, outcome: 1, value: 'caching timeout retry exponential backoff strategy caching' },
+    { scope: 'global', key: 'C', seenCount: 0, updatedAt: daysAgo(3),  relevance: 1, outcome: 1, value: 'caching timeout retry exponential backoff pattern retry' },
+    { scope: 'global', key: 'D', seenCount: 0, updatedAt: daysAgo(4),  relevance: 1, outcome: 1, value: 'database schema migration rollback strategy index creation' },
+  ];
+  const K = 3;
+  // Isolation weights: zeroing salience so seenCount=0 for all doesn't matter;
+  // zeroing recency ensures only relevance+outcome drive the raw rank (all equal).
+  // To GET a diverge, we DO want recency to differentiate raw rank (A>B>C>D) so
+  // the raw order would be [A,B,C] but MMR picks [A,D,B] or similar.
+  // Use default weights so recency drives raw rank.
+  const rankOpts = { now: NOW };
+
+  it('TS and .mjs agree on the selected scope::key order (R9 diverge fixture)', () => {
+    // TS side
+    const tsRanked = rankTs(divergeFixtures, rankOpts);
+    const tsDiverse = selectDiverseTs(tsRanked, K);
+    const tsOrder = tsDiverse.map((r) => `${r.entry.scope}::${r.entry.key}`);
+
+    // .mjs side — rank to get bare entries + need scores for selectDiverse
+    const jsRanked = cli.rankLessons(divergeFixtures, rankOpts);
+    // Compute scores in parallel using the .mjs scorer (same maxSeenCount=0, same now)
+    const maxSeenCount = 0;
+    const jsScores = jsRanked.map((e) => cli.scoreLesson(e, { now: NOW, maxSeenCount, terms: [] }));
+    const jsDiverse = cli.selectDiverse(jsRanked, K, { scores: jsScores });
+    const jsOrder = jsDiverse.map((e) => {
+      const row = e as { scope?: string; key?: string };
+      return `${row.scope}::${row.key}`;
+    });
+
+    expect(tsOrder).toEqual(jsOrder);
+  });
+
+  it('the selected order diverges from the raw-rank order (MMR is exercised)', () => {
+    // Raw-rank order by recency: A(1d), B(2d), C(3d), D(4d) → top-3 = [A,B,C]
+    const tsRanked = rankTs(divergeFixtures, rankOpts);
+    const rawOrder = tsRanked.slice(0, K).map((r) => `${r.entry.scope}::${r.entry.key}`);
+    const tsDiverse = selectDiverseTs(tsRanked, K);
+    const mmrOrder = tsDiverse.map((r) => `${r.entry.scope}::${r.entry.key}`);
+
+    // MMR must pick differently from the raw top-K (if they were the same,
+    // the fixture does not exercise the diversity term at all).
+    expect(mmrOrder).not.toEqual(rawOrder);
+    // D must appear in the MMR selection (it is the distinct lesson).
+    expect(mmrOrder).toContain('global::D');
+    // A must be first (highest raw score, seeds the selection).
+    expect(mmrOrder[0]).toBe('global::A');
+  });
+
+  it('MMR_LAMBDA constant matches the CLI twin', () => {
+    expect(cli.MMR_LAMBDA).toBe(0.7);
   });
 });
 

--- a/packages/mcp-core/src/lesson-rank-parity.spec.ts
+++ b/packages/mcp-core/src/lesson-rank-parity.spec.ts
@@ -289,10 +289,14 @@ describe('selectDiverse parity: TS ↔ .mjs produce the same diverse selection',
     const tsDiverse = selectDiverseTs(tsRanked, K);
     const tsOrder = tsDiverse.map((r) => `${r.entry.scope}::${r.entry.key}`);
 
-    // .mjs side — rank to get bare entries + need scores for selectDiverse
+    // .mjs side — rank to get bare entries + need scores for selectDiverse.
+    // Derive maxSeenCount FROM the fixture (max seenCount) rather than hard-coding
+    // 0: that is the population value `rankLessons` scores against internally, so
+    // the parallel `.mjs` scores are rebuilt by the SAME route rankTs used. A
+    // fixture that later gains a non-zero `seenCount` then stays honest instead of
+    // silently diverging.
     const jsRanked = cli.rankLessons(divergeFixtures, rankOpts);
-    // Compute scores in parallel using the .mjs scorer (same maxSeenCount=0, same now)
-    const maxSeenCount = 0;
+    const maxSeenCount = Math.max(0, ...divergeFixtures.map((f) => f.seenCount ?? 0));
     const jsScores = jsRanked.map((e) => cli.scoreLesson(e, { now: NOW, maxSeenCount, terms: [] }));
     const jsDiverse = cli.selectDiverse(jsRanked, K, { scores: jsScores });
     const jsOrder = jsDiverse.map((e) => {

--- a/packages/mcp-core/src/lesson-rank.ts
+++ b/packages/mcp-core/src/lesson-rank.ts
@@ -229,20 +229,31 @@ export interface RankedLesson<T extends RankableLesson> {
 export const MMR_LAMBDA = 0.7;
 
 /**
- * Word/token Jaccard similarity on the lesson `value`.
+ * Tokenise a lesson `value` into a deduplicated Set: case-fold, split on
+ * non-alphanumeric characters, drop empties. Dependency-free and deterministic
+ * so it mirrors byte-identically across TS, Deno, and the `.mjs` twin.
  *
- * Tokenises by case-folding and splitting on non-alphanumeric characters,
- * deduplicating into a Set, then returning |A∩B| / |A∪B|. Both-empty → 0.
- * Dependency-free and deterministic so it mirrors byte-identically across
- * TS, Deno, and the `.mjs` twin.
+ * PERF: `selectDiverse` calls this ONCE per candidate before the MMR loop and
+ * caches the result — see the `tokens` field it builds. `jaccardSimilarity`
+ * takes the cached Sets, so the O(k²) pairwise comparisons inside the loop cost
+ * no tokenisation. Do NOT re-introduce a `tokenize(value)` call inside the loop:
+ * that regresses the hot path to O(n·k²) tokenisations (measured 34s CPU at
+ * n=200/k=100, `tools.ts` max with 1.5KB values).
  */
-function jaccardSimilarity(a: unknown, b: unknown): number {
-  const tokenize = (v: unknown): Set<string> => {
-    const tokens = String(v ?? '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
-    return new Set(tokens);
-  };
-  const setA = tokenize(a);
-  const setB = tokenize(b);
+function tokenizeValue(v: unknown): Set<string> {
+  const tokens = String(v ?? '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  return new Set(tokens);
+}
+
+/**
+ * Word/token Jaccard similarity between two PRE-TOKENISED value Sets:
+ * |A∩B| / |A∪B|. Both-empty → 0.
+ *
+ * Takes Sets rather than raw values on purpose — the caller tokenises each
+ * candidate once (see `tokenizeValue`) so this stays allocation-free on the
+ * O(k²) hot path.
+ */
+function jaccardSimilarity(setA: Set<string>, setB: Set<string>): number {
   if (setA.size === 0 && setB.size === 0) return 0;
   let intersection = 0;
   for (const t of setA) if (setB.has(t)) intersection += 1;
@@ -260,9 +271,21 @@ export interface SelectDiverseOptions {
  *
  * Greedy MMR: seed with the highest-ranked candidate, then at each step pick
  * the unselected candidate that maximises
- *   λ·score(i) − (1−λ)·max_{j∈selected} jaccardSimilarity(value_i, value_j)
+ *   λ·quantise(score(i)) − (1−λ)·max_{j∈selected} jaccardSimilarity(value_i, value_j)
  * Ties in the MMR objective break by input order (first-wins) so the result
  * is deterministic over the already-rank-ordered input.
+ *
+ * SCORE QUANTISATION: the relevance term uses the score SNAPPED onto the
+ * `SCORE_EPSILON` grid — the exact grid `rankLessons` buckets on for its
+ * scope-precedence tie-break. Two scores within `SCORE_EPSILON` land in the same
+ * bucket, so the MMR objective sees them as equal and the input order (which
+ * `rankLessons` already sorted by scope precedence, then key) decides between
+ * them. Comparing the RAW score here would let a 1e-10 float difference override
+ * scope precedence — the lower-precedence scope could win a near-tie MMR pick.
+ *
+ * PERF: each candidate's `value` is tokenised ONCE up front (the `tokens` field)
+ * so the O(k²) pairwise Jaccard comparisons inside the loop do no tokenisation —
+ * O(n) tokenisations total, not O(n·k²). See `tokenizeValue`.
  *
  * Always-on for ranked mode — no optional param needed. The recency wire path is
  * never affected.
@@ -276,23 +299,32 @@ export function selectDiverse<T extends RankableLesson>(
     ? options.lambda
     : MMR_LAMBDA;
   if (!Array.isArray(ranked) || ranked.length === 0 || k <= 0) return [];
-  const selected: RankedLesson<T>[] = [];
-  const remaining = ranked.slice();
+  const selected: { ranked: RankedLesson<T>; tokens: Set<string>; qScore: number }[] = [];
+  // Pre-tokenise every candidate ONCE and snap its score onto the SCORE_EPSILON
+  // grid up front. The loop below reads these caches — it never tokenises or
+  // re-quantises. See the docblock (PERF + SCORE QUANTISATION).
+  const remaining = ranked.map((r) => ({
+    ranked: r,
+    tokens: tokenizeValue(r.entry.value),
+    qScore: Math.round(r.score / SCORE_EPSILON) * SCORE_EPSILON,
+  }));
   while (selected.length < k && remaining.length > 0) {
     let bestIdx = 0;
     let bestMmr = -Infinity;
     for (let i = 0; i < remaining.length; i++) {
       const candidate = remaining[i];
-      const maxSim = selected.length === 0
-        ? 0
-        : Math.max(...selected.map((s) => jaccardSimilarity(candidate.entry.value, s.entry.value)));
-      const mmr = lambda * candidate.score - (1 - lambda) * maxSim;
+      let maxSim = 0;
+      for (const s of selected) {
+        const sim = jaccardSimilarity(candidate.tokens, s.tokens);
+        if (sim > maxSim) maxSim = sim;
+      }
+      const mmr = lambda * candidate.qScore - (1 - lambda) * maxSim;
       if (mmr > bestMmr) { bestMmr = mmr; bestIdx = i; }
     }
     selected.push(remaining[bestIdx]);
     remaining.splice(bestIdx, 1);
   }
-  return selected;
+  return selected.map((s) => s.ranked);
 }
 
 /**

--- a/packages/mcp-core/src/lesson-rank.ts
+++ b/packages/mcp-core/src/lesson-rank.ts
@@ -221,6 +221,81 @@ export interface RankedLesson<T extends RankableLesson> {
 }
 
 /**
+ * MMR λ (lambda) — weight given to relevance vs diversity in the MMR objective.
+ * At 0.7 the selector favours relevance, with 0.3 of the budget for diversity.
+ * Anchored to Carbonell & Goldstein (1998), the original MMR paper.
+ * Mirrored byte-identically in the edge twin and `packages/cli/src/lessons-pure.mjs`.
+ */
+export const MMR_LAMBDA = 0.7;
+
+/**
+ * Word/token Jaccard similarity on the lesson `value`.
+ *
+ * Tokenises by case-folding and splitting on non-alphanumeric characters,
+ * deduplicating into a Set, then returning |A∩B| / |A∪B|. Both-empty → 0.
+ * Dependency-free and deterministic so it mirrors byte-identically across
+ * TS, Deno, and the `.mjs` twin.
+ */
+function jaccardSimilarity(a: unknown, b: unknown): number {
+  const tokenize = (v: unknown): Set<string> => {
+    const tokens = String(v ?? '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+    return new Set(tokens);
+  };
+  const setA = tokenize(a);
+  const setB = tokenize(b);
+  if (setA.size === 0 && setB.size === 0) return 0;
+  let intersection = 0;
+  for (const t of setA) if (setB.has(t)) intersection += 1;
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export interface SelectDiverseOptions {
+  lambda?: number;
+}
+
+/**
+ * Select the top-K lessons from a ranked list using Maximal Marginal Relevance
+ * (Carbonell & Goldstein, 1998).
+ *
+ * Greedy MMR: seed with the highest-ranked candidate, then at each step pick
+ * the unselected candidate that maximises
+ *   λ·score(i) − (1−λ)·max_{j∈selected} jaccardSimilarity(value_i, value_j)
+ * Ties in the MMR objective break by input order (first-wins) so the result
+ * is deterministic over the already-rank-ordered input.
+ *
+ * Always-on for ranked mode — no optional param needed. The recency wire path is
+ * never affected.
+ */
+export function selectDiverse<T extends RankableLesson>(
+  ranked: readonly RankedLesson<T>[],
+  k: number,
+  options: SelectDiverseOptions = {},
+): RankedLesson<T>[] {
+  const lambda = typeof options.lambda === 'number' && Number.isFinite(options.lambda)
+    ? options.lambda
+    : MMR_LAMBDA;
+  if (!Array.isArray(ranked) || ranked.length === 0 || k <= 0) return [];
+  const selected: RankedLesson<T>[] = [];
+  const remaining = ranked.slice();
+  while (selected.length < k && remaining.length > 0) {
+    let bestIdx = 0;
+    let bestMmr = -Infinity;
+    for (let i = 0; i < remaining.length; i++) {
+      const candidate = remaining[i];
+      const maxSim = selected.length === 0
+        ? 0
+        : Math.max(...selected.map((s) => jaccardSimilarity(candidate.entry.value, s.entry.value)));
+      const mmr = lambda * candidate.score - (1 - lambda) * maxSim;
+      if (mmr > bestMmr) { bestMmr = mmr; bestIdx = i; }
+    }
+    selected.push(remaining[bestIdx]);
+    remaining.splice(bestIdx, 1);
+  }
+  return selected;
+}
+
+/**
  * Rank rows best-first, returning `{ entry, score }` pairs in a NEW array.
  *
  * The score is returned rather than discarded because this one feeds an API

--- a/packages/mcp-core/src/lesson-rank.ts
+++ b/packages/mcp-core/src/lesson-rank.ts
@@ -283,9 +283,20 @@ export interface SelectDiverseOptions {
  * them. Comparing the RAW score here would let a 1e-10 float difference override
  * scope precedence — the lower-precedence scope could win a near-tie MMR pick.
  *
- * PERF: each candidate's `value` is tokenised ONCE up front (the `tokens` field)
- * so the O(k²) pairwise Jaccard comparisons inside the loop do no tokenisation —
- * O(n) tokenisations total, not O(n·k²). See `tokenizeValue`.
+ * PERF — the algorithm is O(n·k), and BOTH factors that could regress it to
+ * O(n·k²) are held down explicitly:
+ *   1. TOKENISE axis: each candidate's `value` is tokenised ONCE up front (the
+ *      `tokens` field) so the pairwise Jaccard comparisons never tokenise —
+ *      O(n) tokenisations total. See `tokenizeValue`.
+ *   2. INTERSECTION axis: each remaining candidate carries a RUNNING `maxSim`
+ *      (its greatest Jaccard similarity to anything selected so far). The
+ *      objective reads that cached scalar — it does NOT loop over `selected`.
+ *      After each pick we update `maxSim` for the still-remaining candidates
+ *      against the ONE just-selected entry only. That is k picks × n candidates
+ *      = O(n·k) Jaccard intersections total, not O(n·k²).
+ * Re-introducing either an in-loop `tokenizeValue` call OR an inner
+ * `for (… of selected)` maxSim recomputation silently restores O(n·k²) —
+ * measured 2.6s CPU at n=200/k=100 vs 58ms for the running form. Don't.
  *
  * Always-on for ranked mode — no optional param needed. The recency wire path is
  * never affected.
@@ -299,32 +310,36 @@ export function selectDiverse<T extends RankableLesson>(
     ? options.lambda
     : MMR_LAMBDA;
   if (!Array.isArray(ranked) || ranked.length === 0 || k <= 0) return [];
-  const selected: { ranked: RankedLesson<T>; tokens: Set<string>; qScore: number }[] = [];
+  const selected: RankedLesson<T>[] = [];
   // Pre-tokenise every candidate ONCE and snap its score onto the SCORE_EPSILON
-  // grid up front. The loop below reads these caches — it never tokenises or
-  // re-quantises. See the docblock (PERF + SCORE QUANTISATION).
+  // grid up front. `maxSim` is the running greatest Jaccard similarity to any
+  // already-selected entry — 0 while nothing is selected. The loop below reads
+  // these caches; it never tokenises, re-quantises, or rescans `selected`.
   const remaining = ranked.map((r) => ({
     ranked: r,
     tokens: tokenizeValue(r.entry.value),
     qScore: Math.round(r.score / SCORE_EPSILON) * SCORE_EPSILON,
+    maxSim: 0,
   }));
   while (selected.length < k && remaining.length > 0) {
     let bestIdx = 0;
     let bestMmr = -Infinity;
     for (let i = 0; i < remaining.length; i++) {
       const candidate = remaining[i];
-      let maxSim = 0;
-      for (const s of selected) {
-        const sim = jaccardSimilarity(candidate.tokens, s.tokens);
-        if (sim > maxSim) maxSim = sim;
-      }
-      const mmr = lambda * candidate.qScore - (1 - lambda) * maxSim;
+      // Reads the cached running maxSim — no inner scan over `selected`.
+      const mmr = lambda * candidate.qScore - (1 - lambda) * candidate.maxSim;
       if (mmr > bestMmr) { bestMmr = mmr; bestIdx = i; }
     }
-    selected.push(remaining[bestIdx]);
-    remaining.splice(bestIdx, 1);
+    const [justSelected] = remaining.splice(bestIdx, 1);
+    selected.push(justSelected.ranked);
+    // Fold the just-selected entry into every remaining candidate's running
+    // maxSim — one Jaccard per remaining candidate per pick, so O(n·k) total.
+    for (const candidate of remaining) {
+      const sim = jaccardSimilarity(candidate.tokens, justSelected.tokens);
+      if (sim > candidate.maxSim) candidate.maxSim = sim;
+    }
   }
-  return selected.map((s) => s.ranked);
+  return selected;
 }
 
 /**

--- a/packages/mcp-core/src/select-diverse.spec.ts
+++ b/packages/mcp-core/src/select-diverse.spec.ts
@@ -112,15 +112,19 @@ describe('selectDiverse: MMR objective and core behavior (AC-1)', () => {
   });
 
   it('first-wins tie-break: equal MMR scores resolve by input order', () => {
-    // Two entries with IDENTICAL score AND identical value → same MMR objective.
-    // Input order determines the winner (first-wins).
+    // Three entries with IDENTICAL score AND identical value. After x seeds the
+    // selection, y and z have the SAME MMR objective (same score, same sim to x),
+    // so this is a genuine tie between two remaining candidates — not the sole
+    // survivor. First-wins must pick y (index 1) over z (index 2) purely on input
+    // order. A `>=` (last-wins) comparator would flip this to z and fail.
     const x = ranked({ scope: 'g', key: 'x', value: 'unique distinct content here' }, 0.8);
     const y = ranked({ scope: 'g', key: 'y', value: 'unique distinct content here' }, 0.8);
-    // Seed is x (index 0). Next pick: MMR(y) after x selected = 0.7*0.8 - 0.3*1 = 0.26.
-    // No other candidate — y is selected as-is.
-    const result = selectDiverse([x, y], 2);
+    const z = ranked({ scope: 'g', key: 'z', value: 'unique distinct content here' }, 0.8);
+    // Seed is x (index 0). Next pick: MMR(y) = MMR(z) = 0.7*0.8 - 0.3*1 = 0.26.
+    // The tie breaks to y because it appears first in the input.
+    const result = selectDiverse([x, y, z], 2);
     expect(result[0].entry.key).toBe('x'); // seeded first
-    expect(result[1].entry.key).toBe('y'); // only remaining
+    expect(result[1].entry.key).toBe('y'); // wins the tie over z on input order
   });
 
   it('degenerate inputs: empty array returns []', () => {
@@ -189,5 +193,49 @@ describe('selectDiverse: integration with real rankLessons output (AC-1)', () =>
     expect(keys).toContain('di');
     // nd3 (lowest raw score among near-dups) must NOT appear — displaced by di.
     expect(keys).not.toContain('nd3');
+  });
+});
+
+// ── Scope precedence survives MMR for near-equal scores (BLOCKING 2) ───────────
+//
+// The MMR objective quantises `score` onto the SCORE_EPSILON grid before using
+// it — the same grid `rankLessons` buckets on. So two scores within
+// SCORE_EPSILON are equal to MMR, and the input order (which `rankLessons` has
+// already sorted by scope precedence, then key) decides between them. Comparing
+// the RAW score would let a sub-epsilon float difference override precedence.
+
+describe('selectDiverse: scope precedence survives MMR for near-equal scores (BLOCKING 2)', () => {
+  it('keeps the higher-precedence scope first when raw scores differ by < SCORE_EPSILON', () => {
+    // hi (higher precedence) has a raw score a hair BELOW lo's — the lower-
+    // precedence row. The gap is a fraction of SCORE_EPSILON, so both land in the
+    // same quantisation bucket. Distinct values → zero Jaccard penalty, so only
+    // the relevance term drives selection: the test isolates the score comparison.
+    const hi = ranked({ scope: 'global', key: 'k', value: 'alpha beta gamma' }, 0.5);
+    const lo = ranked({ scope: 'repo', key: 'k', value: 'delta epsilon zeta' }, 0.5 + SCORE_EPSILON / 4);
+
+    // `rankLessons` (via the real pipeline elsewhere) would order [hi, lo]: same
+    // bucket, then scope precedence puts `global` first. Feed that order in.
+    const result = selectDiverse([hi, lo], 2);
+    const scopes = result.map((r) => r.entry.scope);
+
+    // Quantised: hi seeds first (tie → input order), lo follows → [global, repo].
+    // With the RAW score bug, lo (0.5 + ε/4 > 0.5) would seed first → [repo, global].
+    expect(scopes).toEqual(['global', 'repo']);
+  });
+
+  it('preserves rankLessons scope-precedence order end-to-end through MMR', () => {
+    // Two rows scored identically by every factor EXCEPT scope; near-identical
+    // timestamps put their raw scores within SCORE_EPSILON. `rankLessons` orders
+    // them by the explicit scopeOrder; MMR must not reshuffle that.
+    const fixtures = [
+      { scope: 'repo', key: 'k', updatedAt: daysAgo(1), seenCount: 0, relevance: 1, outcome: 1, value: 'network latency bandwidth throughput' },
+      { scope: 'global', key: 'k', updatedAt: daysAgo(1), seenCount: 0, relevance: 1, outcome: 1, value: 'authentication token session refresh' },
+    ];
+    // global outranks repo despite repo appearing first in the input.
+    const rankedRows = rankLessons(fixtures, { now: NOW, scopeOrder: ['global', 'repo'] });
+    expect(rankedRows.map((r) => r.entry.scope)).toEqual(['global', 'repo']);
+
+    const diverse = selectDiverse(rankedRows, 2);
+    expect(diverse.map((r) => r.entry.scope)).toEqual(['global', 'repo']);
   });
 });

--- a/packages/mcp-core/src/select-diverse.spec.ts
+++ b/packages/mcp-core/src/select-diverse.spec.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest';
+import {
+  selectDiverse,
+  rankLessons,
+  MMR_LAMBDA,
+  SCORE_EPSILON,
+} from './lesson-rank.js';
+import type { RankedLesson, RankableLesson } from './lesson-rank.js';
+
+// ── helpers ────────────────────────────────────────────────────────────────────
+
+const NOW = Date.parse('2026-08-01T00:00:00.000Z');
+const daysAgo = (n: number) => new Date(NOW - n * 86400000).toISOString();
+
+/** Build a RankedLesson directly from entry + score — no rankLessons call. */
+function ranked<T extends RankableLesson>(entry: T, score: number): RankedLesson<T> {
+  return { entry, score };
+}
+
+// ── jaccardSimilarity unit tests (via selectDiverse behavior) ─────────────────
+//
+// jaccardSimilarity is private; its contract is tested through selectDiverse.
+// AC-2: identical token sets → sim=1 (MMR penalty = 1−λ = 0.3, so distinct wins);
+//        disjoint sets → sim<1; both-empty → sim=0.
+
+describe('selectDiverse: jaccardSimilarity semantics (AC-2)', () => {
+  // Two entries with IDENTICAL value text — after the first is selected, the
+  // second should score a full (1−λ)=0.3 MMR penalty and lose to a distinct entry.
+  it('identical token sets produce maximum MMR penalty (sim=1)', () => {
+    const identical = 'caching timeout retry';
+    const a = ranked({ scope: 'g', key: 'a', value: identical }, 0.9);
+    const b = ranked({ scope: 'g', key: 'b', value: identical }, 0.8);
+    const distinct = ranked({ scope: 'g', key: 'c', value: 'database migration schema' }, 0.75);
+    // Raw rank order: a > b > c. After selecting a, MMR(b) = 0.7*0.8 - 0.3*1 = 0.56-0.3 = 0.26.
+    // MMR(c) = 0.7*0.75 - 0.3*sim(c,a) = 0.525 - 0.3*0 = 0.525. So c wins over b.
+    // Mental revert: removing the MMR diversity term (lambda=1) makes order a,b,c — no c promotion.
+    const result = selectDiverse([a, b, distinct], 2);
+    expect(result.map((r) => r.entry.key)).toEqual(['a', 'c']);
+  });
+
+  it('disjoint token sets produce zero MMR penalty (sim<1)', () => {
+    // If two entries share no tokens, sim=0 and MMR(candidate) = λ*score (no penalty).
+    const x = ranked({ scope: 'g', key: 'x', value: 'alpha beta gamma' }, 0.9);
+    const y = ranked({ scope: 'g', key: 'y', value: 'delta epsilon zeta' }, 0.8);
+    // After selecting x, MMR(y) = 0.7*0.8 - 0.3*0 = 0.56. y wins normally.
+    const result = selectDiverse([x, y], 2);
+    expect(result.map((r) => r.entry.key)).toEqual(['x', 'y']);
+  });
+
+  it('both-empty value → sim=0, no penalty (AC-2: both-empty → 0)', () => {
+    // Empty values produce sim=0 between any pair, so order follows MMR with no penalty.
+    const p = ranked({ scope: 'g', key: 'p', value: '' }, 0.9);
+    const q = ranked({ scope: 'g', key: 'q', value: '' }, 0.8);
+    const result = selectDiverse([p, q], 2);
+    // No penalty — order equals raw rank (p, then q).
+    expect(result.map((r) => r.entry.key)).toEqual(['p', 'q']);
+  });
+});
+
+// ── selectDiverse core behavior (AC-1) ────────────────────────────────────────
+
+describe('selectDiverse: MMR objective and core behavior (AC-1)', () => {
+  // AC-10 (PRIMARY): near-dup HIGH-score lessons + one distinct lesson → the
+  // real selectDiverse top-K includes the distinct one over a 2nd near-duplicate.
+  //
+  // Mental revert: removing the diversity term (lambda=1.0) returns the raw
+  // rank order [A,B,C] and the distinct lesson D does NOT appear in top-3.
+  // Setting lambda=1.0 here would flip this test red — the assertion that
+  // mmrOrder contains 'D' would fail because D's score is lower than C's.
+  it('AC-10: distinct lesson promotes over 2nd near-duplicate in real selectDiverse (revert-flips-red)', () => {
+    // Three near-duplicates (A, B, C) share "caching timeout retry" vocabulary;
+    // D has distinct "database schema migration" vocabulary.
+    // Scores set directly on RankedLesson inputs to avoid 4-factor scorer interactions.
+    // All four are pre-scored: A highest, B second, C third, D fourth.
+    const A = ranked({ scope: 'g', key: 'A', value: 'caching timeout retry exponential backoff caching' }, 0.95);
+    const B = ranked({ scope: 'g', key: 'B', value: 'caching timeout retry exponential strategy caching' }, 0.90);
+    const C = ranked({ scope: 'g', key: 'C', value: 'caching retry timeout backoff pattern caching retry' }, 0.85);
+    const D = ranked({ scope: 'g', key: 'D', value: 'database schema migration rollback strategy index' }, 0.80);
+
+    const result = selectDiverse([A, B, C, D], 3);
+    const keys = result.map((r) => r.entry.key);
+
+    // A is always first (seeds the selection — highest score).
+    expect(keys[0]).toBe('A');
+    // D (distinct) must appear in top-3 over the 3rd near-dup C.
+    // Mental revert: lambda=1.0 → order [A,B,C], D absent. That test would fail here.
+    expect(keys).toContain('D');
+    expect(keys).not.toContain('C');
+  });
+
+  it('honors k — returns exactly k entries (or fewer if input is smaller)', () => {
+    const entries = [
+      ranked({ scope: 'g', key: '1', value: 'alpha' }, 0.9),
+      ranked({ scope: 'g', key: '2', value: 'beta' }, 0.8),
+      ranked({ scope: 'g', key: '3', value: 'gamma' }, 0.7),
+    ];
+    expect(selectDiverse(entries, 2)).toHaveLength(2);
+    expect(selectDiverse(entries, 5)).toHaveLength(3); // k > n → return all
+  });
+
+  it('reuses input scores (not recomputed) for the relevance term', () => {
+    // Scores are taken directly from the RankedLesson input — if they were
+    // recomputed from the entry fields the test would need to supply all scorer
+    // inputs. Here we supply only score to prove the interface uses input scores.
+    const a = ranked({ scope: 'g', key: 'a', value: 'x y z' }, 0.95);
+    const b = ranked({ scope: 'g', key: 'b', value: 'x y z' }, 0.5);
+    const c = ranked({ scope: 'g', key: 'c', value: 'p q r' }, 0.6);
+    // After selecting a, MMR(b) = 0.7*0.5 - 0.3*1 = 0.05.
+    // MMR(c) = 0.7*0.6 - 0.3*0 = 0.42. c wins.
+    const result = selectDiverse([a, b, c], 2);
+    expect(result.map((r) => r.entry.key)).toEqual(['a', 'c']);
+  });
+
+  it('first-wins tie-break: equal MMR scores resolve by input order', () => {
+    // Two entries with IDENTICAL score AND identical value → same MMR objective.
+    // Input order determines the winner (first-wins).
+    const x = ranked({ scope: 'g', key: 'x', value: 'unique distinct content here' }, 0.8);
+    const y = ranked({ scope: 'g', key: 'y', value: 'unique distinct content here' }, 0.8);
+    // Seed is x (index 0). Next pick: MMR(y) after x selected = 0.7*0.8 - 0.3*1 = 0.26.
+    // No other candidate — y is selected as-is.
+    const result = selectDiverse([x, y], 2);
+    expect(result[0].entry.key).toBe('x'); // seeded first
+    expect(result[1].entry.key).toBe('y'); // only remaining
+  });
+
+  it('degenerate inputs: empty array returns []', () => {
+    expect(selectDiverse([], 3)).toEqual([]);
+  });
+
+  it('degenerate inputs: k=0 returns []', () => {
+    const e = [ranked({ scope: 'g', key: 'k', value: 'test' }, 0.9)];
+    expect(selectDiverse(e, 0)).toEqual([]);
+  });
+
+  it('k=1 returns only the highest-scored entry (MMR seed)', () => {
+    const entries = [
+      ranked({ scope: 'g', key: 'a', value: 'alpha beta' }, 0.9),
+      ranked({ scope: 'g', key: 'b', value: 'gamma delta' }, 0.8),
+    ];
+    const result = selectDiverse(entries, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].entry.key).toBe('a');
+  });
+
+  it('custom lambda=1 degenerates to raw-rank order (no diversity)', () => {
+    // With lambda=1, the MMR term is λ·score - 0·sim = score. Diversity is ignored.
+    // Mental revert: the AC-10 test above uses default lambda; setting lambda=1
+    // there would flip it red.
+    const A = ranked({ scope: 'g', key: 'A', value: 'caching timeout retry' }, 0.95);
+    const B = ranked({ scope: 'g', key: 'B', value: 'caching timeout retry' }, 0.90);
+    const C = ranked({ scope: 'g', key: 'C', value: 'database schema migration' }, 0.80);
+    const result = selectDiverse([A, B, C], 3, { lambda: 1.0 });
+    expect(result.map((r) => r.entry.key)).toEqual(['A', 'B', 'C']);
+  });
+});
+
+// ── MMR_LAMBDA constant (AC-3) ─────────────────────────────────────────────────
+
+describe('MMR_LAMBDA constant (AC-3)', () => {
+  it('is exported and equals 0.7', () => {
+    expect(MMR_LAMBDA).toBe(0.7);
+  });
+});
+
+// ── Integration: real rankLessons output → selectDiverse (AC-1) ───────────────
+
+describe('selectDiverse: integration with real rankLessons output (AC-1)', () => {
+  it('operates on rankLessons output without recomputing scores', () => {
+    // Four lessons: three near-dups (same "authentication token session" vocab)
+    // plus one distinct ("network latency bandwidth throughput"). Scores driven
+    // by recency. MMR should surface the distinct one over the 3rd near-dup.
+    // Isolation: outcome:1 on all four (cold-start prior = 0.5 would add noise);
+    // salience isolated by zeroing the weight; relevance=1 on all (FTS matched).
+    const fixtures = [
+      { scope: 'r', key: 'nd1', updatedAt: daysAgo(1), seenCount: 0, relevance: 1, outcome: 1, value: 'authentication token session refresh oauth authentication token' },
+      { scope: 'r', key: 'nd2', updatedAt: daysAgo(2), seenCount: 0, relevance: 1, outcome: 1, value: 'authentication token session refresh strategy oauth token session' },
+      { scope: 'r', key: 'nd3', updatedAt: daysAgo(3), seenCount: 0, relevance: 1, outcome: 1, value: 'authentication token session refresh pattern oauth authentication' },
+      { scope: 'r', key: 'di',  updatedAt: daysAgo(4), seenCount: 0, relevance: 1, outcome: 1, value: 'network latency bandwidth throughput optimization tcp connection' },
+    ];
+    // Use salience:0 to isolate recency+relevance+outcome as ranking signals.
+    const weights = { recency: 1, salience: 0, relevance: 1, outcome: 1 };
+    const ranked2 = rankLessons(fixtures, { now: NOW, weights });
+    const diverse = selectDiverse(ranked2, 3);
+    const keys = diverse.map((r) => r.entry.key);
+
+    // nd1 is always first (most recent → highest score seeds selection).
+    expect(keys[0]).toBe('nd1');
+    // The distinct lesson must appear in top-3.
+    expect(keys).toContain('di');
+    // nd3 (lowest raw score among near-dups) must NOT appear — displaced by di.
+    expect(keys).not.toContain('nd3');
+  });
+});

--- a/packages/schemas/src/relevant.ts
+++ b/packages/schemas/src/relevant.ts
@@ -90,6 +90,13 @@ export const RelevantEntrySchema = z.object({
 export type RelevantEntry = z.infer<typeof RelevantEntrySchema>;
 
 export const RelevantResponseSchema = z.object({
+  /**
+   * The selected lessons, ranked by salience+recency then MMR-diversified (same
+   * selection as the MCP `memory.list order=rank` path). Because of the
+   * diversification these are NOT strictly score-descending — a more diverse
+   * lower-scored lesson can precede a higher-scored near-duplicate. Read them as
+   * a diverse best-set, not a monotonic score ordering.
+   */
   entries: z.array(RelevantEntrySchema),
   /**
    * How many candidates were RANKED to produce `entries` — the fetched set, not

--- a/packages/schemas/src/tool-catalog.ts
+++ b/packages/schemas/src/tool-catalog.ts
@@ -186,7 +186,7 @@ export const MCP_TOOLS: readonly McpToolDoc[] = [
         tags: { type: 'array', items: { type: 'string' }, description: 'Filter to entries carrying ANY of these labels (OR).' },
         limit,
         cursor: { type: 'string', description: 'Opaque cursor from a previous response\'s `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` (ranked mode returns a single bounded page; `hasMore` is always false and `nextCursor` always null).' },
-        order: { type: 'string', enum: ['recency', 'rank'], default: 'recency', description: 'recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor).' },
+        order: { type: 'string', enum: ['recency', 'rank'], default: 'recency', description: 'recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor). Note: rank results are MMR-diversified, so they are NOT strictly score-descending — a more diverse lower-scored lesson can precede a higher-scored near-duplicate.' },
       },
     },
     returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or best-first by salience+recency (rank mode). Pass `nextCursor` back as `cursor` to paginate — recency mode only. Rank mode is a single bounded top-N page: `hasMore` is always false and `nextCursor` always null.',

--- a/packages/schemas/src/tool-catalog.ts
+++ b/packages/schemas/src/tool-catalog.ts
@@ -189,7 +189,7 @@ export const MCP_TOOLS: readonly McpToolDoc[] = [
         order: { type: 'string', enum: ['recency', 'rank'], default: 'recency', description: 'recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor). Note: rank results are MMR-diversified, so they are NOT strictly score-descending — a more diverse lower-scored lesson can precede a higher-scored near-duplicate.' },
       },
     },
-    returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or best-first by salience+recency (rank mode). Pass `nextCursor` back as `cursor` to paginate — recency mode only. Rank mode is a single bounded top-N page: `hasMore` is always false and `nextCursor` always null.',
+    returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or ranked by salience+recency then MMR-diversified (rank mode). Because rank mode diversifies, entries are NOT strictly score-descending — a more diverse lower-scored lesson can precede a higher-scored near-duplicate. Pass `nextCursor` back as `cursor` to paginate — recency mode only. Rank mode is a single bounded top-N page: `hasMore` is always false and `nextCursor` always null.',
   },
   {
     name: 'memory.delete',

--- a/packages/web/public/llms.txt
+++ b/packages/web/public/llms.txt
@@ -210,7 +210,7 @@ List lessons for a scope.
 
 Requires **read** permission.
 
-Returns: `{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or best-first by salience+recency (rank mode). Pass `nextCursor` back as `cursor` to paginate — recency mode only. Rank mode is a single bounded top-N page: `hasMore` is always false and `nextCursor` always null.
+Returns: `{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or ranked by salience+recency then MMR-diversified (rank mode). Because rank mode diversifies, entries are NOT strictly score-descending — a more diverse lower-scored lesson can precede a higher-scored near-duplicate. Pass `nextCursor` back as `cursor` to paginate — recency mode only. Rank mode is a single bounded top-N page: `hasMore` is always false and `nextCursor` always null.
 
 ---
 

--- a/packages/web/public/llms.txt
+++ b/packages/web/public/llms.txt
@@ -206,7 +206,7 @@ List lessons for a scope.
 | `tags` |  | array | Filter to entries carrying ANY of these labels (OR). _(array of string)_ |
 | `limit` |  | integer | Maximum entries to return. _(1–100, default `50`)_ |
 | `cursor` |  | string | Opaque cursor from a previous response's `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` (ranked mode returns a single bounded page; `hasMore` is always false and `nextCursor` always null). |
-| `order` |  | string | recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor). _(default `recency`)_ |
+| `order` |  | string | recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor). Note: rank results are MMR-diversified, so they are NOT strictly score-descending — a more diverse lower-scored lesson can precede a higher-scored near-duplicate. _(default `recency`)_ |
 
 Requires **read** permission.
 

--- a/supabase/functions/_shared/lesson-rank.ts
+++ b/supabase/functions/_shared/lesson-rank.ts
@@ -229,20 +229,31 @@ export interface RankedLesson<T extends RankableLesson> {
 export const MMR_LAMBDA = 0.7;
 
 /**
- * Word/token Jaccard similarity on the lesson `value`.
+ * Tokenise a lesson `value` into a deduplicated Set: case-fold, split on
+ * non-alphanumeric characters, drop empties. Dependency-free and deterministic
+ * so it mirrors byte-identically across TS, Deno, and the `.mjs` twin.
  *
- * Tokenises by case-folding and splitting on non-alphanumeric characters,
- * deduplicating into a Set, then returning |A∩B| / |A∪B|. Both-empty → 0.
- * Dependency-free and deterministic so it mirrors byte-identically across
- * TS, Deno, and the `.mjs` twin.
+ * PERF: `selectDiverse` calls this ONCE per candidate before the MMR loop and
+ * caches the result — see the `tokens` field it builds. `jaccardSimilarity`
+ * takes the cached Sets, so the O(k²) pairwise comparisons inside the loop cost
+ * no tokenisation. Do NOT re-introduce a `tokenize(value)` call inside the loop:
+ * that regresses the hot path to O(n·k²) tokenisations (measured 34s CPU at
+ * n=200/k=100, `tools.ts` max with 1.5KB values).
  */
-function jaccardSimilarity(a: unknown, b: unknown): number {
-  const tokenize = (v: unknown): Set<string> => {
-    const tokens = String(v ?? '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
-    return new Set(tokens);
-  };
-  const setA = tokenize(a);
-  const setB = tokenize(b);
+function tokenizeValue(v: unknown): Set<string> {
+  const tokens = String(v ?? '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+  return new Set(tokens);
+}
+
+/**
+ * Word/token Jaccard similarity between two PRE-TOKENISED value Sets:
+ * |A∩B| / |A∪B|. Both-empty → 0.
+ *
+ * Takes Sets rather than raw values on purpose — the caller tokenises each
+ * candidate once (see `tokenizeValue`) so this stays allocation-free on the
+ * O(k²) hot path.
+ */
+function jaccardSimilarity(setA: Set<string>, setB: Set<string>): number {
   if (setA.size === 0 && setB.size === 0) return 0;
   let intersection = 0;
   for (const t of setA) if (setB.has(t)) intersection += 1;
@@ -260,9 +271,21 @@ export interface SelectDiverseOptions {
  *
  * Greedy MMR: seed with the highest-ranked candidate, then at each step pick
  * the unselected candidate that maximises
- *   λ·score(i) − (1−λ)·max_{j∈selected} jaccardSimilarity(value_i, value_j)
+ *   λ·quantise(score(i)) − (1−λ)·max_{j∈selected} jaccardSimilarity(value_i, value_j)
  * Ties in the MMR objective break by input order (first-wins) so the result
  * is deterministic over the already-rank-ordered input.
+ *
+ * SCORE QUANTISATION: the relevance term uses the score SNAPPED onto the
+ * `SCORE_EPSILON` grid — the exact grid `rankLessons` buckets on for its
+ * scope-precedence tie-break. Two scores within `SCORE_EPSILON` land in the same
+ * bucket, so the MMR objective sees them as equal and the input order (which
+ * `rankLessons` already sorted by scope precedence, then key) decides between
+ * them. Comparing the RAW score here would let a 1e-10 float difference override
+ * scope precedence — the lower-precedence scope could win a near-tie MMR pick.
+ *
+ * PERF: each candidate's `value` is tokenised ONCE up front (the `tokens` field)
+ * so the O(k²) pairwise Jaccard comparisons inside the loop do no tokenisation —
+ * O(n) tokenisations total, not O(n·k²). See `tokenizeValue`.
  *
  * Always-on for ranked mode — no optional param needed. The recency wire path is
  * never affected.
@@ -276,23 +299,32 @@ export function selectDiverse<T extends RankableLesson>(
     ? options.lambda
     : MMR_LAMBDA;
   if (!Array.isArray(ranked) || ranked.length === 0 || k <= 0) return [];
-  const selected: RankedLesson<T>[] = [];
-  const remaining = ranked.slice();
+  const selected: { ranked: RankedLesson<T>; tokens: Set<string>; qScore: number }[] = [];
+  // Pre-tokenise every candidate ONCE and snap its score onto the SCORE_EPSILON
+  // grid up front. The loop below reads these caches — it never tokenises or
+  // re-quantises. See the docblock (PERF + SCORE QUANTISATION).
+  const remaining = ranked.map((r) => ({
+    ranked: r,
+    tokens: tokenizeValue(r.entry.value),
+    qScore: Math.round(r.score / SCORE_EPSILON) * SCORE_EPSILON,
+  }));
   while (selected.length < k && remaining.length > 0) {
     let bestIdx = 0;
     let bestMmr = -Infinity;
     for (let i = 0; i < remaining.length; i++) {
       const candidate = remaining[i];
-      const maxSim = selected.length === 0
-        ? 0
-        : Math.max(...selected.map((s) => jaccardSimilarity(candidate.entry.value, s.entry.value)));
-      const mmr = lambda * candidate.score - (1 - lambda) * maxSim;
+      let maxSim = 0;
+      for (const s of selected) {
+        const sim = jaccardSimilarity(candidate.tokens, s.tokens);
+        if (sim > maxSim) maxSim = sim;
+      }
+      const mmr = lambda * candidate.qScore - (1 - lambda) * maxSim;
       if (mmr > bestMmr) { bestMmr = mmr; bestIdx = i; }
     }
     selected.push(remaining[bestIdx]);
     remaining.splice(bestIdx, 1);
   }
-  return selected;
+  return selected.map((s) => s.ranked);
 }
 
 /**

--- a/supabase/functions/_shared/lesson-rank.ts
+++ b/supabase/functions/_shared/lesson-rank.ts
@@ -221,6 +221,81 @@ export interface RankedLesson<T extends RankableLesson> {
 }
 
 /**
+ * MMR λ (lambda) — weight given to relevance vs diversity in the MMR objective.
+ * At 0.7 the selector favours relevance, with 0.3 of the budget for diversity.
+ * Anchored to Carbonell & Goldstein (1998), the original MMR paper.
+ * Mirrored byte-identically in the edge twin and `packages/cli/src/lessons-pure.mjs`.
+ */
+export const MMR_LAMBDA = 0.7;
+
+/**
+ * Word/token Jaccard similarity on the lesson `value`.
+ *
+ * Tokenises by case-folding and splitting on non-alphanumeric characters,
+ * deduplicating into a Set, then returning |A∩B| / |A∪B|. Both-empty → 0.
+ * Dependency-free and deterministic so it mirrors byte-identically across
+ * TS, Deno, and the `.mjs` twin.
+ */
+function jaccardSimilarity(a: unknown, b: unknown): number {
+  const tokenize = (v: unknown): Set<string> => {
+    const tokens = String(v ?? '').toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+    return new Set(tokens);
+  };
+  const setA = tokenize(a);
+  const setB = tokenize(b);
+  if (setA.size === 0 && setB.size === 0) return 0;
+  let intersection = 0;
+  for (const t of setA) if (setB.has(t)) intersection += 1;
+  const union = setA.size + setB.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}
+
+export interface SelectDiverseOptions {
+  lambda?: number;
+}
+
+/**
+ * Select the top-K lessons from a ranked list using Maximal Marginal Relevance
+ * (Carbonell & Goldstein, 1998).
+ *
+ * Greedy MMR: seed with the highest-ranked candidate, then at each step pick
+ * the unselected candidate that maximises
+ *   λ·score(i) − (1−λ)·max_{j∈selected} jaccardSimilarity(value_i, value_j)
+ * Ties in the MMR objective break by input order (first-wins) so the result
+ * is deterministic over the already-rank-ordered input.
+ *
+ * Always-on for ranked mode — no optional param needed. The recency wire path is
+ * never affected.
+ */
+export function selectDiverse<T extends RankableLesson>(
+  ranked: readonly RankedLesson<T>[],
+  k: number,
+  options: SelectDiverseOptions = {},
+): RankedLesson<T>[] {
+  const lambda = typeof options.lambda === 'number' && Number.isFinite(options.lambda)
+    ? options.lambda
+    : MMR_LAMBDA;
+  if (!Array.isArray(ranked) || ranked.length === 0 || k <= 0) return [];
+  const selected: RankedLesson<T>[] = [];
+  const remaining = ranked.slice();
+  while (selected.length < k && remaining.length > 0) {
+    let bestIdx = 0;
+    let bestMmr = -Infinity;
+    for (let i = 0; i < remaining.length; i++) {
+      const candidate = remaining[i];
+      const maxSim = selected.length === 0
+        ? 0
+        : Math.max(...selected.map((s) => jaccardSimilarity(candidate.entry.value, s.entry.value)));
+      const mmr = lambda * candidate.score - (1 - lambda) * maxSim;
+      if (mmr > bestMmr) { bestMmr = mmr; bestIdx = i; }
+    }
+    selected.push(remaining[bestIdx]);
+    remaining.splice(bestIdx, 1);
+  }
+  return selected;
+}
+
+/**
  * Rank rows best-first, returning `{ entry, score }` pairs in a NEW array.
  *
  * The score is returned rather than discarded because this one feeds an API

--- a/supabase/functions/_shared/lesson-rank.ts
+++ b/supabase/functions/_shared/lesson-rank.ts
@@ -283,9 +283,20 @@ export interface SelectDiverseOptions {
  * them. Comparing the RAW score here would let a 1e-10 float difference override
  * scope precedence — the lower-precedence scope could win a near-tie MMR pick.
  *
- * PERF: each candidate's `value` is tokenised ONCE up front (the `tokens` field)
- * so the O(k²) pairwise Jaccard comparisons inside the loop do no tokenisation —
- * O(n) tokenisations total, not O(n·k²). See `tokenizeValue`.
+ * PERF — the algorithm is O(n·k), and BOTH factors that could regress it to
+ * O(n·k²) are held down explicitly:
+ *   1. TOKENISE axis: each candidate's `value` is tokenised ONCE up front (the
+ *      `tokens` field) so the pairwise Jaccard comparisons never tokenise —
+ *      O(n) tokenisations total. See `tokenizeValue`.
+ *   2. INTERSECTION axis: each remaining candidate carries a RUNNING `maxSim`
+ *      (its greatest Jaccard similarity to anything selected so far). The
+ *      objective reads that cached scalar — it does NOT loop over `selected`.
+ *      After each pick we update `maxSim` for the still-remaining candidates
+ *      against the ONE just-selected entry only. That is k picks × n candidates
+ *      = O(n·k) Jaccard intersections total, not O(n·k²).
+ * Re-introducing either an in-loop `tokenizeValue` call OR an inner
+ * `for (… of selected)` maxSim recomputation silently restores O(n·k²) —
+ * measured 2.6s CPU at n=200/k=100 vs 58ms for the running form. Don't.
  *
  * Always-on for ranked mode — no optional param needed. The recency wire path is
  * never affected.
@@ -299,32 +310,36 @@ export function selectDiverse<T extends RankableLesson>(
     ? options.lambda
     : MMR_LAMBDA;
   if (!Array.isArray(ranked) || ranked.length === 0 || k <= 0) return [];
-  const selected: { ranked: RankedLesson<T>; tokens: Set<string>; qScore: number }[] = [];
+  const selected: RankedLesson<T>[] = [];
   // Pre-tokenise every candidate ONCE and snap its score onto the SCORE_EPSILON
-  // grid up front. The loop below reads these caches — it never tokenises or
-  // re-quantises. See the docblock (PERF + SCORE QUANTISATION).
+  // grid up front. `maxSim` is the running greatest Jaccard similarity to any
+  // already-selected entry — 0 while nothing is selected. The loop below reads
+  // these caches; it never tokenises, re-quantises, or rescans `selected`.
   const remaining = ranked.map((r) => ({
     ranked: r,
     tokens: tokenizeValue(r.entry.value),
     qScore: Math.round(r.score / SCORE_EPSILON) * SCORE_EPSILON,
+    maxSim: 0,
   }));
   while (selected.length < k && remaining.length > 0) {
     let bestIdx = 0;
     let bestMmr = -Infinity;
     for (let i = 0; i < remaining.length; i++) {
       const candidate = remaining[i];
-      let maxSim = 0;
-      for (const s of selected) {
-        const sim = jaccardSimilarity(candidate.tokens, s.tokens);
-        if (sim > maxSim) maxSim = sim;
-      }
-      const mmr = lambda * candidate.qScore - (1 - lambda) * maxSim;
+      // Reads the cached running maxSim — no inner scan over `selected`.
+      const mmr = lambda * candidate.qScore - (1 - lambda) * candidate.maxSim;
       if (mmr > bestMmr) { bestMmr = mmr; bestIdx = i; }
     }
-    selected.push(remaining[bestIdx]);
-    remaining.splice(bestIdx, 1);
+    const [justSelected] = remaining.splice(bestIdx, 1);
+    selected.push(justSelected.ranked);
+    // Fold the just-selected entry into every remaining candidate's running
+    // maxSim — one Jaccard per remaining candidate per pick, so O(n·k) total.
+    for (const candidate of remaining) {
+      const sim = jaccardSimilarity(candidate.tokens, justSelected.tokens);
+      if (sim > candidate.maxSim) candidate.maxSim = sim;
+    }
   }
-  return selected.map((s) => s.ranked);
+  return selected;
 }
 
 /**

--- a/supabase/functions/_shared/schemas/relevant.ts
+++ b/supabase/functions/_shared/schemas/relevant.ts
@@ -95,6 +95,13 @@ export const RelevantEntrySchema = z.object({
 export type RelevantEntry = z.infer<typeof RelevantEntrySchema>;
 
 export const RelevantResponseSchema = z.object({
+  /**
+   * The selected lessons, ranked by salience+recency then MMR-diversified (same
+   * selection as the MCP `memory.list order=rank` path). Because of the
+   * diversification these are NOT strictly score-descending — a more diverse
+   * lower-scored lesson can precede a higher-scored near-duplicate. Read them as
+   * a diverse best-set, not a monotonic score ordering.
+   */
   entries: z.array(RelevantEntrySchema),
   /**
    * How many candidates were RANKED to produce `entries` — the fetched set, not

--- a/supabase/functions/_shared/schemas/tool-catalog.ts
+++ b/supabase/functions/_shared/schemas/tool-catalog.ts
@@ -191,7 +191,7 @@ export const MCP_TOOLS: readonly McpToolDoc[] = [
         tags: { type: 'array', items: { type: 'string' }, description: 'Filter to entries carrying ANY of these labels (OR).' },
         limit,
         cursor: { type: 'string', description: 'Opaque cursor from a previous response\'s `nextCursor`. Omit to start from the first page. Ignored when `order` is `rank` (ranked mode returns a single bounded page; `hasMore` is always false and `nextCursor` always null).' },
-        order: { type: 'string', enum: ['recency', 'rank'], default: 'recency', description: 'recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor).' },
+        order: { type: 'string', enum: ['recency', 'rank'], default: 'recency', description: 'recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor). Note: rank results are MMR-diversified, so they are NOT strictly score-descending — a more diverse lower-scored lesson can precede a higher-scored near-duplicate.' },
       },
     },
     returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or best-first by salience+recency (rank mode). Pass `nextCursor` back as `cursor` to paginate — recency mode only. Rank mode is a single bounded top-N page: `hasMore` is always false and `nextCursor` always null.',

--- a/supabase/functions/_shared/schemas/tool-catalog.ts
+++ b/supabase/functions/_shared/schemas/tool-catalog.ts
@@ -194,7 +194,7 @@ export const MCP_TOOLS: readonly McpToolDoc[] = [
         order: { type: 'string', enum: ['recency', 'rank'], default: 'recency', description: 'recency (default, updated_at desc + cursor pagination) or rank (salience+recency; bounded top-N, no cursor). Note: rank results are MMR-diversified, so they are NOT strictly score-descending — a more diverse lower-scored lesson can precede a higher-scored near-duplicate.' },
       },
     },
-    returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or best-first by salience+recency (rank mode). Pass `nextCursor` back as `cursor` to paginate — recency mode only. Rank mode is a single bounded top-N page: `hasMore` is always false and `nextCursor` always null.',
+    returns: '`{ "entries": [{ "key", "value", "tags", "updated_at" }], "hasMore": boolean, "nextCursor": string | null }` — newest-first (recency mode) or ranked by salience+recency then MMR-diversified (rank mode). Because rank mode diversifies, entries are NOT strictly score-descending — a more diverse lower-scored lesson can precede a higher-scored near-duplicate. Pass `nextCursor` back as `cursor` to paginate — recency mode only. Rank mode is a single bounded top-N page: `hasMore` is always false and `nextCursor` always null.',
   },
   {
     name: 'memory.delete',

--- a/supabase/functions/mcp/tools.ts
+++ b/supabase/functions/mcp/tools.ts
@@ -269,6 +269,11 @@ export async function toolList(
     );
 
     const rankedLessons = rankLessons(candidates, { now: Date.now() });
+    // NOTE: `selectDiverse` applies MMR diversification, which REORDERS the page.
+    // The returned rows are therefore NO LONGER monotonically descending by
+    // score — a lower-scored but more diverse lesson can precede a higher-scored
+    // near-duplicate. Consumers of `order=rank` must not assume score-monotonic
+    // output; the tool-catalog `order` description (tool-catalog.ts) says so too.
     const page = selectDiverse(rankedLessons, pageLimit);
 
     const entries = page.map(({ entry }) => ({

--- a/supabase/functions/mcp/tools.ts
+++ b/supabase/functions/mcp/tools.ts
@@ -24,7 +24,7 @@ import { recordAudit } from '../_shared/audit.ts';
 import { applyTenantScope } from './tenant-scope.ts';
 import { decodeCursor, buildPage } from './cursor.ts';
 import { resolveKindHost } from '../_shared/schemas/tags.ts';
-import { rankLessons } from '../_shared/lesson-rank.ts';
+import { rankLessons, selectDiverse } from '../_shared/lesson-rank.ts';
 import type { RankableLesson } from '../_shared/lesson-rank.ts';
 import { outcomeFromTags } from '../_shared/outcome-signal.ts';
 
@@ -269,7 +269,7 @@ export async function toolList(
     );
 
     const rankedLessons = rankLessons(candidates, { now: Date.now() });
-    const page = rankedLessons.slice(0, pageLimit);
+    const page = selectDiverse(rankedLessons, pageLimit);
 
     const entries = page.map(({ entry }) => ({
       id: entry.id,

--- a/supabase/functions/memories/handlers/relevant.ts
+++ b/supabase/functions/memories/handlers/relevant.ts
@@ -14,6 +14,7 @@ import {
 import { parseTagsParam } from '../../_shared/schemas/tags.ts';
 import {
   rankLessons,
+  selectDiverse,
   recencyFactor,
   salienceFactor,
   normalizeRelevance,
@@ -160,9 +161,10 @@ export async function handleRelevant(
   let maxSeenCount = 0;
   for (const c of candidates) maxSeenCount = Math.max(maxSeenCount, seenCountFrom(c));
 
-  const entries = ranked
-    .filter((r) => r.score >= params.min_score)
-    .slice(0, params.limit)
+  const filtered = ranked.filter((r) => r.score >= params.min_score);
+  const diverse = selectDiverse(filtered, params.limit);
+
+  const entries = diverse
     .map(({ entry, score }) => ({
       scope: entry.scope,
       key: entry.key,

--- a/supabase/functions/memories/handlers/relevant.ts
+++ b/supabase/functions/memories/handlers/relevant.ts
@@ -162,6 +162,10 @@ export async function handleRelevant(
   for (const c of candidates) maxSeenCount = Math.max(maxSeenCount, seenCountFrom(c));
 
   const filtered = ranked.filter((r) => r.score >= params.min_score);
+  // MMR diversification (same as `order=rank` in the MCP `tools.ts` path): the
+  // returned `entries` are ranked-then-diversified, so they are NOT strictly
+  // score-descending — a more diverse lower-scored lesson can precede a
+  // higher-scored near-duplicate. Clients must not assume score-monotonic order.
   const diverse = selectDiverse(filtered, params.limit);
 
   const entries = diverse


### PR DESCRIPTION
## Summary

LoreKit's ranked lesson read previously returned the top-K by raw score, which could fill the window with near-duplicate paraphrases of a single concern. This PR adds **Maximal Marginal Relevance** (Carbonell & Goldstein, 1998) as a post-ranker on the two ranked edge read paths.

After `rankLessons` scores the candidates, `selectDiverse` greedily selects top-K by:
```
λ·score(i) − (1−λ)·max_{j∈selected} jaccardSimilarity(value_i, value_j)
```
with `λ = MMR_LAMBDA = 0.7` and similarity = word Jaccard on `value` (case-folded, split on non-alphanumerics).

**MMR is always-on for ranked mode — no new request param or schema change.**

## Changes

- `packages/mcp-core/src/lesson-rank.ts` — adds `MMR_LAMBDA`, `jaccardSimilarity` (private), `selectDiverse` (exported)
- `supabase/functions/_shared/lesson-rank.ts` — byte-identical edge mirror (edge-parity guard)
- `packages/cli/src/lessons-pure.mjs` — behavioral CLI twin (lesson-rank-parity guard); consumed for parity only, not by CLI SessionStart
- `supabase/functions/memories/handlers/relevant.ts` — wires `selectDiverse` between `.filter(min_score)` and the limit cut
- `supabase/functions/mcp/tools.ts` — wires `selectDiverse` in the `order=rank` branch, replacing `.slice(0, pageLimit)`
- `packages/mcp-core/src/select-diverse.spec.ts` (new) — 13 tests: real-selection (near-dups + distinct, revert-flips-red), jaccardSimilarity contract, k/tie-break/degenerate, integration
- `packages/mcp-core/src/lesson-rank-parity.spec.ts` — 3 new parity tests (TS ↔ .mjs selected order agrees; order diverges from raw-rank; `MMR_LAMBDA` constant match)

## Key decisions

- **Jaccard on `value`** (D1): dependency-free, deterministic, byte-mirrorable across TS/Deno/`.mjs`. Does not touch the dormant vector column.
- **`MMR_LAMBDA = 0.7`** (D2): named export, anchored to Carbonell & Goldstein (1998), mirrors `RECENCY_HALF_LIFE_DAYS` style.
- **Always-on, no param** (D3): ranked mode is already the opt-in; avoids schema/llms.txt chain.
- **Two edge paths only** (D4): `core/lessons.mjs` SessionStart keeps `ranked.slice(0, HARD_LESSON_CEILING)`.
- **Recency wire path byte-untouched**: no deletions of `decodeCursor`/`buildPage` lines.

## Test counts

| Suite | Before | After |
|-------|--------|-------|
| `nx test mcp-core` | 1016 (53 files) | **1032 (54 files)** |
| `nx test schemas` | 146 | **146** |
| `nx test cli` | 28 pre-existing failures (baseline) | **28 pre-existing failures (unchanged)** |

## Pre-existing CI failures (inherited, not caused by this PR)

- `web:lint` ~68 errors — broken on `origin/main` before this PR
- `web:build` Combobox issue — broken on `origin/main` before this PR
- `nx test cli` 28 failures (`resolveProjectConnection`, `tree`, `hook` integration, network tests) — same count on baseline

No lockfile change (pure logic addition; no new dep).

## Test plan

- [x] `npx nx test mcp-core --skip-nx-cache` — 1032/1032 pass, including `edge-parity` (22), `lesson-rank-parity` (25), `select-diverse` (13)
- [x] `npx nx test schemas --skip-nx-cache` — 146/146 pass, `render.spec` and `edge-schema-parity` green
- [x] AC-8: `git diff origin/main -- supabase/functions/memories/handlers/relevant.ts supabase/functions/mcp/tools.ts | grep '^-' | grep -Eq 'decodeCursor|buildPage'` returns non-zero (no deletions)
- [x] AC-6: `selectDiverse` absent from `packages/cli/src/core/lessons.mjs`; `ranked.slice(0, HARD_LESSON_CEILING)` retained

🤖 Generated with [Claude Code](https://claude.com/claude-code)