### PR TITLE
feat(memories): order GET /memories/scopes by count, not scope name

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -300,7 +300,7 @@ It is **store-wide**, not limited to any working directory — unlike the `lorek
 }
 ```
 
-**Returns:** `{ "scopes": [{ "scope", "count", "last_activity" }] }`, sorted by scope ascending.
+**Returns:** `{ "scopes": [{ "scope", "count", "last_activity" }] }`, sorted by count desc then scope asc (busiest scope first).
 
 ```json
 {

--- a/packages/cli/src/mcp-server.mjs
+++ b/packages/cli/src/mcp-server.mjs
@@ -248,7 +248,7 @@ const MEMORY_DISPATCH = {
 // networkError, unusable }`. A tool that passed either through verbatim would
 // hand the model two different contracts for one tool name depending on a
 // config value it cannot see. What is left here is what only the MCP surface
-// owns: the ascending sort and the exit-clean degradation below.
+// owns: the count-desc-then-scope-asc sort and the exit-clean degradation below.
 //
 // DEGRADATION IS EXIT-CLEAN, mirroring the `scopes` command, which reports an
 // unreachable remote as a short note at exit 0 rather than failing the run. An

--- a/packages/cli/src/mcp-server.mjs
+++ b/packages/cli/src/mcp-server.mjs
@@ -270,31 +270,31 @@ export async function listScopes(store) {
   return ok ? { ok: true, scopes: sortScopes(scopes) } : { ok: true, scopes: [], note: reason };
 }
 
-// Sorted by scope ascending, which is the contract `docs/mcp-tools.md`, the
-// tool catalog and `llms.txt` all state for `memory.scopes`. The HOSTED surface
-// gets that ordering from `lorekit_memory_scopes` (`order by m.scope asc`,
-// migration 00039/00049), but `LocalStore`/`TwoTierStore.listScopes()` both
-// return their `Map` insertion order — a walk order, not an ordering — so the
-// stdio server owns it here rather than the two surfaces answering differently.
-// Sorting BOTH shapes (not just the local one) makes the guarantee a property
-// of this function instead of an assumption about the store it was handed.
-// Codepoint comparison, deliberately not `localeCompare`: the ordering must not
-// depend on the HOST's locale.
+// Sorted by count DESC then scope asc, which is the contract `docs/mcp-tools.md`,
+// the tool catalog and `llms.txt` all state for `memory.scopes`. The HOSTED
+// surface gets that ordering from `lorekit_memory_scopes` (`order by count(*)
+// desc, m.scope asc`, migration 00065), but `LocalStore`/`TwoTierStore.
+// listScopes()` both return their `Map` insertion order — a walk order, not an
+// ordering — so the stdio server owns it here rather than the two surfaces
+// answering differently. Sorting BOTH shapes (not just the local one) makes the
+// guarantee a property of this function instead of an assumption about the store
+// it was handed.
 //
-// That is ascending-by-scope, not byte-identical parity with the hosted path,
-// and the difference is worth being precise about. `order by m.scope asc` sorts
-// under the DATABASE's collation (`en_US.UTF-8` on a default Supabase project),
-// which does not order like codepoint around punctuation — and a scope string
-// is mostly punctuation (`::`, `/`, `-`), so `repo::a-b` and `repo::ab` can come
-// out in the opposite relative order on the two surfaces. Case cannot differ
-// (every scope segment is lowercased, see docs/scope-format.md). Closing the
-// remaining gap means `collate "C"` on the RPC's `order by`, which changes the
-// order `GET /memories/scopes` has always returned — a public contract change
-// that belongs in its own migration, not here. Until then: both surfaces are
-// sorted ascending, neither is unordered, and nothing should depend on the two
-// agreeing on the exact position of a punctuated neighbour.
+// The primary key is `count` (a number), which orders identically on both
+// surfaces. Only the scope-asc TIEBREAK between equal-count scopes carries the
+// old caveat: it is a codepoint comparison here (deliberately not
+// `localeCompare`, so the ordering never depends on the HOST's locale), while
+// `order by m.scope asc` sorts under the DATABASE's collation (`en_US.UTF-8` on a
+// default Supabase project), which does not order like codepoint around
+// punctuation — and a scope string is mostly punctuation (`::`, `/`, `-`), so
+// two equal-count scopes like `repo::a-b` and `repo::ab` can come out in the
+// opposite relative order on the two surfaces. Case cannot differ (every scope
+// segment is lowercased, see docs/scope-format.md). Nothing should depend on the
+// two agreeing on the exact position of a punctuated equal-count neighbour.
 function sortScopes(rows) {
-  return rows.sort((a, b) => (a.scope < b.scope ? -1 : a.scope > b.scope ? 1 : 0));
+  return rows.sort(
+    (a, b) => b.count - a.count || (a.scope < b.scope ? -1 : a.scope > b.scope ? 1 : 0),
+  );
 }
 
 // Provenance for a tool call: the caller's explicit values win, the working

--- a/packages/cli/src/store/remote.mjs
+++ b/packages/cli/src/store/remote.mjs
@@ -257,7 +257,7 @@ class RemoteStore {
   // The `scopes` array is the SAME `[{ scope, count }]` inventory shape
   // `LocalStore.listScopes()` returns, so `scopes.mjs` feeds both through the
   // same pure `filterScopeInventory`/`summarizeScopeInventory` helpers. Ordering
-  // is not relied upon (the server sorts by scope asc; the view re-sorts by
+  // is not relied upon (the server sorts by count desc; the view re-sorts by
   // scope type). Failures use this store's standard `{ ok:false, error,
   // networkError }` envelope so the caller can degrade gracefully.
   //

--- a/packages/cli/test/mcp-server.test.mjs
+++ b/packages/cli/test/mcp-server.test.mjs
@@ -356,7 +356,8 @@ describe('memory.scopes dispatch', () => {
     const out = await listScopes({
       async listScopes() { return [{ scope: 'global' }, { scope: 'x', count: 'lots' }, {}]; },
     });
-    // Sorted by scope ascending, so the empty-scope row leads.
+    // All counts coerce to 0, so the scope-asc tiebreak decides and the
+    // empty-scope row leads.
     assert.deepEqual(out.scopes, [
       { scope: '', count: 0 },
       { scope: 'global', count: 0 },
@@ -364,16 +365,20 @@ describe('memory.scopes dispatch', () => {
     ]);
   });
 
-  test('sorts by scope ascending regardless of the store shape', async () => {
+  test('sorts by count desc then scope asc regardless of the store shape', async () => {
     // The documented contract (docs/mcp-tools.md, the tool catalog, llms.txt).
-    // The hosted RPC already orders by scope asc; the local/two-tier stores
-    // return walk order, so the normaliser is what makes the two agree.
+    // The hosted RPC already orders by count desc then scope asc (00065); the
+    // local/two-tier stores return walk order, so the normaliser is what makes
+    // the two agree. The counts are chosen so count-desc does NOT coincide with
+    // scope-asc (the busiest scope, repo::acme/api, sorts alphabetically last),
+    // and global/project::z tie at 2 so the scope-asc tiebreak is exercised too.
     const unsorted = [
-      { scope: 'repo::acme/api', count: 1 },
+      { scope: 'repo::acme/api', count: 5 },
       { scope: 'global', count: 2 },
       { scope: 'branch::acme/api::main', count: 3 },
+      { scope: 'project::z', count: 2 },
     ];
-    const expected = ['branch::acme/api::main', 'global', 'repo::acme/api'];
+    const expected = ['repo::acme/api', 'branch::acme/api::main', 'global', 'project::z'];
 
     const local = await listScopes({ async listScopes() { return unsorted; } });
     assert.deepEqual(local.scopes.map((s) => s.scope), expected);

--- a/packages/schemas/src/tool-catalog.ts
+++ b/packages/schemas/src/tool-catalog.ts
@@ -254,7 +254,7 @@ export const MCP_TOOLS: readonly McpToolDoc[] = [
     permission: 'read',
     auth: 'token-or-jwt',
     inputSchema: { type: 'object', properties: {} },
-    returns: '`{ "scopes": [{ "scope", "count", "last_activity" }] }`, sorted by scope ascending. `count` is active (non-archived, non-expired) memories; `last_activity` is the newest `created_at` among them, or `null`.',
+    returns: '`{ "scopes": [{ "scope", "count", "last_activity" }] }`, sorted by count desc then scope asc (busiest scope first). `count` is active (non-archived, non-expired) memories; `last_activity` is the newest `created_at` among them, or `null`.',
   },
   {
     name: 'memory.list_archived',

--- a/packages/web/public/llms.txt
+++ b/packages/web/public/llms.txt
@@ -279,7 +279,7 @@ No arguments.
 
 Requires **read** permission.
 
-Returns: `{ "scopes": [{ "scope", "count", "last_activity" }] }`, sorted by scope ascending. `count` is active (non-archived, non-expired) memories; `last_activity` is the newest `created_at` among them, or `null`.
+Returns: `{ "scopes": [{ "scope", "count", "last_activity" }] }`, sorted by count desc then scope asc (busiest scope first). `count` is active (non-archived, non-expired) memories; `last_activity` is the newest `created_at` among them, or `null`.
 
 ---
 

--- a/packages/web/src/lib/queries/dashboard.ts
+++ b/packages/web/src/lib/queries/dashboard.ts
@@ -72,8 +72,8 @@ async function fetchDashboardData(signal?: AbortSignal): Promise<DashboardData> 
       type: scopeType(scope),
       label: scope.split('::').pop() ?? scope,
       total: count,
-      // The endpoint sorts by scope; the cards are ordered by recency, which
-      // is what `aggregateByScope` used to do client-side.
+      // The endpoint sorts by count desc; the cards are ordered by recency,
+      // which is what `aggregateByScope` used to do client-side.
       lastActivity: last_activity ?? '',
     }))
     .sort((a, b) => b.lastActivity.localeCompare(a.lastActivity));

--- a/packages/web/src/lib/queries/lore.ts
+++ b/packages/web/src/lib/queries/lore.ts
@@ -127,8 +127,10 @@ async function requireBrowserToken(): Promise<string> {
 // ---------------------------------------------------------------------------
 // Scope-tree-only fetch (used by the Lore Explorer sidebar).
 // One row per scope from `GET /memories/scopes`, already counted and sorted by
-// the database — this stays its own lightweight query so the tree renders
-// immediately while the paginated lesson list streams in separately.
+// the database (count desc, scope asc — 00065), which is the order the chip
+// strip renders since this maps but never re-sorts. Stays its own lightweight
+// query so the tree renders immediately while the paginated lesson list streams
+// in separately.
 // ---------------------------------------------------------------------------
 
 async function fetchScopes(signal?: AbortSignal): Promise<ScopeNode[]> {

--- a/packages/web/src/mocks/memories.ts
+++ b/packages/web/src/mocks/memories.ts
@@ -172,7 +172,8 @@ function activeRows(rows: MemoryRow[], archived: boolean): MemoryRow[] {
   return rows.filter((r) => (archived ? r.archived_at !== null : r.archived_at === null));
 }
 
-/** `GET /memories/scopes` — one row per scope, sorted by scope. */
+/** `GET /memories/scopes` — one row per scope, count desc then scope asc
+ *  (mirrors `lorekit_memory_scopes` since 00065, the same order as `/tags`). */
 function scopesFrom(rows: MemoryRow[]) {
   const byScope = new Map<string, { count: number; last: string }>();
   for (const r of activeRows(rows, false)) {
@@ -181,7 +182,7 @@ function scopesFrom(rows: MemoryRow[]) {
     else byScope.set(r.scope, { count: prev.count + 1, last: r.created_at > prev.last ? r.created_at : prev.last });
   }
   return Array.from(byScope.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
+    .sort(([a, av], [b, bv]) => bv.count - av.count || a.localeCompare(b))
     .map(([scope, { count, last }]) => ({ scope, count, last_activity: last }));
 }
 

--- a/supabase/functions/_shared/schemas/tool-catalog.ts
+++ b/supabase/functions/_shared/schemas/tool-catalog.ts
@@ -259,7 +259,7 @@ export const MCP_TOOLS: readonly McpToolDoc[] = [
     permission: 'read',
     auth: 'token-or-jwt',
     inputSchema: { type: 'object', properties: {} },
-    returns: '`{ "scopes": [{ "scope", "count", "last_activity" }] }`, sorted by scope ascending. `count` is active (non-archived, non-expired) memories; `last_activity` is the newest `created_at` among them, or `null`.',
+    returns: '`{ "scopes": [{ "scope", "count", "last_activity" }] }`, sorted by count desc then scope asc (busiest scope first). `count` is active (non-archived, non-expired) memories; `last_activity` is the newest `created_at` among them, or `null`.',
   },
   {
     name: 'memory.list_archived',

--- a/supabase/functions/memories/CLAUDE.md
+++ b/supabase/functions/memories/CLAUDE.md
@@ -374,7 +374,10 @@ collapsing them would make it impossible to tell whether agents actually reach f
 ## `GET /scopes`
 
 Returns every distinct scope the caller can see with its count of active (non-archived,
-non-expired) memories, sorted by scope ascending:
+non-expired) memories, ordered by **count desc then scope asc** (migration 00065, the same
+frequency-first order `/tags` uses) — so the busiest scope leads. The dashboard's scope chip
+strip renders this order directly (`fetchScopes` never re-sorts), which is why the order lives
+in the RPC:
 
 ```json
 {

--- a/supabase/functions/memories/handlers/scopes.ts
+++ b/supabase/functions/memories/handlers/scopes.ts
@@ -9,7 +9,8 @@ type ScopeRow = Database['public']['Functions']['lorekit_memory_scopes']['Return
 
 /**
  * GET /memories/scopes — every distinct scope the caller can see, with its
- * count of active (non-archived, non-expired) memories, sorted by scope asc.
+ * count of active (non-archived, non-expired) memories, sorted by count desc
+ * then scope asc (matching /tags) — the busiest scope leads.
  *
  * This is the REST answer to the CLI's `listScopes()`, which used to return an
  * "unsupported" sentinel because no MCP tool can enumerate scopes (every read

--- a/supabase/migrations/00065_memory_scopes_order_by_count.sql
+++ b/supabase/migrations/00065_memory_scopes_order_by_count.sql
@@ -1,0 +1,73 @@
+-- ═════════════════════════════════════════════════════════════════════════
+-- lorekit_memory_scopes — order the per-scope rollup by COUNT, not scope name.
+--
+-- WHY: the Lore Explorer's scope chip strip renders `GET /memories/scopes` in
+-- the order the endpoint returns (`fetchScopes` maps but never re-sorts), so the
+-- endpoint's ORDER BY *is* the chip order. Alphabetical put a one-memory scope
+-- ahead of the account's busiest one; sorting by count surfaces the scopes a
+-- reader actually works in first.
+--
+-- This also makes the two catalog endpoints consistent: `lorekit_memory_tags`
+-- (00050) already orders `count desc, label asc`. `/scopes` was the odd one out
+-- at `scope asc`; both now lead with frequency and break ties by name.
+--
+-- Signature and return type are unchanged, so a plain `create or replace` (no
+-- DROP) suffices — unlike 00049, which had to DROP to add a column. Everything
+-- else is carried over verbatim from 00049: the service-role-gated actor guard,
+-- the `lorekit_member_org_ids` visibility predicate, the active-rows-only
+-- definition (non-archived AND non-expired), `last_activity`, plpgsql-not-SQL so
+-- the ordering survives, and the revoked PUBLIC/anon grant.
+--
+-- `count desc` is emitted as `count(*) desc` rather than the output alias `count`
+-- to stay unambiguous under `#variable_conflict use_column`; `scope asc` is the
+-- deterministic tiebreaker so equal-count scopes keep a stable order.
+-- ═════════════════════════════════════════════════════════════════════════
+
+create or replace function lorekit_memory_scopes(p_user_id uuid)
+returns table (scope text, count bigint, last_activity timestamptz)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+-- The RETURNS TABLE columns are also plpgsql OUT variables, so an unqualified
+-- reference to any of them inside the query would be ambiguous. Every reference
+-- below is table-qualified, and this directive makes the column win regardless.
+#variable_conflict use_column
+declare
+  -- Honour a caller-supplied p_user_id only on a verified service-role
+  -- connection (the edge resolves the token owner and passes it); an
+  -- authenticated caller is pinned to its own auth.uid(), closing the
+  -- cross-user scope-name enumeration. A NULL actor under service-role is the
+  -- CI escape hatch, preserved by the first visibility branch below.
+  v_actor uuid := case
+    when auth.role() = 'service_role' then coalesce(p_user_id, auth.uid())
+    else auth.uid()
+  end;
+begin
+  return query
+    select m.scope, count(*) as count, max(m.created_at) as last_activity
+      from memories m
+     where (
+             (v_actor is null and auth.role() = 'service_role')
+             or m.user_id = v_actor
+             or m.org_id in (select lorekit_member_org_ids(v_actor))
+           )
+       and m.archived_at is null
+       and (m.expires_at is null or m.expires_at > now())
+     group by m.scope
+     order by count(*) desc, m.scope asc;
+end;
+$$;
+
+revoke execute on function lorekit_memory_scopes(uuid) from public, anon;
+grant  execute on function lorekit_memory_scopes(uuid) to authenticated, service_role;
+
+comment on function lorekit_memory_scopes(uuid) is
+  'Per-scope active counts and last activity visible to the EFFECTIVE caller,
+   ordered by count desc then scope asc (matching lorekit_memory_tags). Actor
+   resolved by the 00046/00041 service-role-gated rule: a caller-supplied
+   p_user_id is honoured only on a verified service-role connection, otherwise
+   auth.uid() wins — so an authenticated caller can never enumerate another
+   user''s scope names. p_user_id IS NULL under service-role is the CI escape
+   hatch. last_activity is max(created_at) over the same counted rows.';

--- a/supabase/tests/migrations.test.sql
+++ b/supabase/tests/migrations.test.sql
@@ -1993,7 +1993,8 @@ $$;
 -- AC-5: A scope whose every row is archived disappears from the result entirely.
 -- AC-6: An org co-member sees the org's scopes (via lorekit_member_org_ids).
 -- AC-7: A non-member does not see that org's scopes.
--- AC-8: Rows come back sorted by scope ascending.
+-- AC-8: Rows come back sorted by count DESC, then scope asc (00065, matching
+--       lorekit_memory_tags) — the busiest scope leads regardless of name.
 
 -- Fresh 'scopes-org' (fa) with owner A + member B, isolated from the phase-3
 -- and safe-org-deletion fixtures above (f3 has unrelated membership churn, f9
@@ -2015,6 +2016,14 @@ insert into memories (user_id, scope, key, value, archived_at) values
   ('00000000-0000-0000-0000-0000000000a1', 'project::scopes-gone', 'sc-gone', 'v', now());
 insert into memories (user_id, scope, key, value, expires_at) values
   ('00000000-0000-0000-0000-0000000000a1', 'project::scopes-a', 'sc-a-expired', 'v', now() - interval '1 minute');
+
+-- A busier scope for A (3 active rows) whose name sorts AFTER project::scopes-a.
+-- Under the old `scope asc` order it would come last; under 00065's `count desc`
+-- it must come FIRST — so A's result distinguishes the two orderings (AC-8).
+insert into memories (user_id, scope, key, value) values
+  ('00000000-0000-0000-0000-0000000000a1', 'repo::acme/scopes-top', 'sc-top-1', 'v'),
+  ('00000000-0000-0000-0000-0000000000a1', 'repo::acme/scopes-top', 'sc-top-2', 'v'),
+  ('00000000-0000-0000-0000-0000000000a1', 'repo::acme/scopes-top', 'sc-top-3', 'v');
 
 -- User B: one active row in a scope of their own.
 insert into memories (user_id, scope, key, value) values
@@ -2084,11 +2093,25 @@ begin
   assert v_rows = 0,
     'memory scopes AC-7: a non-member/non-owner must see none of these scopes';
 
-  -- AC-8: results are ordered by scope ascending.
-  select array_agg(scope) into v_scopes from lorekit_memory_scopes('00000000-0000-0000-0000-0000000000a1');
-  select array_agg(s order by s) into v_sorted from unnest(v_scopes) as s;
+  -- AC-8: the function returns rows already ordered by count desc, then scope
+  -- asc. `array_agg` with no ORDER BY preserves the function-scan row order, so
+  -- comparing it against the same rows re-sorted by the intended key asserts the
+  -- function itself did the ordering.
+  select array_agg(scope) into v_scopes
+    from lorekit_memory_scopes('00000000-0000-0000-0000-0000000000a1');
+  select array_agg(scope order by count desc, scope asc) into v_sorted
+    from lorekit_memory_scopes('00000000-0000-0000-0000-0000000000a1');
   assert v_scopes = v_sorted,
-    format('memory scopes AC-8: results must be sorted by scope asc, got %s', v_scopes);
+    format('memory scopes AC-8: results must be ordered by count desc then scope asc, got %s', v_scopes);
+  -- Concretely, over the three scopes A owns with known counts: they must appear
+  -- busiest-first — top(3) before scopes-a(2) before scopes-org(1) — regardless
+  -- of the other scopes A carries from earlier fixtures. Under the old `scope
+  -- asc` this order was top LAST, so this only holds once count drives it.
+  assert array_position(v_scopes, 'repo::acme/scopes-top')
+           < array_position(v_scopes, 'project::scopes-a')
+     and array_position(v_scopes, 'project::scopes-a')
+           < array_position(v_scopes, 'repo::acme/scopes-org'),
+    format('memory scopes AC-8: known scopes must be count-desc top(3)<scopes-a(2)<scopes-org(1), got %s', v_scopes);
 
   reset role;
   perform set_config('request.jwt.claims', '', true);


### PR DESCRIPTION
## What

The Lore Explorer's scope chip strip now leads with the **busiest** scope instead of the alphabetically-first one. `GET /memories/scopes` is reordered from `scope asc` to **`count desc, scope asc`**, and that order is propagated through the MCP `memory.scopes` contract and the stdio server so every surface agrees.

## Why on the API, not the client

The dashboard renders the endpoint's order directly — `fetchScopes` maps each row but never re-sorts — so the endpoint's `ORDER BY` *is* the chip order. Sorting client-side would just re-implement what the DB can do once, and it's where the sibling catalog already lives: `lorekit_memory_tags` (00050) is already `count desc, label asc`. `/scopes` was the odd one out; now the two are consistent, frequency-first with a name tiebreak.

## The change

- **Migration `00065`** recreates `lorekit_memory_scopes` with `order by count(*) desc, scope asc`. Signature/return type unchanged, so a plain `create or replace` (no DROP). Everything else — the service-role actor guard, the `lorekit_member_org_ids` visibility predicate, the active-rows-only definition, `last_activity` — carries over verbatim from 00049.
- **The MCP `memory.scopes` contract follows.** The hosted tool returns the RPC's rows verbatim, and the CLI stdio server's `sortScopes` now sorts `count desc, scope asc` too (it previously re-sorted scope-asc to mirror the old contract, which would have diverged). The collation caveat between the two surfaces is narrowed to just the scope-asc tiebreak between equal-count scopes.
- **Published contract + docs updated everywhere it was stated**: `tool-catalog.ts` (+ its `_shared` mirror), the regenerated `llms.txt`, `docs/mcp-tools.md`, the scopes handler docblock, and the stale sibling comments in `queries/dashboard.ts` and `store/remote.mjs`.
- **`migrations.test.sql` AC-8** previously asserted `scope asc` and, with the old fixtures, couldn't even distinguish the two orderings. Adds a busier scope whose name sorts *last*, then asserts count-desc robustly (full-array compare + relative order of three known-count scopes). The CLI `mcp-server` sort test gets the same treatment (counts where count-desc ≠ scope-asc, plus an equal-count tiebreak pair).
- **MSW `scopesFrom` mock** mirrors the new order so stories reflect production.

## Not changed

No schema/handler shape change — same `ScopesResponseSchema`. The OpenAPI *summary* doesn't state sort order for `/scopes` or `/tags` (neither did before), so no spec change. The CLI's human `scopes`/`stats` commands re-sort their inventory by scope type (`sortScopeInventory`), so their display is unaffected — only the raw `memory.scopes` MCP tool order changed.

## Tests & docs

- `migrations.test.sql` §AC-8 (rewritten) — runs against a real DB in CI's Integration smoke job.
- CLI `mcp-server.test.mjs` sort test — updated to assert count-desc + tiebreak.
- Storybook — LorePage + ScopeSelector visual stories pass with no baseline change.
- Docs: `memories/CLAUDE.md`, scopes handler docblock, `docs/mcp-tools.md`, the `tool-catalog.ts` MCP reference, and the regenerated `llms.txt` all now state `count desc, scope asc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)