### PR TITLE
refactor(memories): share the dimension-filter predicates + fix usage kind/host

### DIFF
--- a/supabase/functions/_shared/usage.ts
+++ b/supabase/functions/_shared/usage.ts
@@ -86,6 +86,14 @@ export function recordUsageEvent(
     p_correlation_id: params.correlationId ?? null,
     p_client:      params.client ?? null,
     p_scope:       params.scope ?? null,
+    // `kind`/`host` have been on `UsageEventParams` and on the writer RPC since
+    // 00056, and the MCP handler has been resolving and passing them all along —
+    // but they were never in this payload, so the RPC used its defaults and
+    // every `usage_events.kind` / `.host` in the table is NULL. The columns were
+    // dead the whole time, silently, because a telemetry write that drops a
+    // dimension looks exactly like a telemetry write that succeeds.
+    p_kind:        params.kind ?? null,
+    p_host:        params.host ?? null,
   }).then(() => { /* fire-and-forget */ }).catch(() => { /* swallow */ });
 
   const edgeRuntime = (globalThis as {

--- a/supabase/functions/memories/CLAUDE.md
+++ b/supabase/functions/memories/CLAUDE.md
@@ -222,10 +222,15 @@ consequences to know before reading a number:
 
 The eight text/tags/int dimension predicates are the shared inlinable SQL helpers
 `lorekit_match_text` / `lorekit_match_tags` / `lorekit_match_int` (migration 00066), so the
-catalog's per-dimension flags cannot drift from the predicate `GET /activity` and `GET /`
-apply — the load-bearing `nin` null test (an unattributed row is EXCLUDED from a negated
-filter, not silently dropped) lives in ONE place. `owner` is the one dimension that stays
-inline: it is a LEFT JOIN-computed identity (`personal` / org slug), not a scalar column.
+catalog's per-dimension flags cannot drift from the series `GET /activity` counts: **both
+`lorekit_memory_facets` and `lorekit_memory_activity` compose the same helpers**, so the
+load-bearing `nin` null test (an unattributed row is EXCLUDED from a negated filter, not
+silently dropped) lives in ONE place for the two RPCs. `GET /` (`list.ts`) is a **separate**
+implementation — it builds a PostgREST `not.in` predicate (`inListLiteral`), not these SQL
+helpers; it agrees by construction (Postgres `NOT (col IN (…))` is also NULL, hence excludes,
+for a null column) but is not unified with them. `owner` is the one dimension that stays
+inline in the RPCs: it is a LEFT JOIN-computed identity (`personal` / org slug), not a scalar
+column.
 
 ## `seen_count` — recurrence, counted by the writer
 

--- a/supabase/functions/memories/CLAUDE.md
+++ b/supabase/functions/memories/CLAUDE.md
@@ -220,6 +220,13 @@ consequences to know before reading a number:
   exact yield. Mirroring `q` would put a second implementation of `likeNeedle`'s LIKE escaping
   in plpgsql, which the repo-wide "a filter value is encoded ONE way" rule forbids.
 
+The eight text/tags/int dimension predicates are the shared inlinable SQL helpers
+`lorekit_match_text` / `lorekit_match_tags` / `lorekit_match_int` (migration 00066), so the
+catalog's per-dimension flags cannot drift from the predicate `GET /activity` and `GET /`
+apply — the load-bearing `nin` null test (an unattributed row is EXCLUDED from a negated
+filter, not silently dropped) lives in ONE place. `owner` is the one dimension that stays
+inline: it is a LEFT JOIN-computed identity (`personal` / org slug), not a scalar column.
+
 ## `seen_count` — recurrence, counted by the writer
 
 Every route that returns a memory returns `seen_count`: how many times the lesson has been
@@ -442,6 +449,14 @@ size is bounded by distinct active (hour, scope) pairs rather than by memory cou
 
 The window is bounded by default deliberately: an unbounded aggregate over `memories` grows
 with account age and no caller wants "all time".
+
+The series also takes `scope` + the same dimension filters `GET /` and `GET /facets` take
+(migration 00063) plus the `owner` dimension (00064), so the Explorer's stat header agrees
+with the list beneath it. The eight text/tags/int predicates are the shared helpers
+`lorekit_match_text` / `lorekit_match_tags` / `lorekit_match_int` (migration 00066) — the same
+predicates `lorekit_memory_facets` composes, so the chart and the facet menu narrow
+identically; `owner` stays inline. With no filters supplied the response is byte-for-byte the
+pre-00063 aggregate.
 
 ## `GET /read-activity`
 

--- a/supabase/migrations/00066_dimension_filter_helpers.sql
+++ b/supabase/migrations/00066_dimension_filter_helpers.sql
@@ -2,12 +2,13 @@
 -- Reusable dimension-filter predicates — one definition of what each mode
 -- means, composed by every aggregate that narrows memories by dimension.
 --
--- WHY: three functions now apply the SAME per-dimension predicate — GET /memories
--- (00057 facets), the write series (00063 activity) and the owner dimension
--- (00064) — and each spelled it out INLINE, once per dimension. `lorekit_memory_facets`
--- carried eight `case` flags in its base CTE; `lorekit_memory_activity` carried
--- the same eight again in a flat WHERE. Sixteen near-identical copies of a rule
--- that is easy to get subtly wrong:
+-- WHY: two aggregate functions apply the SAME per-dimension predicate — the
+-- facet catalog `lorekit_memory_facets` (00057) and the write series
+-- `lorekit_memory_activity` (00063), both later extended with the owner
+-- dimension in 00064 — and each spelled it out INLINE, once per dimension.
+-- `lorekit_memory_facets` carried eight `case` flags in its base CTE;
+-- `lorekit_memory_activity` carried the same eight again in a flat WHERE.
+-- Sixteen near-identical copies of a rule that is easy to get subtly wrong:
 --
 --     `nin` means `value is not null and value <> all(filter)`
 --
@@ -141,6 +142,18 @@ $$;
 comment on function lorekit_match_int(integer, integer[], text) is
   'Integer counterpart of lorekit_match_text, for memories.origin_pr. Numeric
    comparison so `007` matches PR 7, exactly as GET /memories does. Inlinable.';
+
+-- These are pure predicates that touch no data, so the default PUBLIC EXECUTE is
+-- harmless — but this repo revokes PUBLIC/anon on every function it ships rather
+-- than relying on the default, so match that pattern here too. It does not
+-- affect inlining (which depends on the sql/immutable/single-expression shape,
+-- not on the grant), and the SECURITY DEFINER callers reach them as their owner.
+revoke execute on function lorekit_match_text(text, text[], text)        from public, anon;
+revoke execute on function lorekit_match_tags(text[], text[], text)      from public, anon;
+revoke execute on function lorekit_match_int(integer, integer[], text)   from public, anon;
+grant  execute on function lorekit_match_text(text, text[], text)        to authenticated, service_role;
+grant  execute on function lorekit_match_tags(text[], text[], text)      to authenticated, service_role;
+grant  execute on function lorekit_match_int(integer, integer[], text)   to authenticated, service_role;
 
 -- ── 2. lorekit_memory_facets — composes the helpers ─────────────────────────
 --

--- a/supabase/migrations/00066_dimension_filter_helpers.sql
+++ b/supabase/migrations/00066_dimension_filter_helpers.sql
@@ -1,0 +1,451 @@
+-- ═════════════════════════════════════════════════════════════════════════
+-- Reusable dimension-filter predicates — one definition of what each mode
+-- means, composed by every aggregate that narrows memories by dimension.
+--
+-- WHY: three functions now apply the SAME per-dimension predicate — GET /memories
+-- (00057 facets), the write series (00063 activity) and the owner dimension
+-- (00064) — and each spelled it out INLINE, once per dimension. `lorekit_memory_facets`
+-- carried eight `case` flags in its base CTE; `lorekit_memory_activity` carried
+-- the same eight again in a flat WHERE. Sixteen near-identical copies of a rule
+-- that is easy to get subtly wrong:
+--
+--     `nin` means `value is not null and value <> all(filter)`
+--
+-- The null test is load-bearing and non-obvious. `m.source_agent <> all(...)`
+-- alone is NULL for a row with no agent, which reads as false, so "agent is not
+-- aw" would silently drop every memory nobody attributed — the rows most likely
+-- to be the ones you are hunting for. Written out sixteen times, one copy
+-- eventually loses it, and the two callers disagree about a filter neither
+-- author touched.
+--
+-- So the predicate becomes three tiny functions and every caller composes them.
+-- They are `language sql` + `immutable` + a single expression, which is what
+-- makes PostgreSQL INLINE them into the calling query: the planner still sees a
+-- plain boolean expression over the column and can still use an index. A
+-- plpgsql helper would have been a per-row function call and a planner barrier.
+--
+-- ── What this migration DELIBERATELY does NOT change ────────────────────────
+--
+-- This is a pure refactor. `lorekit_memory_facets` and `lorekit_memory_activity`
+-- keep their 00064 SIGNATURES verbatim (including `p_owner` / `p_owner_mode`)
+-- and their 00064 BEHAVIOUR to the row — only the eight text/tags/int dimension
+-- predicates change, from inline `case` blocks to helper calls that are
+-- identical to them. The owner dimension stays INLINE: it is not a scalar
+-- text/tags/int column but a LEFT JOIN-computed identity (`personal` / org
+-- slug), so it is not one of the three helpers. `migrations.test.sql` §68 /
+-- §69 (incl. the owner §69c) is the executable proof that behaviour did not
+-- move; §80 (added here) pins the helpers directly.
+--
+-- `create or replace` (not drop): the signatures are unchanged, so the body is
+-- swapped in place and the 00064 grants persist. The revoke/grant is re-stated
+-- for the same self-documenting reason every prior migration re-states it.
+-- ═════════════════════════════════════════════════════════════════════════
+
+-- ── 1. The three predicates ─────────────────────────────────────────────────
+
+-- A scalar text column against a value list. Covers source_agent, trigger,
+-- kind, host, origin_repo and origin_branch — every single-valued text
+-- dimension the filter bar offers.
+--
+-- `immutable`, not `stable`: the result depends only on the arguments. That is
+-- also what lets the planner fold it into an index-usable expression.
+create or replace function lorekit_match_text(
+  p_value  text,
+  p_filter text[],
+  p_mode   text
+)
+returns boolean
+language sql
+immutable
+parallel safe
+as $$
+  select coalesce(
+    p_filter is null
+    or case coalesce(p_mode, 'in')
+         -- The null test that is the whole reason this function exists: a row
+         -- with no value must NOT satisfy "is not one of these". Without it the
+         -- comparison is NULL, which filters the row out — silently hiding
+         -- every unattributed row from a negated filter.
+         when 'nin' then (p_value is not null and p_value <> all(p_filter))
+         else p_value = any(p_filter)
+       end,
+    false);
+$$;
+
+comment on function lorekit_match_text(text, text[], text) is
+  'Does a scalar text column satisfy a value-list filter? `nin` negates and
+   requires the value to be NON-NULL, so an unattributed row is excluded from a
+   negated filter rather than silently dropped by NULL logic. A null filter is
+   "not filtered" and matches everything. Inlinable (sql/immutable), so callers
+   keep index access.';
+
+-- A `text[]` column (memories.tags) against a label list. Three modes rather
+-- than two, because a column holding MANY values admits containment: `all` is
+-- @>, `any` is &&, and `none` is the negation of `any`.
+create or replace function lorekit_match_tags(
+  p_value  text[],
+  p_filter text[],
+  p_mode   text
+)
+returns boolean
+language sql
+immutable
+parallel safe
+as $$
+  select coalesce(
+    p_filter is null
+    or case coalesce(p_mode, 'any')
+         when 'all'  then p_value @> p_filter
+         -- NOT(carries any), never NOT(carries all): the latter would also
+         -- admit a row carrying all but one of the named labels.
+         when 'none' then not (p_value && p_filter)
+         else p_value && p_filter
+       end,
+    false);
+$$;
+
+comment on function lorekit_match_tags(text[], text[], text) is
+  'Does a label array satisfy a label filter? `all` is containment (@>), `any`
+   is overlap (&&), `none` is the negation of `any` — never the negation of
+   `all`, which would admit a row carrying all but one named label. A null
+   filter matches everything. Inlinable.';
+
+-- An integer column (memories.origin_pr) against a value list.
+--
+-- Separate from the text helper because the column is an INTEGER and the
+-- comparison must be numeric: `GET /memories` sends the digits bare to the
+-- integer column, so Postgres reads `007` as 7 and matches PR 7. Comparing
+-- `origin_pr::text` would match nothing for that same input and the two routes
+-- would disagree about one query string. The digits-only coercion (dropping a
+-- non-numeric entry, applying no filter when the list reduces to empty) happens
+-- at the CALLER, so this helper only ever receives an already-numeric array.
+create or replace function lorekit_match_int(
+  p_value  integer,
+  p_filter integer[],
+  p_mode   text
+)
+returns boolean
+language sql
+immutable
+parallel safe
+as $$
+  select coalesce(
+    p_filter is null
+    or case coalesce(p_mode, 'in')
+         when 'nin' then (p_value is not null and p_value <> all(p_filter))
+         else p_value = any(p_filter)
+       end,
+    false);
+$$;
+
+comment on function lorekit_match_int(integer, integer[], text) is
+  'Integer counterpart of lorekit_match_text, for memories.origin_pr. Numeric
+   comparison so `007` matches PR 7, exactly as GET /memories does. Inlinable.';
+
+-- ── 2. lorekit_memory_facets — composes the helpers ─────────────────────────
+--
+-- Signature UNCHANGED from 00064 (so no caller moves) and behaviour unchanged:
+-- this replaces the eight inline `case` flags in the base CTE with the helper
+-- calls they are now identical to. The point is that there is one definition of
+-- what `nin` means rather than two — the whole reason the helpers exist, and
+-- undermined by leaving this function as the second copy. Owner stays inline:
+-- it is a LEFT JOIN-computed identity, not one of the three column helpers.
+--
+-- Everything else — the actor rule, the tenant predicate (lorekit_member_org_ids),
+-- the archived partition, the LEFT JOIN orgs, the owner predicate + owner-dimension
+-- self-exclusion, the null/blank drop and the ordering — is 00064's verbatim.
+create or replace function lorekit_memory_facets(
+  p_user_id            uuid,
+  p_archived           boolean default false,
+  p_scope              text    default null,
+  p_tags               text[]  default null,
+  p_tags_mode          text    default 'any',
+  p_source_agent       text[]  default null,
+  p_source_agent_mode  text    default 'in',
+  p_trigger            text[]  default null,
+  p_trigger_mode       text    default 'in',
+  p_kind               text[]  default null,
+  p_kind_mode          text    default 'in',
+  p_host               text[]  default null,
+  p_host_mode          text    default 'in',
+  p_origin_repo        text[]  default null,
+  p_origin_repo_mode   text    default 'in',
+  p_origin_branch      text[]  default null,
+  p_origin_branch_mode text    default 'in',
+  p_origin_pr          text[]  default null,
+  p_origin_pr_mode     text    default 'in',
+  -- Owner dimension (00064). `personal` plus one slug per member org with
+  -- visible rows. All optional: null/absent = not filtered.
+  p_owner              text[]  default null,
+  p_owner_mode         text    default 'in'
+)
+returns table (facet text, value text, count bigint)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  v_actor uuid := case
+    when auth.role() = 'service_role' then coalesce(p_user_id, auth.uid())
+    else auth.uid()
+  end;
+  v_origin_pr integer[] := (
+    select array_agg(x::integer)
+      from unnest(coalesce(p_origin_pr, '{}'::text[])) as x
+     where x ~ '^[0-9]+$'
+  );
+begin
+  return query
+  with base as (
+    select
+      m.tags, m.source_agent, m.trigger, m.kind, m.host,
+      m.origin_repo, m.origin_branch, m.origin_pr,
+      m.org_id, o.slug as org_slug,
+      -- Per-dimension match flag, now from the shared predicates so it cannot
+      -- drift from lorekit_memory_activity's. A null filter is "not filtered" →
+      -- the helper returns true, so an untouched dimension never narrows.
+      lorekit_match_tags(m.tags,          p_tags,          p_tags_mode)          as ok_tag,
+      lorekit_match_text(m.source_agent,  p_source_agent,  p_source_agent_mode)  as ok_source_agent,
+      lorekit_match_text(m.trigger,       p_trigger,       p_trigger_mode)       as ok_trigger,
+      lorekit_match_text(m.kind,          p_kind,          p_kind_mode)          as ok_kind,
+      lorekit_match_text(m.host,          p_host,          p_host_mode)          as ok_host,
+      lorekit_match_text(m.origin_repo,   p_origin_repo,   p_origin_repo_mode)   as ok_origin_repo,
+      lorekit_match_text(m.origin_branch, p_origin_branch, p_origin_branch_mode) as ok_origin_branch,
+      lorekit_match_int (m.origin_pr,     v_origin_pr,     p_origin_pr_mode)     as ok_origin_pr,
+      -- Owner: the computed identity is `personal` (org_id null) or the org slug.
+      -- Stays inline — it is not one of the three column helpers (00064).
+      (p_owner is null or case coalesce(p_owner_mode, 'in')
+         when 'nin' then (
+           (case when m.org_id is null then 'personal' else o.slug end) is not null
+           and (case when m.org_id is null then 'personal' else o.slug end) <> all(p_owner)
+         )
+         else (
+           ('personal' = any(p_owner) and m.org_id is null)
+           or (m.org_id is not null and o.slug = any(p_owner))
+         )
+       end) as ok_owner
+      from memories m
+      -- A personal row has no org, so this is a LEFT join; org rows resolve to
+      -- their slug. Visible org rows are always the caller's own orgs (the
+      -- visibility predicate below admits them only via lorekit_member_org_ids),
+      -- so `o.slug` is never a slug the caller cannot see.
+      left join orgs o on o.id = m.org_id
+     where (
+             (v_actor is null and auth.role() = 'service_role')
+             or m.user_id = v_actor
+             or m.org_id in (select lorekit_member_org_ids(v_actor))
+           )
+       and (
+             case
+               when p_archived then m.archived_at is not null
+               else m.archived_at is null
+                    and (m.expires_at is null or m.expires_at > now())
+             end
+           )
+       and (p_scope is null or m.scope = p_scope)
+  ), cells as (
+    select 'tag'::text as facet, t.tag as value
+      from base b
+      cross join lateral unnest(b.tags) as t(tag)
+     where b.ok_source_agent and b.ok_trigger and b.ok_kind and b.ok_host
+       and b.ok_origin_repo and b.ok_origin_branch and b.ok_origin_pr and b.ok_owner
+    union all
+    select 'source_agent', b.source_agent from base b
+     where b.ok_tag and b.ok_trigger and b.ok_kind and b.ok_host
+       and b.ok_origin_repo and b.ok_origin_branch and b.ok_origin_pr and b.ok_owner
+    union all
+    select 'trigger', b.trigger from base b
+     where b.ok_tag and b.ok_source_agent and b.ok_kind and b.ok_host
+       and b.ok_origin_repo and b.ok_origin_branch and b.ok_origin_pr and b.ok_owner
+    union all
+    select 'kind', b.kind from base b
+     where b.ok_tag and b.ok_source_agent and b.ok_trigger and b.ok_host
+       and b.ok_origin_repo and b.ok_origin_branch and b.ok_origin_pr and b.ok_owner
+    union all
+    select 'host', b.host from base b
+     where b.ok_tag and b.ok_source_agent and b.ok_trigger and b.ok_kind
+       and b.ok_origin_repo and b.ok_origin_branch and b.ok_origin_pr and b.ok_owner
+    union all
+    select 'origin_repo', b.origin_repo from base b
+     where b.ok_tag and b.ok_source_agent and b.ok_trigger and b.ok_kind and b.ok_host
+       and b.ok_origin_branch and b.ok_origin_pr and b.ok_owner
+    union all
+    select 'origin_branch', b.origin_branch from base b
+     where b.ok_tag and b.ok_source_agent and b.ok_trigger and b.ok_kind and b.ok_host
+       and b.ok_origin_repo and b.ok_origin_pr and b.ok_owner
+    union all
+    select 'origin_pr', b.origin_pr::text from base b
+     where b.ok_tag and b.ok_source_agent and b.ok_trigger and b.ok_kind and b.ok_host
+       and b.ok_origin_repo and b.ok_origin_branch and b.ok_owner
+    union all
+    -- Owner is the ONE dimension self-excluded here (every other flag, NOT
+    -- ok_owner), so a drilled-in owner still lists the alternative owner.
+    select 'owner', case when b.org_id is null then 'personal' else b.org_slug end from base b
+     where b.ok_tag and b.ok_source_agent and b.ok_trigger and b.ok_kind and b.ok_host
+       and b.ok_origin_repo and b.ok_origin_branch and b.ok_origin_pr
+  )
+  select c.facet, c.value, count(*) as count
+    from cells c
+   where c.value is not null
+     and btrim(c.value) <> ''
+   group by c.facet, c.value
+   order by c.facet asc, count(*) desc, c.value asc;
+end;
+$$;
+
+revoke execute on function lorekit_memory_facets(
+  uuid, boolean, text, text[], text, text[], text, text[], text, text[], text,
+  text[], text, text[], text, text[], text, text[], text, text[], text
+) from public, anon;
+grant execute on function lorekit_memory_facets(
+  uuid, boolean, text, text[], text, text[], text, text[], text, text[], text,
+  text[], text, text[], text, text[], text, text[], text, text[], text
+) to authenticated, service_role;
+
+comment on function lorekit_memory_facets(
+  uuid, boolean, text, text[], text, text[], text, text[], text, text[], text,
+  text[], text, text[], text, text[], text, text[], text, text[], text
+) is
+  'Value catalog with counts for every filterable memory dimension (tag,
+   source_agent, trigger, kind, host, origin_repo, origin_branch, origin_pr,
+   owner) over the partition selected by p_archived, visible to the EFFECTIVE
+   caller. `owner` (00064) is `personal` for org_id-null rows, else the org
+   slug. Counts are DRILL-DOWN (00057): each dimension is counted with every
+   OTHER active filter applied but not its own (self-exclusion), so the numbers
+   match what adding that value would yield. The eight text/tags/int dimension
+   predicates come from lorekit_match_text / _tags / _int (00066) so their
+   semantics cannot drift from lorekit_memory_activity; owner stays inline. With
+   no filters supplied the result is 00052''s global catalog plus the owner
+   dimension. Same service-role-gated actor rule and ordering as
+   lorekit_memory_tags.';
+
+-- ── 3. lorekit_memory_activity — composes the same helpers ──────────────────
+--
+-- Signature UNCHANGED from 00064. Unlike the facet catalog there is NO
+-- self-exclusion here: a straight count applies every filter directly, so the
+-- eight dimension predicates collapse to a flat WHERE. Replacing the inline
+-- `case` blocks with the helper calls keeps the series byte-identical to 00064
+-- and provably in step with the facet catalog. Owner stays inline. Bucket
+-- validation, the half-open [p_since, p_until) window, the active-only + tenant
+-- predicate, the LEFT JOIN orgs and the date_trunc anchoring are 00064 verbatim.
+create or replace function lorekit_memory_activity(
+  p_user_id uuid,
+  p_bucket  text        default 'day',
+  p_since   timestamptz default null,
+  p_until   timestamptz default null,
+  p_scope              text   default null,
+  p_tags               text[] default null,
+  p_tags_mode          text   default 'any',
+  p_source_agent       text[] default null,
+  p_source_agent_mode  text   default 'in',
+  p_trigger            text[] default null,
+  p_trigger_mode       text   default 'in',
+  p_kind               text[] default null,
+  p_kind_mode          text   default 'in',
+  p_host               text[] default null,
+  p_host_mode          text   default 'in',
+  p_origin_repo        text[] default null,
+  p_origin_repo_mode   text   default 'in',
+  p_origin_branch      text[] default null,
+  p_origin_branch_mode text   default 'in',
+  p_origin_pr          text[] default null,
+  p_origin_pr_mode     text   default 'in',
+  -- Owner dimension (00064) — the SAME predicate as lorekit_memory_facets and
+  -- GET /memories, so the stat header agrees with the list under an owner pill.
+  p_owner              text[] default null,
+  p_owner_mode         text   default 'in'
+)
+returns table (bucket timestamptz, scope text, count bigint)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+#variable_conflict use_column
+declare
+  v_actor uuid := case
+    when auth.role() = 'service_role' then coalesce(p_user_id, auth.uid())
+    else auth.uid()
+  end;
+  -- `origin_pr` is an INTEGER column: coerce the digits-only list numerically so
+  -- this route matches GET /memories on the same input (00057's rationale). A
+  -- non-numeric entry is dropped; a list reducing to empty applies no filter.
+  v_origin_pr integer[] := (
+    select array_agg(x::integer)
+      from unnest(coalesce(p_origin_pr, '{}'::text[])) as x
+     where x ~ '^[0-9]+$'
+  );
+begin
+  if p_bucket is null or p_bucket not in ('hour', 'day') then
+    raise exception 'invalid bucket %, expected hour or day', p_bucket
+      using errcode = '22023';
+  end if;
+
+  return query
+    select date_trunc(p_bucket, m.created_at at time zone 'UTC') at time zone 'UTC' as bucket,
+           m.scope,
+           count(*) as count
+      from memories m
+      -- LEFT join for the owner predicate — a personal row has no org (00064).
+      left join orgs o on o.id = m.org_id
+     where (
+             (v_actor is null and auth.role() = 'service_role')
+             or m.user_id = v_actor
+             or m.org_id in (select lorekit_member_org_ids(v_actor))
+           )
+       and m.archived_at is null
+       and (m.expires_at is null or m.expires_at > now())
+       and (p_since is null or m.created_at >= p_since)
+       and (p_until is null or m.created_at <  p_until)
+       -- Scope is a hard filter, always applied (00057's treatment).
+       and (p_scope is null or m.scope = p_scope)
+       -- Dimension filters — AND across, OR within, from the shared predicates
+       -- (00066) so the semantics cannot drift from lorekit_memory_facets. No
+       -- self-exclusion here: a straight count applies every one directly.
+       and lorekit_match_tags(m.tags,          p_tags,          p_tags_mode)
+       and lorekit_match_text(m.source_agent,  p_source_agent,  p_source_agent_mode)
+       and lorekit_match_text(m.trigger,       p_trigger,       p_trigger_mode)
+       and lorekit_match_text(m.kind,          p_kind,          p_kind_mode)
+       and lorekit_match_text(m.host,          p_host,          p_host_mode)
+       and lorekit_match_text(m.origin_repo,   p_origin_repo,   p_origin_repo_mode)
+       and lorekit_match_text(m.origin_branch, p_origin_branch, p_origin_branch_mode)
+       and lorekit_match_int (m.origin_pr,     v_origin_pr,     p_origin_pr_mode)
+       -- Owner: `personal` for org_id-null rows, else the org slug (00064).
+       and (p_owner is null or case coalesce(p_owner_mode, 'in')
+             when 'nin' then (
+               (case when m.org_id is null then 'personal' else o.slug end) is not null
+               and (case when m.org_id is null then 'personal' else o.slug end) <> all(p_owner)
+             )
+             else (
+               ('personal' = any(p_owner) and m.org_id is null)
+               or (m.org_id is not null and o.slug = any(p_owner))
+             )
+           end)
+     group by 1, m.scope
+     order by 1 asc, m.scope asc;
+end;
+$$;
+
+revoke execute on function lorekit_memory_activity(
+  uuid, text, timestamptz, timestamptz, text, text[], text, text[], text,
+  text[], text, text[], text, text[], text, text[], text, text[], text, text[], text, text[], text
+) from public, anon;
+grant execute on function lorekit_memory_activity(
+  uuid, text, timestamptz, timestamptz, text, text[], text, text[], text,
+  text[], text, text[], text, text[], text, text[], text, text[], text, text[], text, text[], text
+) to authenticated, service_role;
+
+comment on function lorekit_memory_activity(
+  uuid, text, timestamptz, timestamptz, text, text[], text, text[], text,
+  text[], text, text[], text, text[], text, text[], text, text[], text, text[], text, text[], text
+) is
+  'Memories created per UTC hour/day per scope over the half-open
+   [p_since, p_until) window, visible to the EFFECTIVE caller, narrowed by the
+   optional scope + dimension filters (00063) plus the owner dimension (00064,
+   `personal` / org slug). The eight text/tags/int dimension predicates come
+   from lorekit_match_text / _tags / _int (00066) — the SAME predicates
+   lorekit_memory_facets composes and the SAME behaviour GET /memories has, so
+   the stat header agrees with the list. With no filters supplied the result is
+   byte-for-byte 00051''s.';

--- a/supabase/tests/migrations.test.sql
+++ b/supabase/tests/migrations.test.sql
@@ -5619,6 +5619,87 @@ begin
 end;
 $$;
 
+-- ── 80. lorekit_match_text / _tags / _int — the shared predicates (00066) ────
+-- Three inlinable helpers replace eight hand-written `case` blocks per caller.
+-- The rule most likely to be lost in a copy — and the reason they exist — is
+-- that `nin` requires the value to be NON-NULL, so an unattributed row is
+-- EXCLUDED from a negated filter rather than silently dropped by NULL logic.
+--
+-- AC-1: a null filter is "not filtered" and matches everything.
+-- AC-2: `in` is membership; `nin` its negation.
+-- AC-3: a NULL column value satisfies neither `in` NOR `nin` — the load-bearing
+--       asymmetry. `x <> all(...)` alone is NULL for a null x, which reads as
+--       false, so "agent is not aw" would drop every unattributed memory.
+-- AC-4: the helpers are TOTAL — they return a boolean, never NULL, for every
+--       combination including a null value and a null mode.
+-- AC-5: tags modes — `all` is containment, `any` overlap, `none` the negation
+--       of `any` (never of `all`, which would admit "all but one").
+-- AC-6: the integer helper compares NUMERICALLY, so `007` matches PR 7 exactly
+--       as the list route does.
+do $$
+begin
+  -- AC-1: null filter matches everything, whatever the mode says.
+  assert lorekit_match_text('aw', null, 'in'),      'match_text AC-1: null filter must match';
+  assert lorekit_match_text('aw', null, 'nin'),     'match_text AC-1: null filter must match under nin';
+  assert lorekit_match_text(null, null, 'in'),      'match_text AC-1: null value + null filter must match';
+  assert lorekit_match_tags(array['a'], null, 'all'), 'match_tags AC-1: null filter must match';
+  assert lorekit_match_int(7, null, 'in'),          'match_int AC-1: null filter must match';
+
+  -- AC-2: membership and its negation.
+  assert lorekit_match_text('aw', array['aw','claude'], 'in'),
+    'match_text AC-2: a listed value must match under in';
+  assert not lorekit_match_text('other', array['aw'], 'in'),
+    'match_text AC-2: an unlisted value must not match under in';
+  assert lorekit_match_text('other', array['aw'], 'nin'),
+    'match_text AC-2: an unlisted value must match under nin';
+  assert not lorekit_match_text('aw', array['aw'], 'nin'),
+    'match_text AC-2: a listed value must not match under nin';
+
+  -- AC-3: THE asymmetry. A row with no value is excluded either way.
+  assert not lorekit_match_text(null, array['aw'], 'in'),
+    'match_text AC-3: a null value must not match a positive filter';
+  assert not lorekit_match_text(null, array['aw'], 'nin'),
+    'match_text AC-3: a null value must NOT satisfy a negated filter — that is the '
+    'null test the helper exists to centralise';
+  assert not lorekit_match_int(null, array[7], 'nin'),
+    'match_int AC-3: the integer helper must share the null rule';
+
+  -- AC-4: total — never NULL, so a caller can AND the result directly.
+  assert lorekit_match_text(null, array['aw'], 'in') is not null,
+    'match_text AC-4: must return a boolean, never NULL';
+  assert lorekit_match_text('aw', array['aw'], null) is not null,
+    'match_text AC-4: a null mode must default, not propagate NULL';
+  assert lorekit_match_text('aw', array['aw'], null),
+    'match_text AC-4: a null mode must default to `in`';
+  assert lorekit_match_tags(array['a'], array['a'], null),
+    'match_tags AC-4: a null mode must default to `any`';
+
+  -- AC-5: the three tag modes.
+  assert lorekit_match_tags(array['a','b'], array['a','b'], 'all'),
+    'match_tags AC-5: containment holds when every label is present';
+  assert not lorekit_match_tags(array['a'], array['a','b'], 'all'),
+    'match_tags AC-5: containment fails when one label is missing';
+  assert lorekit_match_tags(array['a'], array['a','b'], 'any'),
+    'match_tags AC-5: overlap holds on one shared label';
+  assert not lorekit_match_tags(array['a'], array['a','b'], 'none'),
+    'match_tags AC-5: `none` must reject a row sharing ANY label';
+  -- The discriminating case for `none` being NOT(any) rather than NOT(all):
+  -- a row carrying every named label must be rejected, and so must one
+  -- carrying just one of them (asserted above).
+  assert not lorekit_match_tags(array['a','b'], array['a','b'], 'none'),
+    'match_tags AC-5: `none` must reject a row carrying all named labels';
+  assert lorekit_match_tags(array['c'], array['a','b'], 'none'),
+    'match_tags AC-5: `none` must accept a row sharing no label';
+  assert lorekit_match_tags('{}'::text[], array['a'], 'none'),
+    'match_tags AC-5: a row with no labels shares none, so `none` accepts it';
+
+  -- AC-6: numeric comparison, so a zero-padded entry still matches.
+  assert lorekit_match_int(7, array[7], 'in'), 'match_int AC-6: 7 must match 7';
+  assert lorekit_match_int(7, (select array_agg(x::integer) from unnest(array['007']) as x), 'in'),
+    'match_int AC-6: `007` must resolve to 7 and match, exactly as GET /memories does';
+end;
+$$;
+
 rollback;
 
 \echo 'migrations.test.sql: all assertions passed'


### PR DESCRIPTION
## What

Salvages the two still-relevant pieces of the abandoned **#429**, re-applied onto the current owner-aware RPCs (its own branch predates the owner work, so this is a re-application of the concept, not a cherry-pick). #429's headline feature — the stats header following the filter bar — already shipped via #460, so this takes only the parts that never landed.

## Piece A — shared dimension-filter predicates

`lorekit_memory_facets` (00057) and `lorekit_memory_activity` (00063) each spell the eight dimension filters out **inline** — sixteen near-identical `case` blocks. #460 is what doubled it: `00063` inlined the same blocks `00057` already had. The load-bearing rule is the `nin` null-test:

```
nin  means  value is not null and value <> all(filter)
```

Without the `is not null`, `value <> all(...)` is `NULL` for an unattributed row, which reads as false — so "agent is not aw" would silently drop every memory nobody attributed, the rows you're most likely hunting for. Sixteen copies is sixteen chances to lose it.

**Migration `00066`** extracts three predicates — `lorekit_match_text` / `lorekit_match_tags` / `lorekit_match_int` — each `language sql` + `immutable` + a single expression, so PostgreSQL **inlines** them (the planner still sees a plain boolean over the column and keeps index access; a plpgsql helper would be a per-row call and a planner barrier). It then recreates both RPCs to compose them.

**The recreation is behaviour-preserving to the row.** Both keep their `00064` signatures verbatim (`create or replace`, no drop), and only the eight text/tags/int predicates change. Verified by reading `00066` against `00064` end-to-end: the actor guard, `v_origin_pr` coercion, `left join orgs`, visibility/archived/window/scope predicates, the **inline owner predicate** (both `in` and `nin`), the facets cells CTE with **owner self-exclusion**, ordering, and grants are all identical. The helpers wrap their result in `coalesce(…, false)`; a null column value therefore yields explicit `false` where the inline form yielded SQL `NULL` — indistinguishable in every use site (`where … and ok_x` and a flat `and match(…)` both exclude on `NULL` and on `false`).

## Piece B — the `usage_events` kind/host bug fix

`recordUsageEvent` set `kind`/`host` on its params — the MCP handler has resolved and passed them since 00056 — but **never put them in the writer-RPC payload**, so every `usage_events.kind` / `.host` in the table is NULL. The columns have been dead since they shipped, silently, because a telemetry write that drops a dimension looks exactly like one that succeeds. The RPC has accepted `p_kind`/`p_host` since 00056 (current def 00058); this forwards them. Two-line fix, no migration.

## Not done (deliberately)

#429's TS filter-shape dedup (`MemoryDimensionFilterShape` / `memoryFilterRpcArgs`) is **skipped**: `memoryFilterRpcArgs` has no caller on current `main` (the facets/activity edge handlers build RPC args inline), and the shape predates the owner dimension — so introducing it would be behaviour-adjacent churn on OpenAPI-registered schemas for marginal value, exactly the "risky, low-value" case to leave out. Pieces A and B are the whole of the value.

## Tests & docs

- `migrations.test.sql` **§80** (new) pins the three helpers directly — the null-value asymmetry (`nin` excludes an unattributed row, doesn't drop it), totality (never NULL, so a caller can `AND` the result), the three tag modes with the discriminating `none` = NOT(any) case, and numeric `007` → 7. The existing **§68 / §69** (incl. the owner §69c) are unchanged and are the executable proof the two RPCs' behaviour didn't move — they run against a real DB in CI's Integration smoke.
- `memories/CLAUDE.md` notes the shared helpers in the `/facets` and `/activity` sections.
- No schema/OpenAPI/`llms.txt` change (signatures unchanged, Piece C skipped), so nothing to regenerate; edge-schema mirror confirmed in sync.

Local checks green: `typecheck` (schemas/mcp-core/web), `nx test schemas` (166), `nx test mcp-core` (1119, incl. edge-parity), `lint web` (0 errors). The SQL migration can't run locally (no Docker) — CI's Integration smoke is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQP8ThvZtnpYKCxuBSRN6J)_