### PR TITLE
docs: warn agents off whole-repo nx run-many --all in cloud sandboxes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,32 @@ Harvest real fixtures with `LOREKIT_HOOK_RECORD=<dir>` set on the hook command (
 
 ## NX commands
 
+### Never run whole-repo Nx fan-outs in a cloud sandbox
+
+**Agents must NOT run `pnpm nx run-many -t … --all` (or `npx nx run-many --all`,
+or any other whole-repo fan-out) in a cloud or container environment.** It
+saturates the box — every project's target starts at once, the Nx daemon and the
+spawned workers contend for the small CPU/memory allowance — and the session
+freezes or stalls indefinitely rather than failing cleanly. Recovering costs a
+whole session.
+
+Run the narrow equivalent instead:
+
+```bash
+# What CI actually runs on a PR — only the projects your change affects
+pnpm nx affected -t typecheck,test,lint
+
+# Or name the projects explicitly, one target at a time
+pnpm nx typecheck mcp-core
+pnpm nx test cli
+```
+
+If you genuinely need whole-repo coverage, cap the fan-out and scope the targets
+(`pnpm nx run-many -t typecheck --all --parallel=1`) and run one target per
+invocation — never `typecheck,test,lint` together across every project. The
+unqualified `--all` form below is documented as the CI gate; **CI is where it
+belongs**, not a sandbox.
+
 ### Sandbox baseline — read before trusting a red gate
 
 Three facts about a fresh sandbox/container, each confirmed across three or more
@@ -93,8 +119,12 @@ runs. They cost time every time they are rediscovered:
    was never broken.
 
 ```bash
-# CI gate
+# CI gate — CI ONLY. Do not run this in a cloud/sandbox session; it stalls the
+# box (see "Never run whole-repo Nx fan-outs in a cloud sandbox" above).
 pnpm nx run-many -t typecheck,test,lint --all
+
+# The sandbox-safe equivalent
+pnpm nx affected -t typecheck,test,lint
 
 # Individual packages
 pnpm nx typecheck mcp-core

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,7 +44,8 @@ See [CLAUDE.md](./CLAUDE.md) for the full package map and key decisions.
 ## Everyday commands
 
 ```bash
-# The full CI gate (what must pass before merge)
+# The full CI gate (what must pass before merge) — CI and beefy local machines
+# only; see the warning below before running this in a container.
 pnpm nx run-many -t typecheck,test,lint --all
 
 # Only what your change affects (fast; what CI actually runs on a PR)
@@ -55,6 +56,13 @@ pnpm nx test mcp-core          # needs a local Supabase (see below)
 pnpm nx test cli               # the CLI's node:test suite
 pnpm nx typecheck web
 ```
+
+> **Agents / cloud sandboxes: do not run `run-many … --all`.** The whole-repo
+> fan-out saturates a container's CPU/memory allowance and the session freezes or
+> stalls instead of failing cleanly. Use `pnpm nx affected -t typecheck,test,lint`
+> or name the projects explicitly; if you truly need everything, run one target
+> per invocation with `--parallel=1`. See
+> [CLAUDE.md](./CLAUDE.md#never-run-whole-repo-nx-fan-outs-in-a-cloud-sandbox).
 
 ## Developing the CLI (`@lorekit/cli`)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -89,11 +89,18 @@ pnpm nx db:reset supabase   # reset local DB (dev only)
 ### NX dev & CI
 
 ```bash
-pnpm nx run-many -t typecheck,test,lint --all    # full CI gate
+pnpm nx run-many -t typecheck,test,lint --all    # full CI gate (CI only — see below)
+pnpm nx affected -t typecheck,test,lint          # sandbox-safe equivalent
 pnpm nx typecheck web                            # web app
 pnpm nx serve web                                # Next.js dev server
 pnpm nx test mcp-core                            # needs supabase start
 ```
+
+> **Agents / cloud sandboxes: do not run `run-many … --all`.** The whole-repo
+> fan-out saturates a container's CPU/memory allowance and the session freezes or
+> stalls instead of failing cleanly. Use `nx affected` or name the projects
+> explicitly. See
+> [CLAUDE.md](./CLAUDE.md#never-run-whole-repo-nx-fan-outs-in-a-cloud-sandbox).
 
 ---
 


### PR DESCRIPTION
The whole-repo fan-out saturates a container's CPU/memory allowance and
the session freezes or stalls instead of failing cleanly. Document the
prohibition in CLAUDE.md's NX section (with nx affected / per-project
alternatives and a --parallel=1 escape hatch) and cross-reference it from
DEVELOPMENT.md and SETUP.md, where the same command was listed without
caveat.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012V3UMAVNdtobwYQ5kAXX4K