### PR TITLE
docs(issues): resumable plans for API-token surface consistency

### DIFF
--- a/docs/issues/README.md
+++ b/docs/issues/README.md
@@ -1,0 +1,21 @@
+# API-token surface consistency — execution plans
+
+Resumable plans for making LoreKit's token-capable operation surface consistent
+across **MCP, CLI, and REST**, plus finalizing the scope-authorized-removal work.
+Each plan is self-contained: it opens with a "read first — you have no memory of
+the planning conversation" bootstrap (worktree path, branch stack, first actions),
+so a fresh session can execute it cold.
+
+**Ordering:** the generator **Phase 2** must land before Phases 3a–3d (those edit
+*through* the catalog surface-bindings Phase 2 introduces). The scope-authorized
+removal finalize can run in parallel on its own worktree.
+
+## Surface generator — branch `feat/api-token-surface-generator`
+- [Phase 2 — catalog-driven surface codegen](api-token-surface-generator/plan-generator-phase2-codegen.md) — **do first**
+- [Phase 3a — org token-enablement (via the catalog)](api-token-surface-generator/plan-generator-phase3a-org-token-enablement.md)
+- [Phase 3b — org members + invites on MCP/CLI](api-token-surface-generator/plan-generator-phase3b-org-members-invites.md)
+- [Phase 3c — CLI purge / purge-expired](api-token-surface-generator/plan-generator-phase3c-cli-purge.md)
+- [Phase 3d — analytics reads (decision record)](api-token-surface-generator/plan-generator-phase3d-analytics-decision.md)
+
+## Scope-authorized removal — branch `feat/api-token-scope-authorized-removal`
+- [Finalize → draft PR (stacked on #490) + BYOD follow-up](api-token-scope-authorized-removal/plan-finalize-removal-branch-pr.md)

--- a/docs/issues/api-token-scope-authorized-removal/plan-finalize-removal-branch-pr.md
+++ b/docs/issues/api-token-scope-authorized-removal/plan-finalize-removal-branch-pr.md
@@ -1,0 +1,223 @@
+# Plan — Finalize the scope-authorized-removal branch → stacked draft PR
+
+> **Plan-only artifact.** Nothing here is implemented. A fresh session executes it later.
+
+## Session bootstrap (read first — you have no memory of the planning conversation)
+
+- **Worktree / cwd for THIS plan:**
+  `/Users/mthines/Workspace/lorekit.git/feat/api-token-scope-authorized-removal`
+  (a `gw` worktree of `mthines/lorekit`). Do the commit/verify/PR work HERE, on
+  the `feat/api-token-scope-authorized-removal` branch. **Never** touch/`cd`/
+  `gw clean` the `…/main` worktree.
+- **Branch stack:** `feat/api-token-scope-authorized-removal` is stacked on
+  `feat/combobox-multi-select` (open PR #490 — "scope an API key from the
+  dashboard, and enforce it end to end"). At planning time BOTH branches sit at
+  the same base commit `614e0690` and the removal work is present as
+  **uncommitted / staged changes** in this worktree; nothing is committed on the
+  feature branch yet. `feat/api-token-surface-generator` is stacked ON TOP of this
+  branch — so this PR is the MIDDLE of a three-PR stack (#490 → this → surface-gen).
+- **First action:** `cd` to the worktree and confirm state:
+  `git branch --show-current` → `feat/api-token-scope-authorized-removal`;
+  `git status --short` (expect the removal changes below as uncommitted);
+  `git log --oneline -1` (expect the base `614e0690`).
+- **Use `gw`, not raw `git worktree`.** Create no new worktrees for this plan.
+
+## Context / background — what this PR ships (all DONE + verified, do NOT re-plan)
+
+The change lets a SCOPED `lk_*` API token archive/delete/restore ANY writer's row
+WITHIN its allowlisted scopes, while an unscoped key and any non-service-role
+caller stay own-rows-only (preserving the 00046 IDOR closure); and it adds an
+`existed` signal so a 0-row op reports `not_found` vs `forbidden`. Concretely:
+
+- **Migrations** `supabase/migrations/00070_api_token_scope_authorized_removal.sql`
+  and `00071_api_token_scope_authorized_restore.sql`: extend `memory_delete` and
+  `restore_memory` (both SECURITY DEFINER) with the
+  `v_scope_managed := auth.role()='service_role' AND array_length(p_key_scopes,1)
+  IS NOT NULL` widening + an `existed` return column. `restore_memory` is DROPped
+  from its old `returns uuid` 3-arg form and recreated as
+  `(uuid,text,text,text[],text,uuid[]) returns table(restored,existed)`.
+- **Edge MCP tools** `supabase/functions/mcp/tools.ts`: `toolArchive`,
+  `toolDelete`, `toolRestore` route through `memory_delete`/`restore_memory` (no
+  raw service-role `.update()/.delete()`), pass `keyScoping`, and map `existed` →
+  `reason: 'forbidden' | 'not_found'`.
+- **REST handlers** `supabase/functions/memories/handlers/remove.ts`,
+  `restore.ts`: the personal `scope+key` form routes through the RPCs (the `/:id`
+  form stays direct); `existed` → 403 vs 404.
+- **CLI:** `lorekit archive | delete | restore` subcommands
+  (`packages/cli/src/remove.mjs`, wired in `packages/cli/bin/lorekit.mjs` with the
+  `rm` alias); a `restore` method on `packages/cli/src/store/remote.mjs`. Test:
+  `packages/cli/test/remove.test.mjs` (5 tests, green).
+- **Tests:** `supabase/tests/migrations.test.sql` §83 (delete/archive) + §84
+  (restore) — verified against a real local Postgres; drift guards in
+  `packages/mcp-core/src/tenant-scope-usage.spec.ts` updated (the 5 `p_key_scopes`
+  MCP call sites; the `REMOVAL_TOOLS` mapping guard; `REST_RPC_WRITES` now includes
+  `restore`).
+
+**Expected uncommitted set in this worktree** (from the planning snapshot):
+`M packages/cli/bin/lorekit.mjs`, `M packages/cli/src/store/remote.mjs`,
+`M packages/mcp-core/src/tenant-scope-usage.spec.ts`,
+`M supabase/functions/mcp/tools.ts`,
+`M supabase/functions/memories/handlers/remove.ts`,
+`M supabase/functions/memories/handlers/restore.ts`,
+`M supabase/tests/migrations.test.sql`,
+`?? packages/cli/src/remove.mjs`, `?? packages/cli/test/remove.test.mjs`,
+`?? supabase/migrations/00070_api_token_scope_authorized_removal.sql`,
+`?? supabase/migrations/00071_api_token_scope_authorized_restore.sql`.
+(**NOT** `packages/mcp-core/src/surface-parity.spec.ts` — that belongs to the
+surface-generator branch, not this one. If it shows up here, it leaked from the
+stacked worktree; do NOT include it in this PR.)
+
+## Requirements
+
+- **R1** [user-stated] Commit the removal work on `feat/api-token-scope-authorized-removal`.
+- **R2** [user-stated] Run FULL verification: all affected vitest specs, the SQL
+  sections (§83/§84) in isolation, and the edge Deno checks in CI.
+- **R3** [user-stated] Open the DRAFT PR stacked on #490 (base =
+  `feat/combobox-multi-select`).
+- **R4** [user-stated] Note the BYOD follow-up: mirror `00070`/`00071` into
+  `supabase/byod/bootstrap.sql` (its `memory_delete` + `restore_memory` are the
+  pre-widening own-rows-only forms) and into the `mcp-core` Node `delete.ts` /
+  `archive.ts` (currently unchanged / own-rows-only). This PR does NOT implement
+  the follow-up — it records it (PR body + a tracked note).
+- **R5** [derived] Only this branch's changes land in this PR — exclude anything
+  belonging to `feat/combobox-multi-select` (already in #490) or
+  `feat/api-token-surface-generator` (the parent/child stack).
+- **R6** [process] Open the PR via the repo's `/create-pr` → `/polish` flow, NOT
+  a bare `gh pr create` — the polish quality gate must run before the PR opens.
+
+## Acceptance criteria (verifiable)
+
+- **AC1** (covers R1, R5) The removal work is committed on the branch as one (or a
+  small number of) focused commits, containing EXACTLY the expected set above and
+  nothing from the sibling branches.
+  - `kind: command`: `git status --short` is clean after commit.
+  - `kind: command`: `git diff --name-only feat/combobox-multi-select...HEAD` lists only the 10 removal files (no `surface-parity.spec.ts`, no combobox files).
+- **AC2** (covers R2) All affected vitest specs pass:
+  `corepack pnpm exec vitest run packages/mcp-core/src/tenant-scope-usage.spec.ts`
+  (the updated drift guards — 5 `p_key_scopes` MCP call sites, `REMOVAL_TOOLS`,
+  `REST_RPC_WRITES` with `restore`, and the account-wide guard) is green.
+  - `kind: command`: `corepack pnpm exec vitest run packages/mcp-core/src/tenant-scope-usage.spec.ts` exits 0.
+- **AC3** (covers R2) The CLI removal suite passes:
+  - `kind: command`: `node --test packages/cli/test/remove.test.mjs` — 5 tests green.
+  - `kind: command`: `node --test packages/cli/test/cli.test.mjs` — regression green.
+- **AC4** (covers R2) The SQL sections §83/§84 pass against a real local Postgres,
+  run in ISOLATION (the removal-branch pattern) so the pre-existing unrelated
+  failure near `migrations.test.sql` ~line 2685 (anon grant on
+  `lorekit_org_members_list`, from PR #266 — CI runs it green) does not mask the
+  result.
+  - `kind: command`: isolated-stack run (see Verification) with §83 and §84 asserting green.
+- **AC5** (covers R2) No edge/mcp-core parity guard regressed by the removal work:
+  `corepack pnpm exec vitest run packages/mcp-core/src/edge-parity.spec.ts packages/mcp-core/src/tool-catalog-parity.spec.ts packages/mcp-core/src/rest-tool-name.spec.ts packages/mcp-core/src/rest-route-parity.spec.ts` all green.
+- **AC6** (covers R3, R6) A DRAFT PR is open with base `feat/combobox-multi-select`
+  (stacked on #490), opened through `/create-pr` → `/polish` (not bare `gh`).
+  - `kind: command`: `gh pr view --json isDraft,baseRefName,headRefName` shows `isDraft:true`, `baseRefName:"feat/combobox-multi-select"`, `headRefName:"feat/api-token-scope-authorized-removal"`.
+- **AC7** (covers R4) The PR body has a "Follow-ups (not in this PR)" section
+  naming the BYOD mirror (`supabase/byod/bootstrap.sql` `memory_delete` +
+  `restore_memory`) and the Node mirror (`packages/mcp-core/src/tools/delete.ts` +
+  `archive.ts`), and a LoreKit lesson OR a tracking note is recorded so the
+  follow-up is not lost.
+  - `kind: command`: `gh pr view --json body | grep -iE "byod|bootstrap.sql|delete.ts|archive.ts"` matches.
+- **AC8** (covers R6) CI on the draft PR is watched to green (or the only red is
+  the KNOWN pre-existing ~line-2685 SQL assertion, if CI runs the full
+  `migrations.test.sql` — but per the context CI runs it GREEN, so any red there
+  is a real regression to investigate, NOT to wave off). Independently verify any
+  "infra flake" claim via `gh pr view --json statusCheckRollup` before dismissing.
+
+## Verification
+
+Run from the removal-branch worktree root. macOS has **no `timeout`** — do not wrap.
+
+1. **CLI:** `node --test packages/cli/test/remove.test.mjs packages/cli/test/cli.test.mjs` (AC3).
+2. **Drift guards + parity:** `corepack pnpm exec vitest run packages/mcp-core/src/tenant-scope-usage.spec.ts packages/mcp-core/src/edge-parity.spec.ts packages/mcp-core/src/tool-catalog-parity.spec.ts packages/mcp-core/src/rest-tool-name.spec.ts packages/mcp-core/src/rest-route-parity.spec.ts` (AC2, AC5).
+3. **SQL isolated stack (AC4)** — the removal-branch pattern (so this run never
+   disturbs another worktree's Supabase stack):
+   - Edit `supabase/config.toml` ports by **+100** (api, db, studio, etc.).
+   - `supabase start -x studio,imgproxy,storage-api,realtime,edge-runtime,logflare,vector,pooler,inbucket`
+   - `supabase db reset` (applies migrations 00001…00071).
+   - `psql "$DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/migrations.test.sql`
+     (DB_URL from `supabase status`). Confirm **§83** and **§84** pass. The run may
+     halt at the pre-existing ~line-2685 anon-grant assertion (unrelated, from PR
+     #266); if so, confirm §83/§84 executed and passed BEFORE that point, or run a
+     scratch copy of the file with only §83/§84 to isolate them. Do NOT "fix" the
+     2685 assertion here — it is out of scope and CI runs it green.
+   - `supabase stop`; `git checkout supabase/config.toml` to restore ports.
+4. **Edge Deno checks:** no local Deno harness is assumed — rely on CI for the
+   `supabase/functions/**` Deno type/lint. Before pushing, read-through the
+   `tools.ts` / `remove.ts` / `restore.ts` diffs for unused-param / type issues.
+5. **PR flow (AC6):** run `/create-pr` (which pushes the branch, opens the draft,
+   then runs the review-loop) with base pinned to `feat/combobox-multi-select`.
+   Do NOT `gh pr create` directly. If sub-agent dispatch (`Task`) is unavailable
+   so `/create-pr`'s reviewer step can't run, that is a DEGRADED path — record it
+   in the PR/《Degraded》line and still open the draft; fetch the PR's own review
+   threads (not only a dispatched reviewer) before considering it review-clean.
+6. **CI watch (AC8):** after the draft opens, watch checks; investigate any red
+   with `gh pr view --json statusCheckRollup` rather than assuming a flake.
+
+## PR description (draft skeleton — keep ≤ ~25 lines, narrative)
+
+- **What:** scoped `lk_*` tokens can now archive/delete/restore any writer's row
+  within their allowlisted scopes; unscoped keys and non-service-role callers stay
+  own-rows-only. Adds `existed` → `not_found`/`forbidden`.
+- **Why:** the owner scoped the key deliberately; managing the whole scope is the
+  authority scoping grants. Closes the "can't tell already-gone from not-yours"
+  ambiguity.
+- **How:** `memory_delete`/`restore_memory` gain the `v_scope_managed` widening +
+  `existed`; MCP tools + REST scope+key handlers route through the RPCs; CLI gains
+  `archive`/`delete`/`restore`.
+- **Safety:** the 00046 IDOR closure is preserved — both conjuncts of
+  `v_scope_managed` are load-bearing (service_role gate + non-empty allowlist).
+- **Tests:** migrations §83/§84 (real Postgres), CLI `remove.test.mjs`, drift
+  guards in `tenant-scope-usage.spec.ts`.
+- **Follow-ups (NOT in this PR):** mirror 00070/00071 into
+  `supabase/byod/bootstrap.sql` (`memory_delete` still lacks `existed` + the
+  widening; `restore_memory` is still the `returns uuid` own-rows-only form) and
+  into the Node `packages/mcp-core/src/tools/delete.ts` + `archive.ts` (still
+  own-rows-only). Stacked on #490.
+
+## BYOD follow-up — concrete scope (for AC7's note; NOT implemented here)
+
+- `supabase/byod/bootstrap.sql` `memory_delete(uuid,text,text,text,boolean,text[],text,uuid[])`
+  currently `returns table(deleted, archived)` and filters `where user_id =
+  p_user_id` only. To mirror 00070 (BYOD has no orgs, so no org clause): add the
+  `existed` return column and the personal-branch `v_scope_managed` widening
+  (`auth.role()='service_role' AND array_length(p_key_scopes,1) IS NOT NULL`, row
+  filter `or v_scope_managed` — no `lorekit_api_token_org_allowed` since BYOD has
+  no orgs).
+- `supabase/byod/bootstrap.sql` `restore_memory(uuid,text,text) returns uuid` →
+  rewrite to the 00071 shape `(uuid,text,text,text[],text,uuid[]) returns
+  table(restored,existed)` with the same personal-only widening. Update the
+  trailing `grant execute on function restore_memory(...)` signature.
+- `packages/mcp-core/src/tools/delete.ts` + `archive.ts` (the Node/BYOD-Node
+  library path) are own-rows-only and unchanged; decide whether the Node path
+  even reaches the scope-managed case (it uses a pre-scoped db + RLS, not the
+  service-role RPC path) — the follow-up plan must confirm before mirroring.
+- These are a SEPARATE PR (own threat-model review), tracked as a LoreKit lesson
+  (`repo::mthines/lorekit`) or an issue.
+
+## Risks & mitigations
+
+- **Cross-branch contamination in the commit** (staged surface-gen or combobox
+  files). *Mitigation:* AC1 diff-name check against `feat/combobox-multi-select`;
+  explicitly `git add` only the 10 removal paths; verify with
+  `git diff --cached --name-only` before committing.
+- **The ~line-2685 pre-existing SQL failure masking §83/§84.** *Mitigation:* AC4
+  — verify §83/§84 executed+passed specifically; do not trust an overall exit code.
+- **Bare `gh pr create` skipping the polish gate** (a recorded past failure).
+  *Mitigation:* R6/AC6 — go through `/create-pr` → `/polish`.
+- **A second reviewer's threads left unread before undraft/merge** (recorded
+  failure: a repo bot commented on every push, none read). *Mitigation:* fetch the
+  PR's own review threads (not only a dispatched reviewer) before considering it
+  review-clean; this PR opens as DRAFT so merge is not imminent.
+- **Wrongly dismissing a CI red as an infra flake.** *Mitigation:* AC8 — verify via
+  `statusCheckRollup` before dismissing.
+- **BYOD divergence forgotten.** *Mitigation:* R4/AC7 — recorded in the PR body +
+  a durable lesson/issue.
+
+## Dependencies / ordering
+
+- **Base = `feat/combobox-multi-select` (PR #490).** This PR is the middle of the
+  stack; `feat/api-token-surface-generator` is stacked on top of it. Land/rebase
+  order: #490 → this → surface-gen. If #490 merges to main first, rebase this
+  branch's base to `main` before undrafting.
+- Independent of the Phase-2/3 generator plans in
+  `.agent/feat/api-token-surface-generator/` (those live on the child branch).

--- a/docs/issues/api-token-surface-generator/plan-generator-phase2-codegen.md
+++ b/docs/issues/api-token-surface-generator/plan-generator-phase2-codegen.md
@@ -1,0 +1,308 @@
+# Plan — Generator Phase 2: catalog-driven surface codegen
+
+> **Plan-only artifact.** This file is a resumable execution plan. Nothing here
+> has been implemented. A fresh session executes it later.
+
+## Session bootstrap (read first — you have no memory of the planning conversation)
+
+- **Worktree / cwd:** `/Users/mthines/Workspace/lorekit.git/feat/api-token-surface-generator`
+  (a `gw` worktree of `mthines/lorekit`, the LoreKit agent-memory system). Do
+  **all** work here. **Never** touch, `cd` into, or `gw clean` the `…/main`
+  worktree — run any worktree command from the gw root or another worktree.
+- **Branch:** `feat/api-token-surface-generator`, stacked on
+  `feat/api-token-scope-authorized-removal`, itself stacked on
+  `feat/combobox-multi-select` (open PR #490). Nothing is committed on the two
+  feature branches yet — prior work is present as uncommitted/staged changes
+  carried into each worktree. **Confirm branch before editing:**
+  `git -C <worktree> branch --show-current`.
+- **First action:** `cd` to the worktree and verify anchors exist:
+  `ls packages/schemas/src/tool-catalog.ts packages/mcp-core/src/tool-catalog-parity.spec.ts packages/mcp-core/src/surface-parity.spec.ts scripts/sync-edge-schemas.mjs supabase/functions/mcp/mcp-handler.ts`.
+- **This Phase 2 plan MUST land before Phases 3a–3d** — those plans do their
+  edits *through* the catalog surface bindings this plan introduces. See
+  "Dependencies / ordering".
+
+## Context / background
+
+LoreKit exposes the same set of `memory.*` / `org.*` operations across **four**
+surfaces, each wired by hand and each able to drift from the others:
+
+1. **Canonical catalog** — `packages/schemas/src/tool-catalog.ts`. Zero-import
+   TS. Already the single declaration for the MCP wire (`tools/list` via
+   `toWireTool`/`wireTools`) and the `llms.txt` docs (via
+   `packages/schemas/src/llms/render.ts`). Mirrored verbatim into
+   `supabase/functions/_shared/schemas/tool-catalog.ts` by
+   `scripts/sync-edge-schemas.mjs` (guarded by `edge-schema-parity.spec.ts`).
+2. **Edge MCP dispatch** — `supabase/functions/mcp/mcp-handler.ts` has
+   hand-maintained `MEMORY_TOOLS` and `ORG_TOOLS` dispatch maps + a `tools/call`
+   authz block. Runtime permission gating lives in
+   `packages/mcp-core/src/permissions.ts` (`READ_TOOLS`/`WRITE_TOOLS`), mirrored
+   to `supabase/functions/mcp/permissions.ts`.
+3. **CLI dispatch (human)** — `packages/cli/bin/lorekit.mjs` (`switch` on
+   command, `HUMAN_COMMANDS` set, `COMMAND_ALIASES`, `KNOWN_FLAGS`, and a large
+   per-command `HELP`/`COMMAND_HELP` block), talking to REST via
+   `packages/cli/src/store/remote.mjs`.
+4. **CLI local stdio MCP server** — `packages/cli/src/mcp-server.mjs` has its
+   OWN duplicated `MEMORY_TOOL_DEFS` + `ORG_TOOL_DEFS` + `MEMORY_DISPATCH` +
+   `ORG_DISPATCH`. This is a third copy of the tool list that nothing currently
+   cross-checks against the catalog.
+
+Today the only automated coupling is:
+- `tool-catalog-parity.spec.ts`: catalog ↔ `permissions.ts`, and catalog ↔ the
+  edge `MEMORY_TOOLS`/`ORG_TOOLS` dispatch maps (regex-scraped from handler
+  source).
+- `surface-parity.spec.ts` (added on THIS branch, Phase 1): every `memory.*`
+  catalog tool maps to a CLI command **or a documented exemption**
+  (`MCP_TO_CLI` hand-map, with `{ exempt }` entries for `list_archived`, `purge`,
+  `purge_expired`). Its own docblock says: "When the generator emits both
+  surfaces from the catalog (Phase 2), the mapping below becomes a generated
+  artifact and this hand-written gate can retire."
+
+**Phase 2 goal:** make the catalog the single source of *surface bindings* —
+which of {mcp, cli, rest} exposes each op, the CLI command name + aliases, and
+the handler binding — and add a generator (`scripts/gen-surfaces.mjs`, with
+`--check`, mirroring `sync-edge-schemas.mjs`) plus a completeness gate that
+**absorbs** `surface-parity.spec.ts` and **extends** `tool-catalog-parity.spec.ts`.
+The generator must keep the edge mirror and every existing parity spec green.
+
+### Scope decision (READ THIS — it bounds the whole plan)
+
+There are two possible ambitions for "codegen":
+
+- **(A) Data-model + assertion generator (RECOMMENDED, this plan's default).**
+  The catalog gains per-op `surfaces` bindings. `gen-surfaces.mjs` emits a
+  single generated, committed **manifest** (`surface-manifest.generated.*`) that
+  the specs and (optionally) the runtime dispatch maps read, plus `--check` to
+  fail CI when the manifest is stale — exactly the `sync-edge-schemas.mjs`
+  shape. The hand-written dispatch maps in `mcp-handler.ts` / `lorekit.mjs` /
+  `mcp-server.mjs` are **not** machine-rewritten; instead the completeness gate
+  asserts they equal the manifest (the audit-vocabulary pattern already used by
+  `tool-catalog-parity.spec.ts`). This is low-risk, preserves the "add a tool =>
+  a test fails until you wire it" ergonomics, and is what makes 3a–3d one-edit
+  changes.
+- **(B) Full emitter that rewrites the dispatch source.** Rejected for Phase 2:
+  rewriting hand-maintained TS/JS dispatch with generated blocks is a large blast
+  radius (function *bindings* — actual imported symbols — cannot be expressed in
+  a zero-import catalog), and the byte-for-byte edge mirror + `noUnusedParameters`
+  build make generated source fragile. If pursued later it is a separate plan.
+
+**This plan implements (A).** Every acceptance criterion below is written against
+(A). If a future maintainer wants (B), re-plan it.
+
+## Requirements
+
+- **R1** [user-stated] Extend `tool-catalog.ts` with per-op **surface bindings**:
+  for each tool, which of `mcp` / `cli` / `rest` expose it, the CLI command name
+  + aliases, and the handler binding (as a *name/string*, since the catalog is
+  zero-import and cannot hold function references).
+- **R2** [user-stated] Add `scripts/gen-surfaces.mjs` with a `--check` mode,
+  mirroring `scripts/sync-edge-schemas.mjs`'s structure (pure transform fns +
+  `main()` + `--check` staleness exit 1 + self-invoke guard).
+- **R3** [user-stated] The generator emits, from the catalog: the MCP dispatch
+  map (data form), the CLI command table (data form), the `tools/list` payload
+  (already `wireTools()` — assert it still derives from the catalog), and the
+  docs (already `llms.txt` via `render.ts` — assert unchanged / regenerated).
+- **R4** [user-stated] A completeness gate **replaces/absorbs**
+  `surface-parity.spec.ts` and **extends** `tool-catalog-parity.spec.ts`, so a
+  new tool cannot land on one surface without a conscious catalog edit.
+- **R5** [user-stated] Keep the edge mirror + ALL existing parity specs green:
+  `edge-schema-parity.spec.ts`, `edge-parity.spec.ts`,
+  `tool-catalog-parity.spec.ts`, `tenant-scope-usage.spec.ts`,
+  `rest-route-parity.spec.ts`, `rest-tool-name.spec.ts`, `list-view-parity.spec.ts`,
+  `permissions.spec.ts`, `usage-client-parity.spec.ts`, plus the CLI test suite.
+- **R6** [user-stated] Telemetry is INHERITED, not per-op: confirm (in the plan
+  and in a guard/assertion) that generated ops flow through the central MCP
+  span/usage wrapper (`mcp-handler.ts` `toolSpan` + `recordUsageEvent`) and CLI
+  `traceCommand` (`lorekit.mjs`), so adding an op via the catalog does not
+  require touching telemetry.
+- **R7** [derived] The catalog stays **zero-import** (a `zod`/relative import
+  breaks both the edge mirror parity and the bare-checkout generator — see the
+  `tool-catalog.ts` header and `edge-bare-specifier.spec.ts`). Surface bindings
+  must be plain data.
+- **R8** [derived] `gen-surfaces.mjs` must run on a **bare checkout with no
+  `node_modules`** (same constraint as `generate.ts`/`sync-edge-schemas.mjs`): no
+  runtime deps, node builtins only.
+- **R9** [process] The generated manifest is **committed** and mirrored into the
+  edge tree if any edge code reads it (see Decisions D3); `--check` is added to
+  the same CI job that runs the existing `--check` scripts.
+
+## Decisions (resolve before writing code; defaults chosen)
+
+- **D1 — Binding shape.** Add an optional `surfaces` field to `McpToolDoc`:
+  ```ts
+  interface SurfaceBinding {
+    readonly mcp: boolean;                 // dispatched by the edge MCP handler
+    readonly cli: string | null;           // canonical CLI command, or null
+    readonly cliAliases?: readonly string[];
+    readonly rest?: string | null;         // REST route pattern, e.g. 'POST /purge', or null
+    readonly handler: string;              // dispatch symbol NAME, e.g. 'toolPurge'
+    readonly cliExempt?: string;           // documented reason cli is null but that's intentional
+  }
+  ```
+  Rationale: `handler` is a *string name*, honouring R7. The spec resolves the
+  name→function by asserting the hand-written map's keys/handler-names equal the
+  catalog's, never by importing.
+- **D2 — Where the CLI command metadata lives.** The CLI `bin/lorekit.mjs`
+  cannot import `@lorekit/schemas` at runtime easily (it is a published npm
+  package with its own bundling; check `packages/cli/package.json` deps). Default:
+  the generator emits a small committed **data** file the CLI test imports
+  (`packages/cli/src/surface-manifest.generated.mjs` — plain object, zero-dep),
+  and the CLI dispatch/HELP stays hand-written but is *asserted* against it. Do
+  NOT machine-rewrite `bin/lorekit.mjs`.
+- **D3 — Manifest location + edge mirror.** Emit
+  `packages/schemas/src/surface-manifest.generated.ts` (source of truth, derived
+  from the catalog) and, if any edge function needs it, add it to
+  `MIRRORED_SCHEMA_FILES` in `sync-edge-schemas.mjs`. Default: the edge does NOT
+  need it (dispatch stays hand-written + asserted), so do **not** mirror it —
+  keep the mirrored surface minimal (that file's own comment says so). Re-confirm
+  during execution.
+- **D4 — Retire vs keep `surface-parity.spec.ts`.** Absorb its three assertions
+  into the extended `tool-catalog-parity.spec.ts` (or a new
+  `surface-manifest-parity.spec.ts`) so the coverage is not lost, then delete
+  `surface-parity.spec.ts`. The `MCP_TO_CLI` hand-map becomes the generated
+  `surfaces.cli` field. Confirm the `list_archived` exemption survives as
+  `cliExempt`.
+
+## Acceptance criteria (verifiable)
+
+> Each AC is checkable by a command. `kind: command` ACs are the executable
+> `checks.yaml` (see below). "covers" ties each AC back to a requirement.
+
+- **AC1** (covers R1, R7) `tool-catalog.ts` declares a `surfaces` binding for
+  **every** entry in `MCP_TOOLS`, and the file still imports nothing.
+  - `kind: command`: `corepack pnpm exec vitest run packages/mcp-core/src/tool-catalog-parity.spec.ts` passes, including a new case asserting `MCP_TOOLS.every(t => t.surfaces)` and that `surfaces.handler` is a non-empty string for each.
+  - `kind: command`: `grep -nE "^import |from ['\"]" packages/schemas/src/tool-catalog.ts` returns **no** import lines (still zero-import).
+- **AC2** (covers R2, R8) `scripts/gen-surfaces.mjs` exists, exports pure
+  transform fn(s), has a `main()` + `--check` + self-invoke guard mirroring
+  `sync-edge-schemas.mjs`, and runs on node builtins only.
+  - `kind: command`: `node scripts/gen-surfaces.mjs` writes the manifest and exits 0.
+  - `kind: command`: `node scripts/gen-surfaces.mjs --check` exits 0 immediately after a fresh generate.
+  - `kind: command`: `node -e "const m=require('node:module');"` — smoke that the script has no bare non-builtin `import` (grep: `grep -nE "from ['\"](?!node:)[^./]" scripts/gen-surfaces.mjs` returns nothing).
+- **AC3** (covers R3) The generated manifest reproduces the MCP dispatch map keys,
+  the CLI command table, and matches `wireTools()` / catalog order.
+  - `kind: command`: the extended parity spec asserts `manifest.mcp` keys `===` catalog names where `surfaces.mcp`, and `manifest.cli` `===` catalog names→command where `surfaces.cli`.
+- **AC4** (covers R4, R5, D4) The completeness gate lives in
+  `tool-catalog-parity.spec.ts` (extended) and/or
+  `surface-manifest-parity.spec.ts`; `surface-parity.spec.ts` is deleted and its
+  three assertions are preserved in the new gate.
+  - `kind: command`: `test ! -f packages/mcp-core/src/surface-parity.spec.ts`.
+  - `kind: command`: the new/extended spec, when run, includes assertions equivalent to the old three (every `memory.*` mapped; every non-exempt mapping is a real CLI `case`; anti-vacuity that the CLI switch parsed). Prove by deleting one `case` in a scratch copy → the spec goes red (do NOT commit the scratch change).
+- **AC5** (covers R5) The full affected spec set is green:
+  `corepack pnpm exec vitest run packages/mcp-core/src/tool-catalog-parity.spec.ts packages/mcp-core/src/edge-schema-parity.spec.ts packages/mcp-core/src/edge-parity.spec.ts packages/mcp-core/src/permissions.spec.ts packages/mcp-core/src/rest-tool-name.spec.ts packages/mcp-core/src/list-view-parity.spec.ts packages/schemas/src/llms/render.spec.ts` all pass.
+- **AC6** (covers R5) The edge mirror is in sync: `node scripts/sync-edge-schemas.mjs --check` exits 0 (the `tool-catalog.ts` change is mirrored).
+- **AC7** (covers R3) `llms.txt` regenerates with no unexpected diff:
+  `node --experimental-transform-types packages/schemas/src/llms/generate.ts --check` exits 0 (surface bindings are docs-invisible unless the plan chose to render them; default: not rendered, so no `llms.txt` change).
+- **AC8** (covers R6) A telemetry-inheritance guard asserts the central wrappers
+  still bracket every dispatched op: a spec (extend `mcp-auth-tracing.spec.ts` or
+  add `surface-telemetry.spec.ts`) that greps `mcp-handler.ts` for the single
+  `toolSpan`/`recordUsageEvent` bracket around `MEMORY_TOOLS[...]`/`ORG_TOOLS[...]`
+  dispatch, and greps `bin/lorekit.mjs` that every `HUMAN_COMMANDS` command is
+  dispatched via `traceCommand(`.
+  - `kind: command`: `corepack pnpm exec vitest run packages/mcp-core/src/mcp-auth-tracing.spec.ts` passes.
+- **AC9** (covers R5) CLI suite green: `node --test packages/cli/test/*.test.mjs`
+  (or at minimum `cli.test.mjs`, `remove.test.mjs`, and any new
+  surface-manifest test) passes.
+- **AC10** (covers R9) A `--check` invocation of `gen-surfaces.mjs` is added to
+  the same CI workflow step that runs `sync-edge-schemas.mjs --check` /
+  `generate.ts --check` (find it under `.github/workflows/`).
+  - `kind: command`: `grep -rn "gen-surfaces.mjs" .github/workflows/` returns a `--check` invocation.
+
+## File changes (concrete paths)
+
+- **Edit** `packages/schemas/src/tool-catalog.ts`
+  - Add `SurfaceBinding` interface + `surfaces` field on `McpToolDoc`.
+  - Populate `surfaces` for all 15 tools. Encode the current reality:
+    - `memory.write` → `{ mcp:true, cli:'write', rest:'POST /', handler:'toolWrite' }`
+    - `memory.read` → `{ mcp:true, cli:'show', rest:'GET /', handler:'toolRead' }`
+    - `memory.list` → `{ mcp:true, cli:'list', cliAliases:['ls'], rest:'GET /', handler:'toolList' }`
+    - `memory.delete` → `{ mcp:true, cli:'delete', cliAliases:['rm'], rest:'DELETE /', handler:'toolDelete' }`
+    - `memory.search` → `{ mcp:true, cli:'search', cliAliases:['grep'], rest:'POST /search', handler:'toolSearch' }`
+    - `memory.archive` → `{ mcp:true, cli:'archive', rest:'DELETE /', handler:'toolArchive' }`
+    - `memory.scopes` → `{ mcp:true, cli:'scopes', rest:'GET /scopes', handler:'toolScopes' }`
+    - `memory.list_archived` → `{ mcp:true, cli:null, cliExempt:'surfaced via `list --archived`', rest:'GET /?archived=true', handler:'toolListArchived' }`
+    - `memory.restore` → `{ mcp:true, cli:'restore', rest:'POST /restore', handler:'toolRestore' }`
+    - `memory.purge` → `{ mcp:true, cli:null, cliExempt:'KNOWN GAP — slated for Phase 3c', rest:'POST /purge', handler:'toolPurge' }`
+    - `memory.purge_expired` → `{ mcp:true, cli:null, cliExempt:'KNOWN GAP — Phase 3c', rest:'POST /purge-expired', handler:'toolPurgeExpired' }`
+    - `org.create`/`org.list`/`org.rename`/`org.delete` → `{ mcp:true, cli:null, cliExempt:'org.* exposed via local mcp-server passthrough, not a lorekit subcommand', rest:'…', handler:'toolOrgCreate' … }`
+    - (Encode the CURRENT `auth:'jwt-only'` for org tools; Phase 3a flips it.)
+- **Add** `scripts/gen-surfaces.mjs` — pure `toManifest(catalog)` +
+  `expectedManifest()` + `main()` (`--check`) + self-invoke guard. Structure is a
+  near-copy of `scripts/sync-edge-schemas.mjs`.
+- **Add** `packages/schemas/src/surface-manifest.generated.ts` (or `.mjs` per
+  D2/D3) — the emitted artifact, committed, with a GENERATED banner + regenerate
+  instruction.
+- **Add** `packages/mcp-core/src/surface-manifest-parity.spec.ts` OR extend
+  `packages/mcp-core/src/tool-catalog-parity.spec.ts` — completeness gate
+  (absorbs the three `surface-parity.spec.ts` assertions), manifest freshness,
+  MCP-map/CLI-table equivalence.
+- **Delete** `packages/mcp-core/src/surface-parity.spec.ts` (its coverage moves
+  per D4).
+- **Edit (assertion only, if D2 needs it)** `packages/cli/test/*.test.mjs` — a new
+  test that the CLI `HUMAN_COMMANDS`/`COMMAND_ALIASES` match the manifest's
+  `cli`/`cliAliases`.
+- **Edit** `scripts/sync-edge-schemas.mjs` — ONLY if D3 flips to mirror the
+  manifest (default: no change; the `tool-catalog.ts` edit is already mirrored by
+  the existing `tool-catalog.ts` entry).
+- **Edit** `.github/workflows/<the check workflow>` — add `gen-surfaces.mjs --check`.
+- **Possibly edit** `packages/mcp-core/src/mcp-auth-tracing.spec.ts` (or add
+  `surface-telemetry.spec.ts`) for AC8.
+- **Docs:** run the docs-drift greps (see Risks) — `docs/mcp-tools.md`,
+  `docs/architecture.md`, `docs/key-files.md`, `packages/cli/README.md`,
+  `CLAUDE.md` package map. A new script + generated file likely wants a
+  `docs/key-files.md` line and a mention in `docs/architecture.md`'s "surfaces"
+  narrative.
+
+## Verification
+
+Run from the worktree root. macOS has **no `timeout`** — do not wrap commands in it.
+
+1. `corepack pnpm exec vitest run packages/mcp-core/src/tool-catalog-parity.spec.ts packages/mcp-core/src/edge-schema-parity.spec.ts packages/mcp-core/src/edge-parity.spec.ts packages/mcp-core/src/permissions.spec.ts packages/mcp-core/src/rest-tool-name.spec.ts packages/mcp-core/src/list-view-parity.spec.ts` — all green (AC1, AC3, AC4, AC5).
+2. `corepack pnpm exec vitest run packages/schemas/src/llms/render.spec.ts` — green (AC7 companion).
+3. `node scripts/gen-surfaces.mjs && node scripts/gen-surfaces.mjs --check` — write then confirm fresh (AC2).
+4. `node scripts/sync-edge-schemas.mjs --check` — edge mirror in sync (AC6).
+5. `node --experimental-transform-types packages/schemas/src/llms/generate.ts --check` — `llms.txt` unchanged (AC7).
+6. `node --test packages/cli/test/cli.test.mjs packages/cli/test/remove.test.mjs` (+ any new surface-manifest CLI test) — green (AC9).
+7. **Guard-bites proof (lesson: `mock-that-reimplements-the-thing-under-test`):**
+   for the completeness gate and manifest-freshness check, temporarily perturb
+   the real artifact (remove one `case` in `bin/lorekit.mjs`, or hand-edit the
+   generated manifest) and confirm the spec flips **red**, then restore. A gate
+   that stays green through a real perturbation asserts nothing. Do NOT commit
+   the perturbation.
+8. Whole-package sanity (optional, RAM-aware — run sequentially, not in
+   parallel): `corepack pnpm exec vitest run packages/mcp-core` and
+   `corepack pnpm exec vitest run packages/schemas`.
+
+## Risks & mitigations
+
+- **Catalog gains an import by accident** (breaks edge mirror + bare-checkout
+  generator). *Mitigation:* AC1's grep + the existing `edge-bare-specifier.spec.ts`;
+  keep `surfaces` plain data with string `handler`.
+- **Manifest drift undetected** (the classic "mock re-implements the thing").
+  *Mitigation:* AC4/AC10 make `--check` a CI gate; Verification step 7 proves the
+  gate bites; the manifest is *derived from* the catalog, and the spec compares
+  the hand-written dispatch to the manifest, never a re-encoded literal.
+- **Docs-drift on sibling surfaces** (lesson: grep sibling NAMES, not just the
+  command string). *Mitigation:* before claiming no doc drift, grep BOTH the new
+  names (`gen-surfaces`, `surface-manifest`) AND an existing sibling
+  (`sync-edge-schemas`) across `docs/`, `packages/cli/README.md`, bundled skill
+  rule files + their generated plugin mirrors, and root `CLAUDE.md`. Regenerate
+  any mirror with the repo's sync script — never hand-edit.
+- **`noUnusedParameters` / TS6133 build strictness** if a generated `.ts` is
+  added (the schemas package is type-checked). *Mitigation:* keep the generated
+  file free of unused locals; run `pnpm nx typecheck schemas` (or the repo's
+  typecheck target) before finishing.
+- **CLI is a published package** and may not resolve `@lorekit/schemas` at
+  runtime. *Mitigation:* D2 — the CLI reads a committed zero-dep `.mjs` manifest,
+  not the workspace package; dispatch stays hand-written and only *asserted*.
+- **Over-reach into option (B)** (rewriting dispatch source). *Mitigation:* this
+  plan is (A) only; if tempted, stop and re-plan.
+
+## Dependencies / ordering
+
+- **Precedes 3a, 3b, 3c, 3d.** All four Phase-3 plans perform their surface edits
+  *through* the `surfaces` bindings + manifest this plan introduces, so they are
+  one-edit-plus-regenerate changes instead of the 6-place ripple that got 3a
+  reverted before. Land Phase 2 first.
+- **Depends on** the removal branch's `surface-parity.spec.ts` (present on this
+  branch) — this plan absorbs and deletes it.
+- Independent of the removal-branch finalize plan
+  (`.agent/feat/api-token-scope-authorized-removal/…`), which can land in parallel.

--- a/docs/issues/api-token-surface-generator/plan-generator-phase3a-org-token-enablement.md
+++ b/docs/issues/api-token-surface-generator/plan-generator-phase3a-org-token-enablement.md
@@ -1,0 +1,241 @@
+# Plan — Generator Phase 3a: org tools for `lk_*` tokens (redo cleanly via the catalog)
+
+> **Plan-only artifact.** Nothing here is implemented. A fresh session executes it later.
+
+## Session bootstrap (read first)
+
+- **Worktree / cwd:** `/Users/mthines/Workspace/lorekit.git/feat/api-token-surface-generator`
+  (a `gw` worktree of `mthines/lorekit`). Do all work here. **Never** touch/`cd`/`gw clean` `…/main`.
+- **Branch:** `feat/api-token-surface-generator` (stack: → `feat/api-token-scope-authorized-removal` → `feat/combobox-multi-select`, PR #490). Confirm with `git branch --show-current`.
+- **First action:** verify anchors:
+  `ls supabase/functions/mcp/mcp-handler.ts supabase/functions/mcp/tools.ts packages/schemas/src/tool-catalog.ts packages/mcp-core/src/permissions.ts supabase/migrations/00041_org_actor_override.sql`.
+- **HARD DEPENDENCY:** Phase 2 (`plan-generator-phase2-codegen.md`) MUST already
+  be landed — this plan makes its change *through* the catalog `surfaces`/`auth`/
+  `permission` fields so it is one edit, not the 6-place ripple that got the
+  manual version reverted.
+
+## Context / background
+
+The MCP `org.create` / `org.list` / `org.rename` / `org.delete` tools are still
+**JWT-only**, even though the entire REST `/orgs*` surface already serves `lk_*`
+API tokens on every route.
+
+What already exists (do NOT re-plan):
+- `00041_org_actor_override.sql` added a trailing `p_actor_user_id uuid default
+  null` to 8 org RPCs, resolved via `lorekit_org_actor(p_actor_user_id)` =
+  `auth.role()='service_role' ? coalesce(p_actor_user_id, auth.uid()) : auth.uid()`.
+  An `authenticated` caller's `p_actor_user_id` is ignored; only a verified
+  service_role JWT may name an actor. Fails closed on NULL actor.
+- `supabase/functions/orgs/index.ts` serves `lk_*` tokens on **every** route with
+  `requires: 'read' | 'write'` (list/get = read; create/rename/delete/members/
+  invites mutations = write), each handler passing `p_actor_user_id: actorUserId(auth)`
+  and adding an explicit membership/tenant predicate where it used to lean on RLS.
+- `packages/cli/src/store/remote.mjs` already routes `orgCreate/orgList/orgRename/
+  orgDelete` through REST (`/orgs*`) — no MCP transport left in that store.
+
+What is STILL a gap:
+- `supabase/functions/mcp/mcp-handler.ts` rejects api_key callers for any tool in
+  `ORG_TOOLS` **before dispatch** (the `if (isOrgTool) { if (!isJwtAuth(auth)) …
+  JSONRPC_FORBIDDEN }` block). Org tools are dispatched `(db, args, span)` — no
+  `userId` is threaded to them.
+- `supabase/functions/mcp/tools.ts` `toolOrgCreate/Rename/Delete` call their RPCs
+  with NO `p_actor_user_id`, and `toolOrgList` does a direct
+  `.from('org_members').select('role, orgs(...)')` that relies on RLS — which is
+  bypassed for the service-role client an api_key caller gets, so it must be
+  scoped by `user_id` explicitly.
+- The catalog marks org tools `auth:'jwt-only'`, `permission:null`;
+  `permissions.ts` has no org entries; `tool-catalog-parity.spec.ts` asserts
+  `permission===null ⇒ auth==='jwt-only'`; `llms.txt` renders the JWT-only
+  footnote; the CLI local `mcp-server.mjs` `ORG_TOOL_DEFS` describe them.
+
+This exact change was prototyped and **REVERTED** off the removal branch because
+the manual version needed a 6-place ripple: catalog `auth`/`permission`,
+`permissions.ts`, the `tool-catalog-parity.spec.ts` model, the edge mirror,
+`llms.txt`, and docs. Phase 2's catalog surface bindings collapse that to one
+catalog edit + regenerate + the two edge behavioural edits (dispatcher gate +
+handler actor/scoping). This plan does it THAT way.
+
+### The target behaviour
+
+- `org.list` → `permission: 'read'` (a `lk_ro_*` or `lk_rw_*` token may list).
+- `org.create` / `org.rename` / `org.delete` → `permission: 'write'` (needs
+  `lk_wo_*`/`lk_rw_*`). Token permission is orthogonal to org role — a `lk_rw_*`
+  held by a viewer still cannot rename (the RPC's `lorekit_org_can` denies →
+  LK002 → forbidden). This mirrors the REST router's own note.
+- `auth: 'token-or-jwt'` for all four (JWT still works; api_key now also works).
+- Dispatcher passes the resolved `userId` (`getUserId(auth)`) to org tools so they
+  can send `p_actor_user_id: userId`. For a JWT caller `getUserId` is null and the
+  RPCs fall back to `auth.uid()` — unchanged behaviour.
+- `toolOrgList` must scope its `org_members` read by `user_id` for the api_key
+  (service-role) path, since RLS is bypassed. A JWT caller keeps RLS-only scoping.
+
+## Requirements
+
+- **R1** [user-stated] Drop the JWT-only gate on `org.*` in `mcp-handler.ts`.
+- **R2** [user-stated] Apply read/write permission: `org.list`=read; create/rename/delete=write — enforced by the same `toolRequires`/`canRead`/`canWrite` path the memory tools use.
+- **R3** [user-stated] Pass `p_actor_user_id: userId` from the org tool handlers to their RPCs.
+- **R4** [user-stated] Scope `toolOrgList`'s direct `org_members` read by `user_id` for api_key auth (service-role bypasses RLS); JWT auth stays RLS-scoped.
+- **R5** [user-stated] Do it THROUGH the Phase-2 catalog so it is ONE edit: change `surfaces`/`auth`/`permission` in `tool-catalog.ts`, regenerate the manifest + mirror + `llms.txt`, and every parity spec re-derives.
+- **R6** [user-stated] Update the catalog model + EVERY parity spec the change implies: the `permission===null ⇒ jwt-only` invariant in `tool-catalog-parity.spec.ts` must become "org tools carry a permission + `token-or-jwt`", and `permissions.ts` `READ_TOOLS`/`WRITE_TOOLS` gain the org entries.
+- **R7** [derived] Preserve `org.delete` MCP semantics (SOFT delete via `lorekit_org_delete`) and the `resolveOrgId` slug→id lookup; do not regress to the CLI `mcp-server.mjs` description that says "cascade-deleted / unrecoverable" (that text is already wrong vs the edge — flag it, see Risks).
+- **R8** [derived] The edge mirror (`_shared/schemas/tool-catalog.ts`, `mcp/permissions.ts`) stays byte-parity via the sync scripts.
+
+## Decisions (defaults chosen)
+
+- **D1 — org list = read, mutations = write.** Matches `orgs/index.ts` exactly
+  (`GET /`=read, `POST/PATCH/DELETE`=write). This is the authoritative source.
+- **D2 — dispatch signature.** Change `ORG_TOOLS` handlers to accept `userId`
+  (either `(db, args, userId, span)` to match the memory family, or keep
+  `(db, args, span)` and pass `userId` inside args-adjacent). Default: unify on
+  `(db, args, userId, span)` so both maps look alike and the dispatcher passes
+  `toolUserId`/`getUserId(auth)` uniformly. Update the `mcp-handler.ts` call site
+  and all four `toolOrg*` signatures + their RPC calls.
+- **D3 — `toolOrgList` scoping.** When `userId` is non-null (api_key), add
+  `.eq('user_id', userId)` to the `org_members` select. When null (JWT), leave it
+  RLS-scoped. Mirror the `applyTenantScope`/`memberOrgIds` posture already used by
+  the memory read tools. (There is no `applyTenantScope` for `org_members`; a
+  direct `.eq('user_id', userId)` is correct and is the same shape the REST
+  `_shared/api/tenant.ts` uses.)
+- **D4 — permission model in the catalog.** `org.list.permission='read'`,
+  others `'write'`; all four `auth='token-or-jwt'`. `McpToolPermission` already
+  allows `'read'|'write'|null` — org tools stop being `null`. The
+  `render.ts` `renderPermissionMatrix` filters `permission!==null`, so org tools
+  will now appear in the matrix rows; confirm the JWT-only footnote is removed or
+  reworded (they are no longer JWT-only). This is a deliberate `llms.txt` diff.
+
+## Acceptance criteria (verifiable)
+
+- **AC1** (covers R1) An api_key (`lk_rw_*`) `tools/call` for `org.list` is NOT
+  rejected by the dispatcher's org-JWT gate. The `if (!isJwtAuth(auth))` block for
+  org tools is removed/replaced by the memory-family permission check path.
+  - `kind: command`: `grep -n "org.* tools require Supabase JWT" supabase/functions/mcp/mcp-handler.ts` returns **nothing** (the JWT-only refusal string is gone).
+- **AC2** (covers R2, R6) `permissions.ts` gates the org tools: `org.list` in
+  `READ_TOOLS`, `org.create`/`org.rename`/`org.delete` in `WRITE_TOOLS`; and
+  `tool-catalog-parity.spec.ts` passes with the new model (org tools have a
+  permission + `token-or-jwt`).
+  - `kind: command`: `corepack pnpm exec vitest run packages/mcp-core/src/tool-catalog-parity.spec.ts packages/mcp-core/src/permissions.spec.ts` passes.
+- **AC3** (covers R3) All three write org handlers send `p_actor_user_id`.
+  - `kind: command`: `grep -nc "p_actor_user_id" supabase/functions/mcp/tools.ts` is ≥ 3 (create/rename/delete; list too if it moves to an RPC — default it stays a table read).
+- **AC4** (covers R4) `toolOrgList` scopes by `user_id` on the api_key path.
+  - `kind: command`: `grep -n "eq('user_id'" supabase/functions/mcp/tools.ts` shows a match inside `toolOrgList` (verify by reading the function body).
+- **AC5** (covers R5, R8) One catalog edit drives the rest; edge mirror + llms
+  regenerate cleanly.
+  - `kind: command`: `node scripts/sync-edge-schemas.mjs --check` exits 0.
+  - `kind: command`: `node scripts/gen-surfaces.mjs --check` exits 0.
+  - `kind: command`: `node --experimental-transform-types packages/schemas/src/llms/generate.ts --check` exits 0 AFTER regenerating (the permission-matrix change is committed).
+- **AC6** (covers R2/R7 — behavioural) A SQL test section proves the org RPCs
+  honour a service-role actor override end-to-end: an `lk_*`-shaped call (service
+  role + `p_actor_user_id`) can `org.list`/`create`/`rename`/`delete` as that
+  actor, and a viewer-role actor is denied `rename` (LK002). Add
+  `migrations.test.sql` §85 (org actor via api_key surface).
+  - `kind: command`: run the isolated-stack SQL harness (see Verification) and confirm §85 passes.
+- **AC7** (covers R6) `mcp-authz-status.spec.ts` / `mcp-auth-tracing.spec.ts`
+  still pass (the org tools now emit the same authz spans as memory tools).
+  - `kind: command`: `corepack pnpm exec vitest run packages/mcp-core/src/mcp-authz-status.spec.ts packages/mcp-core/src/mcp-auth-tracing.spec.ts` passes.
+- **AC8** (covers R7) `org.delete` MCP path still calls `lorekit_org_delete`
+  (SOFT delete) and resolves slug→id first.
+  - `kind: command`: `grep -n "lorekit_org_delete\|resolveOrgId" supabase/functions/mcp/tools.ts` shows both in `toolOrgDelete`.
+- **AC9** (regression) The CLI `mcp-server.mjs` org passthrough still works and
+  the four org tools are still advertised; CLI suite green.
+  - `kind: command`: `node --test packages/cli/test/mcp-server.test.mjs` passes.
+
+## File changes (concrete paths)
+
+- **Edit** `packages/schemas/src/tool-catalog.ts` — the ONE conceptual edit:
+  set `org.list` `permission:'read'`, `org.create/rename/delete` `permission:'write'`,
+  all four `auth:'token-or-jwt'`; update their `surfaces` (Phase 2) if the binding
+  encodes auth. Reword the org-tool descriptions if they claim JWT-only.
+- **Edit** `packages/mcp-core/src/permissions.ts` — add `org.list` to `READ_TOOLS`,
+  `org.create`/`org.rename`/`org.delete` to `WRITE_TOOLS`. Update the docblock.
+- **Edit** `supabase/functions/mcp/permissions.ts` (mirror) — via
+  `node scripts/sync-edge-schemas.mjs`? NO — `permissions.ts` is a MANUAL mirror
+  (`limits.ts`/`created-at.ts` pattern, not the schema sync). Edit it by hand to
+  match, keep `edge-parity.spec.ts` green.
+- **Edit** `supabase/functions/mcp/mcp-handler.ts`:
+  - Remove the `isOrgTool` JWT-only refusal block.
+  - Route org tools through the same `toolRequires`/`canRead`/`canWrite` permission
+    check as memory tools (org tools now have a non-null `toolRequires`).
+  - Pass `toolUserId` (`getUserId(auth)`) into the `ORG_TOOLS[...]` call (D2).
+  - Keep the scope-allowlist / account-wide refusal path memory-only (org tools
+    carry no scope; ensure the scope checks are guarded so they don't run for org
+    tools — they key off `toolArgs['scope']`/`scopes`, which org tools don't send,
+    so they are inert, but confirm).
+- **Edit** `supabase/functions/mcp/tools.ts`:
+  - `toolOrgCreate/Rename/Delete`: accept `userId`, pass `p_actor_user_id: userId`
+    to `lorekit_org_create` / `lorekit_org_rename` / `lorekit_org_delete`.
+  - `toolOrgList`: accept `userId`; when non-null, `.eq('user_id', userId)` on the
+    `org_members` select.
+  - Update the file header comment that says org tools "REQUIRE a Supabase user
+    JWT … receive -32001" — no longer true.
+- **Edit** `packages/mcp-core/src/tool-catalog-parity.spec.ts` — replace the
+  `permission===null ⇒ auth==='jwt-only'` invariant with the new one (org tools
+  have a permission + `token-or-jwt`); ensure the read/write set assertions include
+  the org tools. (If Phase 2 moved these to a manifest spec, edit there.)
+- **Edit** `packages/schemas/src/llms/render.spec.ts` — update expectations if the
+  permission matrix / footnote text changed.
+- **Regenerate** `packages/web/public/llms.txt` (`generate.ts`), the surface
+  manifest (`gen-surfaces.mjs`), and the edge mirror (`sync-edge-schemas.mjs`).
+- **Edit** `packages/cli/src/mcp-server.mjs` — reword `ORG_TOOL_DEFS` descriptions
+  that say "require JWT auth" / "cascade-deleted / unrecoverable" to match reality
+  (soft delete; token-or-jwt). Keep dispatch unchanged (still proxies to REST).
+- **Add** `supabase/tests/migrations.test.sql` §85 — org actor override via the
+  service-role + `p_actor_user_id` path (AC6). Seed `auth.users` a1/b2/c3 + an org;
+  assert list/create/rename/delete as actor, and a viewer denied rename.
+- **Docs:** `docs/org-sharing.md`, `docs/mcp-tools.md`, `docs/api-tokens.md`,
+  `docs/architecture.md`, `docs/decisions.md`, `packages/web/public/llms.txt`
+  (generated) — update any statement that `org.*` is JWT-only. Run the sibling-name
+  docs-drift greps (Risks) before claiming done.
+
+## Verification
+
+Run from the worktree root. No `timeout` on macOS.
+
+1. Static/parity: `corepack pnpm exec vitest run packages/mcp-core/src/tool-catalog-parity.spec.ts packages/mcp-core/src/permissions.spec.ts packages/mcp-core/src/edge-parity.spec.ts packages/mcp-core/src/edge-schema-parity.spec.ts packages/mcp-core/src/mcp-authz-status.spec.ts packages/mcp-core/src/mcp-auth-tracing.spec.ts` — all green.
+2. Regenerate + check: `node scripts/sync-edge-schemas.mjs --check`, `node scripts/gen-surfaces.mjs --check`, `node --experimental-transform-types packages/schemas/src/llms/generate.ts --check`.
+3. CLI: `node --test packages/cli/test/mcp-server.test.mjs`.
+4. **SQL (isolated stack, MANDATORY for AC6)** — the removal-branch pattern:
+   - Edit `supabase/config.toml` ports by +100 (studio/api/db/etc.) so this run
+     never disturbs another worktree's stack.
+   - `supabase start -x studio,imgproxy,storage-api,realtime,edge-runtime,logflare,vector,pooler,inbucket`
+   - `supabase db reset`
+   - `psql "$DB_URL" -v ON_ERROR_STOP=1 -f supabase/tests/migrations.test.sql`
+     (DB_URL from `supabase status`). Expect §85 to pass. NOTE the pre-existing,
+     unrelated failure around `migrations.test.sql` ~line 2685 (an anon-grant
+     assertion on `lorekit_org_members_list` from PR #266) — CI runs green;
+     verify §85 specifically rather than trusting a clean overall exit.
+   - `supabase stop` and `git checkout supabase/config.toml` to restore ports.
+5. Edge Deno type/lint runs in CI (no local Deno harness assumed). Rely on CI for
+   the `supabase/functions/**` Deno checks; do a manual read-through of
+   `tools.ts`/`mcp-handler.ts` diffs for `noUnusedParameters`-style issues.
+
+## Risks & mitigations
+
+- **Reintroducing the 6-place ripple / partial edit** (the reason this was
+  reverted). *Mitigation:* Phase-2 dependency is hard; drive from the catalog and
+  regenerate; the parity specs (AC2/AC5) fail if any surface is missed.
+- **`toolOrgList` cross-tenant leak** — forgetting `.eq('user_id', userId)` on the
+  service-role path would list every org's memberships. *Mitigation:* AC4 grep +
+  AC6 SQL test with two users; read the function body to confirm the predicate is
+  reachable (not returned-around).
+- **Permission-matrix / footnote diff in `llms.txt`** surprising a reviewer.
+  *Mitigation:* it is intended; call it out in the PR body and update
+  `render.spec.ts` expectations (AC5).
+- **CLI `mcp-server.mjs` description drift** — it currently claims org tools need
+  JWT and that delete is a hard cascade. *Mitigation:* R7/AC-file-change reword;
+  do not leave contradictory copy (lesson:
+  `instruction-file-fixes-contradict-siblings-not-opened-in-the-same-edit` — open
+  every file that states the org-auth fact in the same edit).
+- **Scope-allowlist path accidentally applied to org tools** in the dispatcher.
+  *Mitigation:* org tools send no `scope`/`scopes`, so the checks are inert, but
+  guard the branch explicitly (org tools skip the memory scope/account-wide block).
+- **Docs-drift on sibling surfaces.** *Mitigation:* grep the sibling terms
+  (`org.list`, `jwt-only`, "dashboard session") across `docs/`, `README.md`,
+  bundled skill rule files + generated plugin mirrors, root `CLAUDE.md`; regenerate
+  mirrors with the sync script.
+
+## Dependencies / ordering
+
+- **Depends on Phase 2** (catalog surface bindings + `gen-surfaces.mjs` + manifest
+  gate). Do not start 3a until Phase 2 is green.
+- Independent of 3b/3c/3d, but 3b (members + invites) shares the "org tools now
+  serve tokens" premise — land 3a first so 3b builds on token-capable org tooling.

--- a/docs/issues/api-token-surface-generator/plan-generator-phase3b-org-members-invites.md
+++ b/docs/issues/api-token-surface-generator/plan-generator-phase3b-org-members-invites.md
@@ -1,0 +1,256 @@
+# Plan — Generator Phase 3b: org members + invites on MCP + CLI
+
+> **Plan-only artifact.** Nothing here is implemented. A fresh session executes it later.
+
+## Session bootstrap (read first)
+
+- **Worktree / cwd:** `/Users/mthines/Workspace/lorekit.git/feat/api-token-surface-generator`
+  (`gw` worktree of `mthines/lorekit`). Do all work here. **Never** touch/`cd`/`gw clean` `…/main`.
+- **Branch:** `feat/api-token-surface-generator` (stack → `…-scope-authorized-removal` → `feat/combobox-multi-select`, PR #490). Confirm with `git branch --show-current`.
+- **First action:** verify anchors:
+  `ls supabase/functions/orgs/handlers/members/ supabase/functions/orgs/handlers/invites/ supabase/functions/mcp/tools.ts packages/schemas/src/tool-catalog.ts packages/schemas/src/member.ts packages/schemas/src/invite.ts`.
+- **DEPENDENCIES:** land **Phase 2** (catalog surface bindings + generator) and
+  **Phase 3a** (org tools serve tokens) first. This plan adds *new* org
+  sub-resource tools/commands and assumes the token-capable org surface from 3a.
+
+## Context / background
+
+The REST `orgs` function already exposes org MEMBERS and INVITES sub-resources,
+and all serve `lk_*` tokens (via `actorUserId(auth)` + explicit membership gates,
+per `00041` + `orgs/index.ts`):
+
+- **Members:** `GET /:slug/members` (`handleListMembers` → RPC
+  `lorekit_org_members_list`), `PATCH /:slug/members/:userId` (`handleChangeRole`
+  → RPC `lorekit_org_member_role`, body `{ role }`), `DELETE /:slug/members/:userId`
+  (`handleRemoveMember` → RPC `lorekit_org_member_remove`, or `lorekit_org_leave`
+  for self). Response shapes: list → `{ entries: [{ user_id, handle, avatar_url,
+  role, joined_at }] }`; change-role → `{ slug, userId, role }`; remove → 204.
+- **Invites:** `GET /:slug/invites` (`handleListInvites` → direct `org_invites`
+  select, gated on the `invite` capability; a plain member gets `{ entries: [] }`),
+  `POST /:slug/invites` (`handleCreateInvite` → RPC `lorekit_org_invite`, body
+  `CreateInviteBodySchema` = `{ email?, handle?, role }` with exactly one of
+  email/handle, role excludes `owner`, default `member`; returns
+  `{ inviteId }`), `DELETE /:slug/invites/:inviteId` (`handleRevokeInvite` → RPC
+  `lorekit_org_invite_revoke`). Response shapes from `packages/schemas/src/member.ts`
+  (`OrgMemberListResponseSchema`) and `invite.ts` (`OrgInviteListResponseSchema`,
+  `CreateInviteBodySchema`).
+
+There are **no MCP tools and no CLI subcommands** for members or invites today.
+`rest-tool-name.ts` already names these routes with the `member.*` audit-action
+vocabulary (`member.role_change`, `member.remove`, `member.invite`,
+`member.revoke`) — there is a naming precedent to reuse.
+
+**Known safe RPC invariants (already enforced server-side, do not re-implement):**
+- Admin cannot act on owner/admin targets; last owner cannot be removed/demoted;
+  owner role is non-assignable via change-role (v1); revoke only a pending invite.
+- Self-removal via API token currently fails closed (LK002/403) because
+  `lorekit_org_leave` got no actor override in 00041 — a documented gap, not a bug
+  to fix here.
+
+## BLAST-RADIUS FLAG (user-requested — resolve explicitly)
+
+These operations let an autonomous agent holding an `lk_rw_*` token **remove org
+members and revoke invites** — destructive, people-facing, and easy to trigger by
+mistake from a agent loop. This is materially higher-stakes than memory CRUD.
+The plan MUST decide a guard posture, not silently ship parity:
+
+- **Reads** (`org.members.list`, `org.invites.list`) — low risk; ship as normal
+  `read`-permission tools/commands.
+- **Additive writes** (`org.invite`) — medium risk; ship as `write`, but with
+  clear tool descriptions.
+- **Destructive writes** (`org.member.remove`, `org.member.set_role`,
+  `org.invite.revoke`) — HIGH risk. **Default recommendation:** gate them behind
+  an explicit opt-in so they are NOT reachable by default:
+  - **MCP:** keep them OFF the default catalog OR mark them with a new
+    `surfaces` flag (Phase 2) `dangerous: true` and require a server-side env/flag
+    (e.g. `LOREKIT_ENABLE_ORG_MEMBER_WRITES`) checked in the dispatcher; absent →
+    the tool is not advertised in `tools/list` and `tools/call` returns a clear
+    "disabled" error.
+  - **CLI:** require an interactive confirmation (a `y/N` prompt) unless `--yes`
+    is passed, mirroring `migrate`'s dry-run-by-default posture. `--json`/non-TTY
+    without `--yes` refuses rather than auto-confirming.
+  - The RPC invariants (last-owner, admin-vs-owner) are the backstop, but the
+    opt-in is the "an agent should not remove a teammate on a whim" guard.
+
+If the executor (or user) decides parity-without-opt-in is acceptable, that is a
+conscious choice to record in the plan's Decisions + PR body — do not default to it.
+
+## Requirements
+
+- **R1** [user-stated] New MCP tools + CLI commands for **members**: list,
+  change-role, remove.
+- **R2** [user-stated] New MCP tools + CLI commands for **invites**: list, create,
+  revoke.
+- **R3** [user-stated] Built over the EXISTING REST/RPC surface — no new
+  migrations, no new RPCs, no new REST routes. The CLI store calls `/orgs/:slug/*`;
+  the MCP tools call the same RPCs the REST handlers call (or, simpler and
+  drift-free, the MCP tools call the REST routes via the same client the org tools
+  use — decide in D2).
+- **R4** [user-stated] FLAG the blast radius and propose a guard/opt-in for the
+  destructive ops (see the section above). The plan's Decisions must record the
+  chosen posture.
+- **R5** [derived] Do it THROUGH the Phase-2 catalog: new tools get `surfaces`
+  bindings; the completeness gate + `permissions.ts` + edge mirror + `llms.txt`
+  re-derive.
+- **R6** [derived] Reuse the `member.*` naming from `rest-tool-name.ts` /
+  audit-log actions; do not invent a third vocabulary.
+- **R7** [derived] Response shapes match the schemas (`member.ts`, `invite.ts`);
+  the CLI `--json` output and the MCP `tools/call` payload must be a published,
+  stable shape (the same discipline `remote.mjs` org methods follow).
+
+## Decisions (defaults chosen — CONFIRM before coding)
+
+- **D1 — tool names.** MCP: `org.members.list`, `org.members.set_role`,
+  `org.members.remove`, `org.invites.list`, `org.invites.create`,
+  `org.invites.revoke`. (Dot-hierarchical, consistent with `memory.list_archived`
+  style; the parity spec's dispatch-map regex `'([a-z_]+\.[a-z_]+)'` currently
+  matches ONE dot — a three-segment `org.members.list` will NOT match it, so the
+  regex in `tool-catalog-parity.spec.ts`/`surface-manifest-parity.spec.ts` must be
+  widened to `[a-z_]+(?:\.[a-z_]+)+`. Flag this in the file-changes.) Alternative:
+  flat `org.member_list` etc. to avoid the regex change — decide D1 explicitly.
+- **D2 — MCP handler implementation.** Two options:
+  - **(a)** New `toolOrgMembersList` etc. in `supabase/functions/mcp/tools.ts`
+    calling the SAME RPCs the REST handlers call (`lorekit_org_members_list`,
+    `lorekit_org_member_role`, `lorekit_org_member_remove`, `lorekit_org_invite`,
+    `lorekit_org_invite_revoke`) + the direct `org_invites` select for list, each
+    passing `p_actor_user_id: userId` and the membership gate. Most faithful; more
+    code duplicated from the REST handlers.
+  - **(b)** MCP tools proxy to the REST routes via a service-side fetch. Rejected —
+    the edge function calling its own sibling function over HTTP is fragile.
+  - **Default: (a).** Mirror the REST handlers' logic (slug→org_id lookup,
+    `isOrgMember` gate, `hasOrgCapability` for invite list, RPC call, audit).
+    Extract the shared slug→id + membership-gate helper if it reduces the copy.
+- **D3 — destructive-op guard.** Default: opt-in per the BLAST-RADIUS section
+  (env flag for MCP dispatch; `--yes` confirmation for CLI). Record the decision.
+- **D4 — CLI command surface.** Add a `lorekit org` command group:
+  `lorekit org members [--org <slug>]`, `lorekit org set-role <slug> <userId> <role>`,
+  `lorekit org remove-member <slug> <userId>`, `lorekit org invites <slug>`,
+  `lorekit org invite <slug> --email|--handle <x> [--role member]`,
+  `lorekit org revoke-invite <slug> <inviteId>`. OR flat top-level commands. Decide
+  D4; default is a nested `org` group to avoid polluting the top-level command
+  namespace. Whichever is chosen must round-trip through the manifest gate (a nested
+  group changes how `surface-manifest-parity.spec.ts` matches CLI commands — Phase 2's
+  gate assumed one `switch` `case` per command; a subcommand group needs the gate
+  taught about it).
+- **D5 — self-removal.** MCP/CLI `remove-member` targeting yourself hits the
+  `lorekit_org_leave` gap (403 under a token). Surface the server's error verbatim;
+  do NOT special-case it. Document as a known gap (follow-up: give
+  `lorekit_org_leave` an actor override — separate migration).
+
+## Acceptance criteria (verifiable)
+
+- **AC1** (covers R1, R2, R5) The six new tools exist in the catalog with
+  `surfaces` bindings and correct `permission` (list=read; create/set_role/remove/
+  revoke=write) and `auth:'token-or-jwt'`; the completeness/manifest gate passes.
+  - `kind: command`: `corepack pnpm exec vitest run packages/mcp-core/src/tool-catalog-parity.spec.ts packages/mcp-core/src/permissions.spec.ts` passes (with the widened multi-dot regex if D1 chose dotted names).
+- **AC2** (covers R1, R2, D2) The edge dispatch map `ORG_TOOLS` gains the six
+  handlers, and `tool-catalog-parity.spec.ts`'s catalog↔dispatch assertion passes.
+  - `kind: command`: `grep -nE "org\.(members|invites)\." supabase/functions/mcp/mcp-handler.ts` shows all six mapped.
+- **AC3** (covers R6) The MCP handlers + CLI store map to the `member.*` audit
+  vocabulary / `rest-tool-name.ts` names; `rest-tool-name.spec.ts` still passes.
+  - `kind: command`: `corepack pnpm exec vitest run packages/mcp-core/src/rest-tool-name.spec.ts` passes.
+- **AC4** (covers R3, R7) The CLI store methods exist on `remote.mjs`
+  (`orgMembersList`, `orgMemberSetRole`, `orgMemberRemove`, `orgInvitesList`,
+  `orgInviteCreate`, `orgInviteRevoke`) calling `/orgs/:slug/*` with
+  `encodeURIComponent` on path segments, returning the published `{ ok, ... }`
+  shapes; a CLI test covers each against a mocked REST layer.
+  - `kind: command`: `node --test packages/cli/test/org.test.mjs` (new) passes.
+- **AC5** (covers R4, D3) The destructive ops honour the guard: MCP tools are
+  absent from `tools/list` (or return a disabled error) unless the opt-in flag is
+  set; CLI destructive commands refuse without `--yes` in non-interactive mode.
+  - `kind: command`: a CLI test asserts `org remove-member … --json` (non-TTY, no
+    `--yes`) exits non-zero with a "confirmation required" message; and with
+    `--yes` it proceeds (mocked).
+  - `kind: command`: an MCP-handler or mcp-server test asserts the destructive
+    tool is not advertised without the flag (whichever surface enforces it).
+- **AC6** (covers R1, R2 — behavioural) SQL test §86 (org members/invites via the
+  service-role + actor path): seed an org with owner a1 + member b2; assert list
+  members, set b2→admin, invite by email, list invites (owner sees it, plain
+  member sees empty), revoke invite, remove b2; and assert admin-vs-owner and
+  last-owner invariants still deny.
+  - `kind: command`: isolated-stack SQL harness passes §86 (see Verification).
+- **AC7** (covers R5) `node scripts/gen-surfaces.mjs --check`,
+  `node scripts/sync-edge-schemas.mjs --check`, and
+  `node --experimental-transform-types packages/schemas/src/llms/generate.ts --check`
+  all exit 0 after regeneration.
+- **AC8** (covers R7) The CLI local `mcp-server.mjs` advertises + dispatches the
+  new tools (proxying to the new `remote.mjs` methods), and its test passes.
+  - `kind: command`: `node --test packages/cli/test/mcp-server.test.mjs` passes.
+
+## File changes (concrete paths)
+
+- **Edit** `packages/schemas/src/tool-catalog.ts` — six new `McpToolDoc` entries
+  with `surfaces` bindings, permissions, `token-or-jwt`, and (for destructive)
+  the `dangerous`/opt-in flag if D3 adds one to the binding shape.
+- **Edit** `packages/mcp-core/src/permissions.ts` (+ manual mirror
+  `supabase/functions/mcp/permissions.ts`) — add the six to READ/WRITE sets.
+- **Edit** `supabase/functions/mcp/mcp-handler.ts` — add six entries to `ORG_TOOLS`,
+  thread `userId`, and (D3) the opt-in gate for the destructive three.
+- **Edit** `supabase/functions/mcp/tools.ts` — six new `toolOrg*` handlers (D2a),
+  mirroring the REST handlers' slug→id + membership-gate + RPC-call + audit logic.
+  Consider a shared `resolveOrgIdForActor`/`requireMembership` helper.
+- **Edit** `packages/cli/src/store/remote.mjs` — six new methods over `/orgs/:slug/*`.
+- **Add** `packages/cli/src/org.mjs` — the `org` command group (D4) with the
+  `--yes` confirmation for destructive ops.
+- **Edit** `packages/cli/bin/lorekit.mjs` — register the `org` command (dispatch +
+  `HUMAN_COMMANDS` + `KNOWN_FLAGS` for `--role`/`--email`/`--handle`/`--invite-id` +
+  `HELP`/`COMMAND_HELP` entry + `traceCommand` wrap).
+- **Edit** `packages/cli/src/mcp-server.mjs` — add the six to `ORG_TOOL_DEFS` +
+  `ORG_DISPATCH` (proxy to the new `remote.mjs` methods).
+- **Edit** `packages/mcp-core/src/tool-catalog-parity.spec.ts` (or the Phase-2
+  manifest spec) — widen the dispatch-map name regex to multi-dot if D1 chose
+  dotted names; extend the CLI-command assertion for the `org` subcommand group.
+- **Add** `packages/cli/test/org.test.mjs` — CLI command + store coverage (AC4,
+  AC5).
+- **Add** `supabase/tests/migrations.test.sql` §86 (AC6).
+- **Regenerate** `packages/web/public/llms.txt`, the surface manifest, the edge
+  mirror.
+- **Docs:** `docs/org-sharing.md` (members/invites via CLI/MCP), `docs/mcp-tools.md`,
+  `docs/cli.md`, `docs/api-tokens.md` (the opt-in flag), `packages/cli/README.md`,
+  `packages/web/public/llms.txt` (generated). Run sibling-name docs-drift greps.
+
+## Verification
+
+Run from the worktree root. No `timeout` on macOS.
+
+1. `corepack pnpm exec vitest run packages/mcp-core/src/tool-catalog-parity.spec.ts packages/mcp-core/src/permissions.spec.ts packages/mcp-core/src/rest-tool-name.spec.ts packages/mcp-core/src/edge-parity.spec.ts packages/mcp-core/src/edge-schema-parity.spec.ts` — green.
+2. `node --test packages/cli/test/org.test.mjs packages/cli/test/mcp-server.test.mjs packages/cli/test/cli.test.mjs` — green.
+3. Regenerate + `--check`: `gen-surfaces.mjs`, `sync-edge-schemas.mjs`, `generate.ts`.
+4. **SQL isolated stack (AC6):** same recipe as Phase 3a's plan — config.toml
+   ports +100, `supabase start -x …`, `supabase db reset`, `psql -f
+   supabase/tests/migrations.test.sql`, confirm §86, `supabase stop`, restore
+   config. Watch the pre-existing ~line-2685 failure (unrelated).
+5. **Guard-bites proof** for AC5: confirm the destructive-op refusal actually
+   fires (flip the opt-in flag / drop `--yes`) and that removing the guard flips
+   the test — do not commit the perturbation.
+6. Edge Deno checks: rely on CI; read-through the `tools.ts`/`mcp-handler.ts`
+   diffs for unused-param / type issues.
+
+## Risks & mitigations
+
+- **Destructive op triggered by an agent** (the flagged blast radius).
+  *Mitigation:* D3 opt-in + `--yes`; RPC invariants as backstop; AC5 proves the
+  guard bites.
+- **Multi-dot tool names break the dispatch-map regex** silently (the parity gate
+  would stop matching the new tools and pass vacuously). *Mitigation:* widen the
+  regex AND keep/raise the anti-vacuity `toBeGreaterThanOrEqual(N)` count in
+  `tool-catalog-parity.spec.ts` so a regex that matches nothing fails.
+- **Duplicating REST-handler logic in `tools.ts`** drifts from the REST behaviour
+  (membership gate, capability gate for invite-list). *Mitigation:* extract shared
+  helpers where possible; §86 SQL test exercises both the allow and deny paths;
+  keep the `invite`-capability empty-list behaviour identical (a plain member sees
+  `{ entries: [] }`, not a 403).
+- **Self-removal 403 confuses users.** *Mitigation:* D5 — surface the server error
+  verbatim, document the `lorekit_org_leave` follow-up.
+- **CLI subcommand group breaks the Phase-2 manifest gate's one-case-per-command
+  assumption.** *Mitigation:* teach the gate about the `org` group (D4) in the same
+  edit; do not leave the gate asserting against a model it no longer matches.
+- **Docs-drift on sibling surfaces.** *Mitigation:* grep sibling names
+  (`org.create`, `member.`, "invite") across all doc/skill/mirror surfaces before
+  claiming done.
+
+## Dependencies / ordering
+
+- **Depends on Phase 2 AND Phase 3a.** 3a makes the org surface token-capable;
+  this adds sub-resources on top. Do not start before both are green.
+- Independent of 3c/3d.

--- a/docs/issues/api-token-surface-generator/plan-generator-phase3c-cli-purge.md
+++ b/docs/issues/api-token-surface-generator/plan-generator-phase3c-cli-purge.md
@@ -1,0 +1,195 @@
+# Plan — Generator Phase 3c: CLI `purge` / `purge-expired`
+
+> **Plan-only artifact.** Nothing here is implemented. A fresh session executes it later.
+
+## Session bootstrap (read first)
+
+- **Worktree / cwd:** `/Users/mthines/Workspace/lorekit.git/feat/api-token-surface-generator`
+  (`gw` worktree of `mthines/lorekit`). Do all work here. **Never** touch/`cd`/`gw clean` `…/main`.
+- **Branch:** `feat/api-token-surface-generator` (stack → `…-scope-authorized-removal` → `feat/combobox-multi-select`, PR #490). Confirm with `git branch --show-current`.
+- **First action:** verify anchors:
+  `ls packages/cli/bin/lorekit.mjs packages/cli/src/store/remote.mjs supabase/functions/memories/handlers/purge.ts packages/mcp-core/src/account-wide-tools.ts packages/schemas/src/tool-catalog.ts`.
+- **DEPENDENCY:** land **Phase 2** first (this adds the two CLI commands through
+  the catalog `surfaces` bindings so the manifest gate closes the KNOWN-GAP
+  exemptions instead of leaving them hand-written).
+
+## Context / background
+
+`memory.purge` and `memory.purge_expired` exist on MCP (`toolPurge`,
+`toolPurgeExpired`) and on REST (`POST /memories/purge`, `POST
+/memories/purge-expired` — `handlePurge`/`handlePurgeExpired`). There is **no CLI
+subcommand** for either. Phase 1's `surface-parity.spec.ts` records both as
+explicit `{ exempt: 'KNOWN GAP — … slated for the generator' }` entries; Phase 2
+carries them forward as `cliExempt` in the catalog `surfaces` binding. This plan
+closes both gaps.
+
+Key facts:
+- REST contract (`handlers/purge.ts`): `POST /memories/purge` takes an optional
+  body validated by `PurgeMemoriesBodySchema` (`{ retention_days }`, 1–365,
+  default 30 via the schema — over HTTP an out-of-range value is a 4xx, not a
+  silent clamp). `POST /memories/purge-expired` takes no body. Both return
+  `{ purged: <number> }`. Both are rate-limited (429) and support the dry-run
+  header. Both require a user-scoped credential (service-role → 403).
+- **Account-wide refusal (PRESERVE):** both endpoints call
+  `refuseAccountWideSweep(auth, 'memory.purge'|'memory.purge_expired', …)`, which
+  uses `isRefusedForScopedKey` from `_shared/account-wide-tools.ts`. A token with a
+  non-empty scope allowlist gets a 403 — account-wide sweeps are refused for
+  scoped keys. The CLI must NOT try to work around this; it just surfaces the
+  server's 403.
+- The CLI `remote.mjs` store has **no** `purge`/`purgeExpired` method yet. It must
+  gain them, calling `POST /memories/purge` and `/purge-expired`.
+- **Local store:** does the offline `.lorekit/` store support purge? Check
+  `packages/cli/src/store/local.mjs`. Purge = permanently delete archived rows
+  older than N days (and TTL-expired rows). The local store has archive/TTL
+  semantics for some ops; decide whether `lorekit purge` supports `--local` or is
+  remote-only. Default: purge is a **remote** maintenance op (the RPCs are
+  user-scoped server state); a `--local` purge is only meaningful if the local
+  store tracks `archived_at`/`expires_at` — confirm and, if not cheaply
+  supportable, make purge remote-only with a clear message on `--local` (mirror
+  how `bootstrap`/`migrate --to remote` are remote-only).
+
+## Requirements
+
+- **R1** [user-stated] Wire `lorekit purge` and `lorekit purge-expired`
+  subcommands over the existing REST `/purge` / `/purge-expired` routes.
+- **R2** [user-stated] Preserve the account-wide refusal for scoped keys — a
+  scoped `lk_*` token running `lorekit purge` gets the server's 403 surfaced
+  clearly, never silently downgraded or worked around.
+- **R3** [user-stated] Do it THROUGH the Phase-2 catalog: flip the two
+  `cliExempt` KNOWN-GAP bindings to real CLI commands (`purge`, `purge-expired`),
+  regenerate the manifest, and let the completeness gate confirm the exemptions
+  are gone.
+- **R4** [derived] `purge` accepts `--retention-days <1..365>` (default 30,
+  matching `PURGE_RETENTION_DAYS_DEFAULT`); `purge-expired` takes no options.
+- **R5** [derived] Both are destructive + irreversible — apply a confirmation
+  guard: dry-run/confirm by default, `--yes` to apply, `--json` for scripting.
+  Mirror `migrate`'s posture (dry-run default, `--yes`/`--apply` to write).
+- **R6** [derived] Telemetry inheritance: both commands dispatch via
+  `traceCommand` like every other human command (Phase-2 R6 guard covers this).
+
+## Decisions (defaults chosen — CONFIRM)
+
+- **D1 — confirmation posture.** Default: `purge`/`purge-expired` PROMPT for
+  confirmation (`y/N`) in an interactive TTY and REQUIRE `--yes` in
+  non-interactive / `--json` mode (refuse otherwise). This matches the "destructive
+  op should not fire from an agent loop unattended" posture and `migrate`'s
+  dry-run-by-default. Alternative: dry-run-by-default (show "would purge N")
+  needs a count endpoint the API may not expose — the purge RPCs return the count
+  only AFTER deleting, so a true dry-run count is not available; therefore go with
+  the confirm-or-`--yes` gate, not a dry-run preview. (The REST dry-run header
+  stops before the write and returns nothing useful to preview, so it is not the
+  right primitive for a CLI preview.)
+- **D2 — remote-only vs `--local`.** Default: remote-first like `write`
+  (remote when usable, else a clear message). Support `--local` only if
+  `local.mjs` already tracks archived/expired rows cheaply; otherwise `--local`
+  prints "purge is a remote maintenance operation" and exits non-zero. Confirm by
+  reading `local.mjs` before deciding.
+- **D3 — command names + aliases.** `purge` and `purge-expired` (hyphenated,
+  matching the REST route + `rest-tool-name.ts` `memory.purge_expired`). No
+  aliases. These are new `HUMAN_COMMANDS`.
+- **D4 — scoped-key 403 UX.** On a 403 with the account-wide refusal message,
+  print the server's message verbatim plus a one-line hint ("use an unscoped
+  token for maintenance sweeps") — do not translate it into a generic error.
+
+## Acceptance criteria (verifiable)
+
+- **AC1** (covers R1, R3) The catalog `surfaces` bindings for `memory.purge` /
+  `memory.purge_expired` now name real CLI commands (`purge`, `purge-expired`),
+  the `cliExempt` KNOWN-GAP reasons are gone, and the Phase-2 completeness/manifest
+  gate passes with no exemption for these two.
+  - `kind: command`: `corepack pnpm exec vitest run packages/mcp-core/src/tool-catalog-parity.spec.ts` passes.
+  - `kind: command`: `grep -n "KNOWN GAP" packages/schemas/src/tool-catalog.ts` no longer matches the purge bindings.
+- **AC2** (covers R1) `bin/lorekit.mjs` dispatches both: `case 'purge'` and
+  `case 'purge-expired'` exist, both in `HUMAN_COMMANDS`, both wrapped in
+  `traceCommand`.
+  - `kind: command`: `grep -nE "case 'purge(-expired)?':" packages/cli/bin/lorekit.mjs` shows both.
+- **AC3** (covers R1, R4) `remote.mjs` has `purge({ retentionDays })` and
+  `purgeExpired()` calling `POST /memories/purge` (with `{ retention_days }` when
+  provided) and `POST /memories/purge-expired`, returning `{ ok, purged, error,
+  networkError, httpStatus }`.
+  - `kind: command`: `node --test packages/cli/test/purge.test.mjs` (new) passes, covering: success returns purged count; 403 account-wide refusal surfaced; 429 rate-limit surfaced; retention-days passthrough.
+- **AC4** (covers R2, D4) A scoped-key 403 is surfaced with the server's
+  account-wide-refusal message, not a generic failure.
+  - `kind: command`: the `purge.test.mjs` case for a mocked 403 asserts the printed/`--json` error contains the refusal message text.
+- **AC5** (covers R5, D1) Destructive-confirm guard: `purge`/`purge-expired`
+  without `--yes` in non-interactive/`--json` mode refuse; with `--yes` they
+  proceed (mocked).
+  - `kind: command`: `purge.test.mjs` asserts the refuse-without-`--yes` and
+    proceed-with-`--yes` branches.
+- **AC6** (covers R4) `--retention-days` is validated 1–365 (reject out of range
+  with an actionable error before any request); default 30.
+  - `kind: command`: `purge.test.mjs` asserts `--retention-days 0` and `400` are rejected client-side, and the default is 30.
+- **AC7** (regression) Full CLI suite green:
+  `node --test packages/cli/test/*.test.mjs` (or at least `cli.test.mjs`,
+  `purge.test.mjs`, `remove.test.mjs`).
+- **AC8** (covers R3) `node scripts/gen-surfaces.mjs --check` and
+  `node scripts/sync-edge-schemas.mjs --check` exit 0 after regeneration; the CLI
+  local `mcp-server.mjs` is unaffected (purge tools already advertised there? they
+  are MCP tools — confirm `MEMORY_TOOL_DEFS`/`MEMORY_DISPATCH` already include
+  purge; if not, that is a separate pre-existing gap, note it).
+
+## File changes (concrete paths)
+
+- **Add** `packages/cli/src/purge.mjs` — `purge(args)` and `purgeExpired(args)`,
+  mirroring `remove.mjs`'s structure (store pick, confirm/`--yes` guard, `--json`,
+  outcome mapping). Reuse `pickStore`-style selection or the existing store
+  resolution helpers (`resolveStores`/`resolveDenies` from `stores.mjs`/`control.mjs`).
+- **Edit** `packages/cli/src/store/remote.mjs` — add `purge({ retentionDays })`
+  and `purgeExpired()` methods (POST to `/memories/purge` / `/purge-expired`,
+  passing `{ retention_days }` when set, returning the standard envelope with
+  `httpStatus` + `error` so the 403/429 UX works).
+- **Edit** `packages/cli/bin/lorekit.mjs`:
+  - import `{ purge, purgeExpired } from '../src/purge.mjs'`;
+  - `case 'purge': return traceCommand('purge', …)`,
+    `case 'purge-expired': return traceCommand('purge-expired', …)`;
+  - add `'purge'`, `'purge-expired'` to `HUMAN_COMMANDS`;
+  - add `'retention-days'` to `KNOWN_FLAGS`;
+  - add `COMMAND_HELP.purge` + `COMMAND_HELP['purge-expired']` entries and mention
+    them in the top-level `HELP` Commands list.
+- **Edit** `packages/schemas/src/tool-catalog.ts` — flip the two purge `surfaces`
+  bindings: `cli:'purge'` / `cli:'purge-expired'`, drop `cliExempt`.
+- **Add** `packages/cli/test/purge.test.mjs` — command + store coverage (ACs 3–6).
+- **Edit (only if the Phase-2 gate needs it)** the manifest parity spec — no
+  change expected beyond removing the exemption, which the catalog edit handles.
+- **Regenerate** the surface manifest (`gen-surfaces.mjs`) and, if the CLI reads a
+  committed manifest for its command table (Phase-2 D2), regenerate that too.
+- **Docs:** `docs/cli.md`, `docs/api-tokens.md` (scoped-key refusal),
+  `packages/cli/README.md`, `packages/web/public/llms.txt` (only if it lists CLI
+  commands). Run sibling-name docs-drift greps (`purge`, `purge-expired`, and an
+  existing sibling like `migrate`).
+
+## Verification
+
+Run from the worktree root. No `timeout` on macOS.
+
+1. `node --test packages/cli/test/purge.test.mjs packages/cli/test/cli.test.mjs packages/cli/test/remove.test.mjs` — green (ACs 2–7). The `purge.test.mjs` mocks `restFetch` (like the existing CLI store tests) so no live backend is needed.
+2. `corepack pnpm exec vitest run packages/mcp-core/src/tool-catalog-parity.spec.ts` — green (AC1).
+3. `node scripts/gen-surfaces.mjs --check` and `node scripts/sync-edge-schemas.mjs --check` — exit 0 (AC8).
+4. **Guard-bites proof:** for AC5, confirm removing the `--yes` guard makes the
+   refuse-test flip; for AC4, confirm the 403 message passthrough test fails if
+   the error is swallowed. Do not commit perturbations.
+5. No SQL/isolated-stack run needed — this plan adds no migration and no RPC; the
+   server behaviour it calls is already covered by the removal branch's tests and
+   the existing purge handler tests. (The account-wide refusal is unit-tested in
+   `tenant-scope-usage.spec.ts`'s `account-wide tool guard` describe block, which
+   stays green.)
+
+## Risks & mitigations
+
+- **Working around the scoped-key refusal** (e.g. retrying with a different scope
+  or splitting the sweep). *Mitigation:* R2/AC4 — surface the 403 verbatim; the
+  CLI performs exactly one request and reports the server's answer.
+- **A `--local` purge that silently does nothing** because the local store lacks
+  archived/expired tracking. *Mitigation:* D2 — read `local.mjs` first; if
+  unsupported, make `--local` an explicit refusal, not a no-op success.
+- **Unconfirmed destructive run from an agent.** *Mitigation:* D1/AC5 confirm-or-
+  `--yes` gate.
+- **Out-of-range `--retention-days` sent to the server** (the schema 4xx would be
+  a confusing round-trip). *Mitigation:* AC6 validates client-side first.
+- **Docs-drift.** *Mitigation:* sibling-name greps before claiming done.
+
+## Dependencies / ordering
+
+- **Depends on Phase 2.** Independent of 3a / 3b / 3d. Smallest of the Phase-3
+  plans — good candidate to land immediately after Phase 2 to exercise the manifest
+  gate's "close a KNOWN-GAP exemption" path end to end.

--- a/docs/issues/api-token-surface-generator/plan-generator-phase3d-analytics-decision.md
+++ b/docs/issues/api-token-surface-generator/plan-generator-phase3d-analytics-decision.md
@@ -1,0 +1,158 @@
+# Plan / Decision Record — Generator Phase 3d: analytics reads on MCP/CLI?
+
+> **Plan-only artifact + decision record.** Nothing is implemented. This captures
+> a recommendation and, if overridden, the minimal path.
+
+## Session bootstrap (read first)
+
+- **Worktree / cwd:** `/Users/mthines/Workspace/lorekit.git/feat/api-token-surface-generator`
+  (`gw` worktree of `mthines/lorekit`). **Never** touch/`cd`/`gw clean` `…/main`.
+- **Branch:** `feat/api-token-surface-generator` (stack → `…-scope-authorized-removal` → `feat/combobox-multi-select`, PR #490).
+- **First action (if pursued):** `ls supabase/functions/memories/handlers/{usage,tags,facets,activity,read-activity,relevant}.ts packages/schemas/src/tool-catalog.ts`.
+- **DEPENDENCY (only if pursued):** Phase 2.
+
+## Context / background
+
+The REST `memories` function exposes several **analytics reads** that have NO MCP
+tool and no CLI command:
+
+| REST route | handler | `rest-tool-name.ts` name | MCP tool? | CLI? |
+|---|---|---|---|---|
+| `GET /usage` | `handleUsage` | `memory.usage` | none | none |
+| `GET /tags` | `handleTags` | `memory.tags` | none | none |
+| `GET /facets` | `handleFacets` | `memory.facets` | none | none |
+| `GET /activity` | `handleActivity` | `memory.activity` | none | none |
+| `GET /read-activity` | `handleReadActivity` | `memory.read-activity` | none | none |
+| `GET /relevant` | `handleRelevant` | `memory.relevant` | via `memory.list order=rank` | via `remote.relevant()` |
+
+`/relevant` is already covered functionally: MCP's `memory.list order=rank` and
+the CLI's `remote.relevant()` (used by the SessionStart-hook ranking path) both
+answer the "what is worth reading" question. So `/relevant` is NOT part of this
+decision — it is done.
+
+The five remaining (`usage`, `tags`, `facets`, `activity`, `read-activity`) are
+**dashboard telemetry / Explorer drill-down** reads. They power the web
+dashboard's charts and filters (usage-over-time, tag facets, activity heatmaps).
+They are aggregate reads keyed by `scope_type` or tag/time buckets, not
+lesson-CRUD.
+
+## The decision
+
+**Recommendation: DO NOT add `usage` / `tags` / `facets` / `activity` /
+`read-activity` to MCP or the CLI.** Rationale:
+
+1. **They are dashboard telemetry, not agent primitives.** An agent's job is to
+   read/write *lessons* (the `memory.*` CRUD + `list order=rank` shortlist). Usage
+   rollups, tag facets, and activity heatmaps are humans-looking-at-a-dashboard
+   concerns. The dashboard (`packages/web`) already renders them from these
+   routes. No agent workflow in the repo consumes them.
+2. **Tool-list bloat degrades the agent.** Every tool added to `tools/list` costs
+   context and adds a choice the model can get wrong. Five analytics tools that no
+   loop calls is negative-value surface area — the exact "always-heavy" anti-pattern
+   the tool catalog's minimalism guards against.
+3. **The completeness gate does not force them.** `surface-parity.spec.ts` /
+   Phase-2's manifest gate only require **catalogued MCP tools** to map to a CLI
+   command. These REST routes are NOT MCP tools, so leaving them REST-only creates
+   no parity violation. `rest-tool-name.ts` already names them for usage-event
+   aggregation; that is the only cross-surface coupling and it is satisfied.
+4. **CLI has adjacent affordances already.** `lorekit stats` / `lorekit scopes` /
+   `lorekit list` cover the "what do I have" question a human at a terminal asks;
+   the deep analytics belong in the dashboard where they are visualised.
+
+**Action for Phase 3d: record this as a decision, add a short note to the surface
+docs so the omission is deliberate-not-accidental, and add (if Phase 2's manifest
+supports it) a `surfaces` annotation marking these REST routes as
+`intentionallyRestOnly: 'dashboard analytics'` so a future audit does not re-flag
+them.** No new tools, no new CLI commands.
+
+## Requirements
+
+- **R1** [user-stated] Produce a short decision record on whether to surface
+  `tags`/`facets`/`activity`/`usage` (and `read-activity`) on MCP/CLI.
+- **R2** [user-stated] Recommendation is NOT to add them (dashboard telemetry,
+  tool bloat) — capture the rationale.
+- **R3** [user-stated] If pursued anyway, capture the minimal path.
+- **R4** [derived] Make the omission explicit so the Phase-2 completeness gate /
+  a future surface audit treats it as intentional, not a gap.
+
+## Acceptance criteria (verifiable)
+
+- **AC1** (covers R1, R2, R4) A decision is recorded in the repo's decisions doc
+  (`docs/decisions.md`) stating the five analytics reads stay REST-only, with the
+  rationale, and (if Phase-2 manifest supports it) the catalog/manifest annotates
+  them `intentionallyRestOnly`.
+  - `kind: command`: `grep -niE "analytics.*rest-only|rest-only.*analytics|dashboard telemetry" docs/decisions.md` matches the new entry.
+- **AC2** (covers R4) No parity/completeness spec regresses by the decision (the
+  routes were never MCP tools; nothing forces them on).
+  - `kind: command`: `corepack pnpm exec vitest run packages/mcp-core/src/tool-catalog-parity.spec.ts packages/mcp-core/src/rest-tool-name.spec.ts` passes unchanged.
+- **AC3** (covers R2) The recommendation is discoverable next to the other surface
+  docs (a one-liner in `docs/mcp-tools.md` and/or `docs/architecture.md` noting
+  the analytics reads are dashboard-only).
+  - `kind: command`: `grep -niE "usage|tags|facets|activity" docs/mcp-tools.md` shows the "REST/dashboard-only, not exposed as agent tools" note.
+
+## If pursued anyway — the minimal path (NOT recommended)
+
+Only if the user overrides the recommendation. The minimal, lowest-bloat path:
+
+- **Do NOT add per-metric tools.** Adding five tools is the worst option. If
+  anything, add ONE read-only inspection tool, e.g. `memory.stats`, that returns
+  a compact rollup (counts by scope_type + top tags) — a single, agent-legible
+  summary rather than five dashboard endpoints. This keeps `tools/list` growth to
+  one entry.
+- **CLI:** surface via flags on the existing `stats` command
+  (`lorekit stats --tags` / `--activity`) rather than new top-level commands, so
+  the human-facing surface does not sprout five analytics verbs.
+- **Wiring (per op, through Phase-2 catalog):**
+  - Add the tool to `tool-catalog.ts` with `surfaces` binding + `permission:'read'`.
+  - Add a `toolStats` handler in `supabase/functions/mcp/tools.ts` calling the same
+    RPC the REST handler calls, passing `p_key_scopes` where the drift guard
+    (`tenant-scope-usage.spec.ts` RPC-backed reads list) requires it — note
+    `usage` is deliberately excluded from that guard because it emits no scope
+    NAME (rolls up by `scope_type`), so a `usage`-derived tool must keep that
+    property or the guard's exclusion list must be revisited.
+  - Add the dispatch-map entry + permission-set entry + regenerate manifest/mirror/llms.
+  - `remote.mjs` method + CLI flag + tests + SQL section if a new RPC path is hit.
+- **Cost to acknowledge:** each analytics tool is context the model pays for every
+  session and a scope-leak surface (`facets`/`tags`/`activity` are name-bearing —
+  they MUST pass `p_key_scopes`, unlike `usage`). This is exactly the risk the
+  recommendation avoids.
+
+## File changes (concrete paths)
+
+- **Recommended path:**
+  - **Edit** `docs/decisions.md` — add the decision entry (AC1).
+  - **Edit** `docs/mcp-tools.md` and/or `docs/architecture.md` — one-line note that
+    the analytics reads are dashboard/REST-only (AC3).
+  - **Optional edit** `packages/schemas/src/tool-catalog.ts` — if the Phase-2
+    binding shape has an `intentionallyRestOnly` annotation, mark the five routes
+    (only if the catalog models REST-only routes at all; if the catalog is
+    MCP-tools-only, skip and rely on the decisions doc).
+- **If pursued (not recommended):** the wiring list above — `tool-catalog.ts`,
+  `permissions.ts` (+ mirror), `mcp-handler.ts`, `tools.ts`, `remote.mjs`,
+  `bin/lorekit.mjs` (or `stats.mjs`), new CLI test, `migrations.test.sql` section
+  if a name-bearing RPC is newly reached, regenerate manifest/mirror/llms, docs.
+
+## Verification
+
+Run from the worktree root. No `timeout` on macOS.
+
+- Recommended path: `corepack pnpm exec vitest run packages/mcp-core/src/tool-catalog-parity.spec.ts packages/mcp-core/src/rest-tool-name.spec.ts` (AC2), and the doc greps (AC1, AC3). No stack/SQL run needed.
+- If pursued: the full Phase-3-style verification (parity specs + regenerate `--check` + CLI tests + isolated-stack SQL for any name-bearing RPC).
+
+## Risks & mitigations
+
+- **Tool-list bloat** (the reason to say no). *Mitigation:* the recommendation
+  itself; if overridden, cap at ONE summary tool, not five.
+- **Scope leak via name-bearing analytics** (`facets`/`tags`/`activity`).
+  *Mitigation:* if pursued, they MUST pass `p_key_scopes` (the RPC-backed-reads
+  drift guard in `tenant-scope-usage.spec.ts` enforces this for REST; an MCP twin
+  would need the same). `usage` is the only one exempt (no scope name).
+- **Silent re-flagging** by a future surface audit. *Mitigation:* AC1/AC4 record
+  the decision so the omission is documented intent.
+
+## Dependencies / ordering
+
+- Recommended path depends on nothing (pure docs + decision) and can land any
+  time, but is cleanest AFTER Phase 2 so the decisions doc can reference the
+  manifest's `intentionallyRestOnly` concept if it exists.
+- If pursued, depends on Phase 2 like 3a–3c.


### PR DESCRIPTION
Resumable execution plans for making LoreKit's token-capable operation surface
consistent across **MCP, CLI, and REST** — moved out of the gitignored `.agent/`
scratch dir into `docs/issues/` so they persist and are reviewable. Each plan
opens with a "read first — you have no memory" bootstrap (worktree, branch stack,
first actions) so a fresh session can execute it cold.

- **Phase 2** — catalog-driven surface codegen (`tool-catalog.ts` → MCP dispatch + CLI + `tools/list` + docs, with a completeness gate). Do first.
- **Phase 3a–3d** — org token-enablement (via the catalog), org members/invites, CLI purge, analytics decision.
- **Finalize** — commit/verify/PR the scope-authorized-removal work + BYOD mirror.

Docs only — no code. Base is #490 (`feat/combobox-multi-select`), the stack this
initiative sits on; the actual removal + generator code is on stacked branches
(currently local/uncommitted).