### PR TITLE
fix(ci): run preview DB reset non-interactively (--yes)

### DIFF
--- a/.github/workflows/rebuild-preview.yml
+++ b/.github/workflows/rebuild-preview.yml
@@ -130,13 +130,12 @@ jobs:
 
       # The ONE step that clears drifted history rows AND orphan schema objects:
       # re-provision the remote DB from the migration files on this ref.
-      # NOTE: depending on the pinned CLI version, `db reset --linked` may prompt
-      # for confirmation. Verify on the FIRST manual `workflow_dispatch` run
-      # (before the cron ever fires); if it hangs on a prompt, drive it
-      # non-interactively with whatever confirmation flag the installed CLI
-      # exposes (or pipe `y`).
+      # `db reset --linked` prompts `[y/N]` to confirm wiping the remote DB, which
+      # a CI runner has no TTY to answer (it aborts with `context canceled`). The
+      # global `--yes` flag answers the prompt so the flush runs unattended on the
+      # weekly cron, a `/reset-preview` comment, or a manual dispatch.
       - name: Reset preview database from migrations
-        run: supabase db reset --linked
+        run: supabase db reset --linked --yes
 
       # `db reset` wipes the seeded orgs-smoke user along with everything else,
       # so the orgs REST smoke self-skips (announced, non-fatal) until it is


### PR DESCRIPTION
## Summary

The **Rebuild preview DB** workflow (`rebuild-preview.yml`) failed on its first real run: `supabase db reset --linked` prompts `Do you want to reset the remote database? [y/N]`, and a CI runner has no TTY to answer it, so it aborted with `context canceled`. This is the exact caveat the step's own NOTE comment predicted ("if it hangs on a prompt, drive it non-interactively").

## Change

- `supabase db reset --linked` → `supabase db reset --linked --yes`. `--yes` is a global CLI flag ("Answer yes to all prompts"), verified on CLI 2.105.0.
- Replaced the now-stale NOTE with a comment explaining why `--yes` is required.

## Why now

The shared `preview` project has drifted migration history (rows `00067`–`00069` from an abandoned branch's `/preview`, no longer in local migrations at `00066`), which blocks `/preview` on open PRs with *"Remote migration versions not found in local migrations directory."* The reset workflow is the intended flush for that drift, but it couldn't run unattended until this fix. After merge: re-run the rebuild (`/reset-preview` or manual dispatch), then re-run `/preview`.

## Verification

Workflow-only change; no app code or tests affected. `--yes` confirmed present in `supabase db reset` global flags.