### PR TITLE
blog: fix maxLessons tuning + two figures in the (date-gated) scaling post

### DIFF
--- a/packages/web/public/blog/read-pipeline.svg
+++ b/packages/web/public/blog/read-pipeline.svg
@@ -52,10 +52,10 @@
   <text x="222" y="500" class="lbl" font-size="11.5">budget — fill 3000 chars, then stop</text>
 
   <rect x="60" y="522" width="300" height="120" rx="11" fill="#2a2010" stroke="#f5a623"/>
-  <text x="210" y="548" text-anchor="middle" class="k" font-size="13.5" font-weight="700" fill="#f5a623">LoreKit: 8 of 6,000 loaded</text>
+  <text x="210" y="548" text-anchor="middle" class="k" font-size="13.5" font-weight="700" fill="#f5a623">LoreKit: 8 of 6000 loaded</text>
   <line x1="80" y1="560" x2="340" y2="560" stroke="#f5a623" stroke-opacity="0.25"/>
   <text x="80" y="580" class="k" font-size="11" fill="#34d399">- (repo) supabase-rls::empty-array-is-not-no-rows</text>
   <text x="80" y="598" class="k" font-size="11" fill="#34d399">- (global) always-typecheck-before-done</text>
   <text x="80" y="616" class="lbl" font-size="11">…6 more, ranked &amp; de-duplicated</text>
-  <text x="80" y="634" class="k" font-size="10.5" fill="#f5a623">More lore: 5,992 more → memory.search</text>
+  <text x="80" y="634" class="k" font-size="9" fill="#f5a623">More lore: repo 4000 · global 2000 → memory.search</text>
 </svg>

--- a/packages/web/public/blog/read-scaling.svg
+++ b/packages/web/public/blog/read-scaling.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 430" role="img" aria-label="Two rows sharing one pipeline. Top: a six-lesson store injects all six, with no scope map. Bottom: a sixty-thousand-lesson store injects the same-sized bounded block of eight ranked, de-duplicated lessons, plus a scope map and a memory.search pointer. The injected block is the same size in both; only the denominator and the map grow.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 430" role="img" aria-label="Two rows sharing one pipeline. Top: a six-lesson store injects all six, with no scope map. Bottom: a sixty-thousand-lesson store injects the same-sized bounded block of eight ranked, de-duplicated lessons, plus a per-scope map of where the rest live, reachable with memory.search. The injected block is the same size in both; only the denominator and the map grow.">
   <style>
     text{font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;fill:#e7ebf2}
     .lbl{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;fill:#8892a4;letter-spacing:.02em}
@@ -25,7 +25,7 @@
   <line x1="182" y1="104" x2="248" y2="150" stroke="#8892a4" stroke-width="1.5" marker-end="url(#ar2)"/>
   <line x1="402" y1="150" x2="470" y2="104" stroke="#8892a4" stroke-width="1.5" marker-end="url(#ar2)"/>
   <rect x="472" y="40" width="220" height="128" rx="10" fill="#2a2010" stroke="#f5a623"/>
-  <text x="484" y="60" class="k" font-size="11.5" font-weight="700" fill="#f5a623">6 of 6 loaded</text>
+  <text x="484" y="60" class="k" font-size="11.5" font-weight="700" fill="#f5a623">6 memories loaded</text>
   <line x1="484" y1="68" x2="680" y2="68" stroke="#f5a623" stroke-opacity="0.22"/>
   <text x="484" y="82" class="k" font-size="10" fill="#7ce6bf">- supabase-rls::empty-array…</text>
   <text x="484" y="95" class="k" font-size="10" fill="#7ce6bf">- typecheck-before-done</text>
@@ -35,7 +35,7 @@
   <text x="484" y="147" class="k" font-size="10" fill="#7ce6bf">- branch-name-seeds-the-read</text>
   <text x="484" y="160" class="lbl" font-size="10">no map — nothing left to point at</text>
 
-  <text x="30" y="278" class="lbl" font-size="12" fill="#f5a623">B · LARGE — 60,000 lessons</text>
+  <text x="30" y="278" class="lbl" font-size="12" fill="#f5a623">B · LARGE — 60000 lessons</text>
   <rect x="30" y="292" width="150" height="120" rx="10" fill="#13151a" stroke="#2a2d38"/>
   <g stroke="#8892a4" stroke-opacity="0.35">
     <line x1="42" y1="304" x2="168" y2="304"/><line x1="42" y1="312" x2="168" y2="312"/>
@@ -45,15 +45,15 @@
     <line x1="42" y1="368" x2="168" y2="368"/><line x1="42" y1="376" x2="168" y2="376"/>
     <line x1="42" y1="384" x2="168" y2="384"/><line x1="42" y1="392" x2="168" y2="392"/>
   </g>
-  <text x="105" y="356" text-anchor="middle" class="k" font-size="18" font-weight="700" fill="#e7ebf2">60,000</text>
+  <text x="105" y="356" text-anchor="middle" class="k" font-size="18" font-weight="700" fill="#e7ebf2">60000</text>
   <line x1="182" y1="352" x2="248" y2="230" stroke="#8892a4" stroke-width="1.5" marker-end="url(#ar2)"/>
   <line x1="402" y1="230" x2="470" y2="352" stroke="#8892a4" stroke-width="1.5" marker-end="url(#ar2)"/>
   <rect x="472" y="288" width="220" height="128" rx="10" fill="#2a2010" stroke="#f5a623"/>
-  <text x="484" y="308" class="k" font-size="11.5" font-weight="700" fill="#f5a623">8 of 60,000 loaded</text>
+  <text x="484" y="308" class="k" font-size="11.5" font-weight="700" fill="#f5a623">8 of 60000 loaded</text>
   <line x1="484" y1="316" x2="680" y2="316" stroke="#f5a623" stroke-opacity="0.22"/>
   <text x="484" y="332" class="k" font-size="10" fill="#7ce6bf">- supabase-rls::empty-array…</text>
   <text x="484" y="347" class="k" font-size="10" fill="#aeb9ff">- loop::reviewer-lessons (≤1)</text>
   <text x="484" y="362" class="k" font-size="10" fill="#7ce6bf">- branch-name-seeds-the-read</text>
   <text x="484" y="377" class="lbl" font-size="10">…5 more, ranked &amp; de-duplicated</text>
-  <text x="484" y="399" class="k" font-size="9.5" fill="#f5a623">More lore: 59,992 more → memory.search</text>
+  <text x="484" y="399" class="k" font-size="9.5" fill="#f5a623">More lore: repo 40000 · global 20000</text>
 </svg>

--- a/packages/web/src/content/blog/agent-memory-working-set.mdx
+++ b/packages/web/src/content/blog/agent-memory-working-set.mdx
@@ -49,7 +49,7 @@ const score =
 
 Recency is one factor, decaying on a two-week half-life — not the sort order. **Salience** is recurrence: a lesson you've re-learned five times outranks a fresh one-off, which is exactly the signal you want a big store to surface. **Outcome** leans toward lessons that helped, with a cold-start prior of `0.5` so a brand-new lesson isn't buried for lacking a track record. The budget goes to what's been *earned* — and the more your store holds, the more that ranking is doing for you.
 
-There's a relevance factor in there too, and it's the part a first read can't fake: at session start there's no task yet. So LoreKit distills a query from your **branch name** — a session on `feat/embedding-pipeline` lifts embedding lessons up the ranking. It only ever *lifts* an on-topic lesson (a non-match scores zero), so a bare `main` or a detached `HEAD` simply falls back to recency-plus-salience. Cheap, deterministic, and it means even a sixty-thousand-lesson store opens leaning toward what you're actually about to do.
+There's a relevance factor in there too, and it's the part a first read can't fake: at session start there's no task yet. So LoreKit distills a query from your **branch name** — a session on `feat/embedding-pipeline` lifts embedding lessons up the ranking. It only ever *lifts* an on-topic lesson (a non-match scores zero), so a bare `main` or a detached `HEAD` simply falls back to recency, salience, and outcome. Cheap, deterministic, and it means even a sixty-thousand-lesson store opens leaning toward what you're actually about to do.
 
 ## It stays legible as it grows
 
@@ -67,23 +67,23 @@ A **per-bucket cap** keeps any single self-improvement loop — a bot writing it
 Then **MMR** — Maximal Marginal Relevance, Carbonell & Goldstein 1998, at λ=0.7 — removes near-duplicates. A dense store has clusters that score alike *and read alike* (`pr395-it3`, `it4`, `it5` — the same lesson three times); MMR keeps the best and pushes the echoes down, so the budget buys variety instead of repetition. The bigger the store, the more this earns its keep.
 
 <figure>
-  <img src="/blog/read-pipeline.svg" alt="A vertical pipeline: lessons across scopes pass through precedence, ranking by signal, a per-loop cap that drops extra loop rows, MMR that drops near-duplicates, and a 3000-character budget, into a bounded block that reports 8 of 6,000 plus a scope map." width="620" height="680" />
+  <img src="/blog/read-pipeline.svg" alt="A vertical pipeline: lessons across scopes pass through precedence, ranking by signal, a per-loop cap that drops extra loop rows, MMR that drops near-duplicates, and a 3000-character budget, into a bounded block that reports 8 of 6000 plus a per-scope map." width="620" height="680" />
   <figcaption>Precedence decides which copy of a key survives; ranking, the per-bucket cap, MMR, and the character budget decide which survivors you see. Nothing about the read grows with the store except the number it honestly cites.</figcaption>
 </figure>
 
 ## It always tells you what it didn't show
 
-This is the part that makes large stores safe. The header reports both numbers — `8 of 6,000` — and in the default `hybrid` shape it appends a scope map of where the rest live:
+This is the part that makes large stores safe. The header reports both numbers — `8 of 6000` — and in the default `hybrid` shape it appends a scope map of where the rest live:
 
 ```text
-LoreKit: 8 of 6,000 memories loaded · repo::mthines/lorekit — considerations, not rules; read any in full with memory.read.
+LoreKit: 8 of 6000 memories loaded · repo::mthines/lorekit — considerations, not rules; read any in full with memory.read.
 - (repo::mthines/lorekit) supabase-rls::empty-array-is-not-no-rows — RLS returns 200 + [], not a 4xx…
 - (global) always-typecheck-before-done — run the typecheck before you claim it's done
 - … 6 more, ranked and de-duplicated, inside the budget …
-More lore: branch::…/feat/x 12 · repo::mthines/lorekit 4,180 · global 1,808 — memory.search or memory.read to drill in.
+More lore: branch::…/feat/x 12 · repo::mthines/lorekit 4180 · global 1808 — memory.search or memory.read to drill in.
 ```
 
-(That block is illustrative — the shape `formatLessons` produces, not a single capture.) The counts are exact at any size: they come from the store's own inventory — a Postgres aggregate on the hosted side — not from the bounded read, so a scope holding four thousand lessons reports `4,180`, not a hand-wavy `100+` — and when the store can't enumerate (an unreachable remote, no inventory), it falls back to the approximate `+`-suffixed count rather than inventing a total. A truncated read is never mistaken for a complete one: the agent can see there's more and reach for `memory.search` to pull the exact lesson it needs. The working set stays small; the store behind it can be enormous.
+(That block is illustrative — the shape `formatLessons` produces, not a single capture. The real output prints raw counts, no thousands separators.) The counts are exact at any size: they come from the store's own inventory — a Postgres aggregate on the hosted side — not from the bounded read, so a scope holding four thousand lessons reports `4180`, not a hand-wavy `100+` — and when the store can't enumerate (an unreachable remote, no inventory), it falls back to the approximate `+`-suffixed count rather than inventing a total. A truncated read is never mistaken for a complete one: the agent can see there's more and reach for `memory.search` to pull the exact lesson it needs. The working set stays small; the store behind it can be enormous.
 
 ## The second gear: relevance when you fail
 
@@ -102,7 +102,7 @@ I'll be honest about *why* those three: the matcher is lexical, not semantic. Th
 
 The heaviest writers to a real store aren't people — they're loops. The `aw` agent (plan → build → test → PR) and `pr-reviewer` we build LoreKit with run this loop on every task: they read their ranked `loop::aw-lessons` and `loop::reviewer-lessons` before they act, and write a new lesson the moment something bites. Over a busy month that's thousands of entries — most of them one bot's private bookkeeping.
 
-Those thousands of entries are exactly what the ranking and the per-bucket cap are for. When a loop reads its *own* bucket by tag it gets everything, uncapped — that's its working memory. When *you* open a coding session, the same store's read ranks across all of it and caps each `loop::` bucket at one — its single best lesson still surfaces — so your window fills with the general, human-written lessons a task needs, not a review bot's iteration log. One store, two very different reads — and neither starves the other.
+Those thousands of entries are exactly what the ranking and the per-bucket cap are for. When a loop reads its *own* bucket by tag it gets the whole bucket — uncapped by the loop limit, paged so it can walk all of it — that's its working memory. When *you* open a coding session, the same store's read ranks across all of it and caps each `loop::` bucket at one — its single best lesson still surfaces — so your window fills with the general, human-written lessons a task needs, not a review bot's iteration log. One store, two very different reads — and neither starves the other.
 
 And it isn't only LoreKit's loops. The same wiring is a skill: `lorekit-setup` scaffolds the read-fail-write loop into your own skill, agent, or workflow — the bucket, the scopes, the read-before-you-act and write-on-friction — so your automation gets better across runs the way the `aw` agent does, and the ranked read keeps its growing memory out of everyone else's way.
 
@@ -121,23 +121,22 @@ Nothing above is a mode you switch on. The same code runs against every store:
 Start local with a handful and it's useful on day one; point it at a shared, org-wide store a year later and the read that worked at six still works at sixty thousand — and when you want a fatter or leaner read, it's a dial, not a rewrite.
 
 <figure>
-  <img src="/blog/read-scaling.svg" alt="The same read at six lessons and at sixty thousand. A six-lesson store injects all six with no scope map; a sixty-thousand-lesson store injects a same-sized bounded block plus a denominator and a memory.search pointer." width="720" height="430" />
+  <img src="/blog/read-scaling.svg" alt="The same read at six lessons and at sixty thousand. A six-lesson store injects all six with no scope map; a sixty-thousand-lesson store injects a same-sized bounded block plus a denominator and a per-scope map of where the rest live." width="720" height="430" />
   <figcaption>Same code, same 3000-character budget, same gates. A small store injects everything it has; a store ten thousand times larger injects a same-sized block plus an honest denominator and a path to the rest. The working set is a fixed window; the store behind it is unbounded.</figcaption>
 </figure>
 
 ## Turn it up, or off
 
-Two dials govern the read, and they're the same whether your store holds six lessons or sixty thousand. They live in your repo config (`.lorekit.json`, which wins) or your user config (`~/.lorekit/config.json`):
+A few dials govern the read, and they're the same whether your store holds six lessons or sixty thousand. They live in your repo config (`.lorekit.json`, which wins) or your user config (`~/.lorekit/config.json`):
 
 ```json
 {
   "hooks.sessionStart.maxChars": 5000,
-  "hooks.sessionStart.maxLessons": 150,
   "hooks.sessionStart.loopCap": 0
 }
 ```
 
-`maxChars` is the character budget (200–20,000) — how many lines you actually *see* (about 25 at the default 3000). `maxLessons` is the subtler one: it's the **read depth** — how many candidate memories per scope the ranker gets to choose those lines from (default 100, up to the API's 100-per-page max). That's where relevance comes from: at depth 100 the ranker picks its ~25 lines from up to 400 candidates across a four-scope hierarchy; at 25 it'd be choosing from the newest handful, so a lesson you re-learned five times last quarter never even enters the running. Raising it reads deeper and diversifies wider — a little more work per session start, which is the trade. `loopCap: 0` drops the self-improvement `loop::` buckets entirely and reads only human-written memories.
+`maxChars` is the character budget (200–20,000) — how many lines you actually *see*, about 25 at the default 3000. Turn it up to see more, down to spend less of your window. `maxLessons` is the subtler one, and it really only moves in one direction. It's the **read depth** — how many candidate memories per scope the ranker picks those lines from — and its default of 100 already sits at the API's 100-per-page ceiling. So raising it above 100 buys nothing; lowering it toward the floor of 25 shrinks the candidate pool for a cheaper, shallower read. That depth is where relevance comes from: at 100 the ranker picks its ~25 lines from up to 400 candidates across a four-scope hierarchy; drop it to 25 and it's choosing from the newest handful, so a lesson you re-learned five times last quarter might never enter the running. `loopCap: 0` drops the self-improvement `loop::` buckets entirely and reads only human-written memories.
 
 And past whatever slice you pick, the rest of the store is one `memory.search` away. You tune the working set, not the ceiling on what your agent can reach.
 
@@ -154,4 +153,4 @@ None of these are things I'd rather you found at 2am.
 
 ## See it for yourself
 
-Wire up the loop and start a session. The header tells you how much of your lore fit the budget — `8 of 6,000` — and the scope map points at the rest. That one line is the whole idea: a bounded, ranked slice, and an honest pointer to everything behind it. Tune it up or down with the dials above; the store behind it scales either way. 🙂
+Wire up the loop and start a session. The header tells you how much of your lore fit the budget — `8 of 6000` — and the scope map points at the rest. That one line is the whole idea: a bounded, ranked slice, and an honest pointer to everything behind it. Tune it up or down with the dials above; the store behind it scales either way. 🙂


### PR DESCRIPTION
## What

A fresh, skeptical accuracy review of the still-**date-gated** "6 → 60,000" post (`agent-memory-working-set.mdx`, `date: 2026-12-01`, hidden from `/blog`) against the actual read-pipeline code turned up one blocking inaccuracy and two figures rendering output the CLI can't produce. This fixes them before the post is ever un-hidden. **This PR does not publish the post** — it stays date-gated.

### Blocking
- **`maxLessons` tuning advice was false and self-contradicting.** The example set `hooks.sessionStart.maxLessons: 150` and the prose promised raising it "reads deeper and diversifies wider." But `scopeReadLimit` clamps the per-scope fetch to `MAX_STORE_LIST_LIMIT = 100` and the default is already `100`, so `150` fetches the identical rows — and it contradicted two other lines in the same post ("never more than the API's 100 per page"). Reframed honestly: `maxLessons` is a **read-depth dial that only moves down** (25 floor, 100 = the API ceiling); raising it above 100 buys nothing, lowering it toward 25 shrinks the candidate pool for a cheaper, shallower read. Dropped `150` from the example.

### Figures (major)
- **`read-scaling.svg`:** `6 of 6 loaded` → `6 memories loaded`. `formatLessons` only emits the `X of Y` form when something is truncated; the old label contradicted the post's own thesis.
- **`read-pipeline.svg` + `read-scaling.svg`:** replaced the bare `N more` with a **per-scope scope map** (`repo … · global …`), which is what `renderScopeMap` actually emits and what the post's own example (and the figure alt text) promise.

### Polish
- Simulated CLI output no longer shows thousands separators (the CLI prints raw ints, e.g. `8 of 6000`, `4180`); English prose keeps its commas.
- "recency-plus-salience" → include the always-on **outcome** factor.
- The loop's by-tag read described as **paged**, not literally unbounded.

## Notes
- The reframed tuning paragraph was run through the humanizer (voice preserved, technical claims locked).
- **Docs:** no `llms.txt` impact (blog is self-contained). No config/CLI contract changed — this is content + figure accuracy only.
- Verified: blog specs (MDX pipeline for every post + `sections.spec` drift guard) pass; all three SVGs validate with `xmllint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8s1w6a6bdvwq1tYE4ViQN)_