### PR TITLE
blog: Vercel draft preview, date-sorted index, and a new data-model post (draft)

### DIFF
--- a/packages/web/src/app/blog/[slug]/page.tsx
+++ b/packages/web/src/app/blog/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';
 import { MDXRemote } from 'next-mdx-remote/rsc';
-import { getAllPosts, getPost } from '@/lib/blog/content';
+import { getAllPosts, getPost, draftsVisible } from '@/lib/blog/content';
 import { blogMdxComponents } from '@/components/blog/mdx-components';
 import { blogMdxOptions } from '@/lib/blog/mdx-render-options';
 import { BlogProse } from '@/components/blog/BlogProse';
@@ -12,6 +12,7 @@ import { MobileTableOfContents } from '@/components/blog/MobileTableOfContents';
 import { ReadingProgress } from '@/components/blog/ReadingProgress';
 import { PostLikes } from '@/components/blog/PostLikes';
 import { BlogPostCta } from '@/components/blog/BlogPostCta';
+import { DraftNotice } from '@/components/blog/DraftNotice';
 import { ReadingTelemetry } from '@/components/content/ReadingTelemetry';
 import { formatPostDate, readingLabel } from '@/lib/blog/format';
 
@@ -41,6 +42,10 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
   const { slug } = await params;
   const post = getPost(slug);
   if (!post) notFound();
+  // Defence in depth: a draft is already absent from `generateStaticParams` in
+  // production (so it 404s via `dynamicParams = false`), but guard here too so a
+  // future direct caller can never render one outside preview/dev.
+  if (post.isDraft && !draftsVisible()) notFound();
 
   return (
     <>
@@ -62,6 +67,8 @@ export default async function BlogPostPage({ params }: { params: Promise<{ slug:
             <ArrowLeft className="size-4" aria-hidden />
             All posts
           </Link>
+
+          {post.isDraft && <DraftNotice date={post.date} />}
 
           <header className="mb-8 border-b border-[var(--color-border)] pb-8">
             <h1 className="text-2xl font-bold leading-tight tracking-tight text-[var(--color-content-primary)] sm:text-3xl">

--- a/packages/web/src/components/blog/BlogPostCard.stories.tsx
+++ b/packages/web/src/components/blog/BlogPostCard.stories.tsx
@@ -14,6 +14,7 @@ const POST: PostMeta = {
   tags: ['self-healing', 'self-improving', 'agents'],
   order: 1,
   keywords: [],
+  isDraft: false,
 };
 
 const meta: Meta<typeof BlogPostCard> = {
@@ -35,6 +36,17 @@ type Story = StoryObj<typeof BlogPostCard>;
 
 /** Visual-regression story: the card as it appears on the `/blog` index. */
 export const Default: Story = {};
+
+/**
+ * A future-dated draft — shows the "Not yet live" badge (preview/dev only).
+ * Snapshot disabled: no committed baseline ships with this story, so it stays
+ * out of visual regression until someone generates one with `-u`. It still
+ * renders in Storybook for manual review and keeps the `PostMeta` type honest.
+ */
+export const Draft: Story = {
+  args: { post: { ...POST, isDraft: true } },
+  parameters: { chromatic: { disableSnapshot: true } },
+};
 
 // Keeps the `StoryObj<typeof BlogPostCard>` type so a `PostMeta` change breaks
 // this file at compile time.

--- a/packages/web/src/components/blog/BlogPostCard.test.stories.tsx
+++ b/packages/web/src/components/blog/BlogPostCard.test.stories.tsx
@@ -21,6 +21,7 @@ const POST: PostMeta = {
   tags: ['self-healing', 'self-improving', 'agents'],
   order: 1,
   keywords: [],
+  isDraft: false,
 };
 
 const meta: Meta<typeof BlogPostCard> = {

--- a/packages/web/src/components/blog/BlogPostCard.tsx
+++ b/packages/web/src/components/blog/BlogPostCard.tsx
@@ -17,6 +17,11 @@ export function BlogPostCard({ post }: { post: PostMeta }) {
       className="group block rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elevated)]/40 p-5 transition-colors duration-200 hover:border-[var(--color-accent)]/50 hover:bg-[var(--color-bg-elevated)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] sm:p-6"
     >
       <div className="flex items-center gap-2 font-mono text-xs text-[var(--color-content-tertiary)]">
+        {post.isDraft && (
+          <span className="rounded-full border border-[var(--color-accent)]/40 bg-[var(--color-accent)]/10 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--color-accent)]">
+            Not yet live
+          </span>
+        )}
         <time dateTime={post.date}>{formatPostDate(post.date)}</time>
         <span aria-hidden>·</span>
         <span>{readingLabel(post.readingMinutes)}</span>

--- a/packages/web/src/components/blog/DraftNotice.tsx
+++ b/packages/web/src/components/blog/DraftNotice.tsx
@@ -1,0 +1,22 @@
+import { Clock } from 'lucide-react';
+import { formatPostDate } from '@/lib/blog/format';
+
+/**
+ * A subtle "not yet live" banner shown at the top of a future-dated post. It
+ * only ever renders on preview/dev — in production drafts are filtered out and
+ * 404 (see `getAllPosts` / `draftsVisible`), so this never reaches a real
+ * reader. Names the scheduled release date so a reviewer knows when it goes live.
+ */
+export function DraftNotice({ date }: { date: string }) {
+  return (
+    <div
+      role="status"
+      className="mb-6 flex items-center gap-2 rounded-lg border border-[var(--color-accent)]/40 bg-[var(--color-accent)]/10 px-3 py-2 font-mono text-xs text-[var(--color-accent)]"
+    >
+      <Clock className="size-3.5 shrink-0" aria-hidden />
+      <span>
+        Preview — not yet live.{date && <> Scheduled for {formatPostDate(date)}.</>}
+      </span>
+    </div>
+  );
+}

--- a/packages/web/src/content/blog/agent-memory-working-set.mdx
+++ b/packages/web/src/content/blog/agent-memory-working-set.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Your agent's memory should scale from 6 lessons to 60,000"
 description: "The obvious answer to agent memory — inject the lessons — breaks the moment your store gets interesting. LoreKit spends a fixed slice of your context window on the highest-signal, de-duplicated lessons, so the read costs the same at 6 lessons or 60,000 — and always tells you what it left out. Here's how it scales, and the honest limits."
-date: "2026-12-01"
+date: "2026-08-22"
 author: "Mads Thines"
 readingMinutes: 8
 tags: ["agent-memory", "context-window", "retrieval", "ranking", "lorekit"]

--- a/packages/web/src/content/blog/give-your-agent-a-memory.mdx
+++ b/packages/web/src/content/blog/give-your-agent-a-memory.mdx
@@ -173,7 +173,7 @@ Honest boundary while you're deciding: there's no semantic search here, and noth
 
 The obvious worry about a store that only grows: it gets worse the more it learns. A folder with six lessons injects six lines. A year-old team store with sixty thousand can't inject sixty thousand.
 
-It doesn't. The read spends a fixed slice of your context window — not a fixed number of lessons — on the highest-signal, de-duplicated ones, and tells you exactly what it left out. Same code, both ends of the range. A follow-up post digs into exactly how that scales.
+It doesn't. The read spends a fixed slice of your context window — not a fixed number of lessons — on the highest-signal, de-duplicated ones, and tells you exactly what it left out. Same code, both ends of the range. That's the next post: [Your agent's memory should scale from 6 lessons to 60,000](/blog/agent-memory-working-set).
 
 ## Start local today
 

--- a/packages/web/src/lib/blog/content.ts
+++ b/packages/web/src/lib/blog/content.ts
@@ -86,17 +86,19 @@ export const getPost = cache((slug: string): Post | null => {
 });
 
 /**
- * Every VISIBLE post, newest first. In production, future-dated drafts are
- * omitted — which also removes them from `generateStaticParams`, so with
- * `dynamicParams = false` their URL 404s until the date lands. On preview/dev,
- * drafts are kept (listed with a badge and reachable) so they can be reviewed
- * before going live. This is the single seam that gates draft visibility; the
- * detail route relies on it rather than re-checking, so the rule lives here.
+ * Every VISIBLE post, **newest first by `date`** (ISO strings sort
+ * chronologically; ties fall back to the registry `order`). In production,
+ * future-dated drafts are omitted — which also removes them from
+ * `generateStaticParams`, so with `dynamicParams = false` their URL 404s until
+ * the date lands. On preview/dev, drafts are kept (listed with a badge and
+ * reachable) so they can be reviewed before going live. This is the single seam
+ * that gates draft visibility; the detail route relies on it rather than
+ * re-checking, so the rule lives here.
  */
 export const getAllPosts = cache((): Post[] => {
   const showDrafts = draftsVisible();
   return BLOG_SLUGS.map((slug) => getPost(slug))
     .filter((p): p is Post => p !== null)
     .filter((p) => showDrafts || !p.isDraft)
-    .sort((a, b) => a.order - b.order);
+    .sort((a, b) => b.date.localeCompare(a.date) || a.order - b.order);
 });

--- a/packages/web/src/lib/blog/content.ts
+++ b/packages/web/src/lib/blog/content.ts
@@ -5,7 +5,21 @@ import { cache } from 'react';
 import matter from 'gray-matter';
 import { BLOG_SLUGS } from './sections';
 import { extractToc, type TocItem } from './toc';
-import { isPublished } from './publish';
+import { isPublished, draftsVisibleIn } from './publish';
+import { resolveDeploymentEnvironment } from '../otel-deployment-env';
+
+/**
+ * Whether future-dated drafts are listed and reachable in THIS deployment.
+ * True on preview / development / local, false in production — so a draft is
+ * previewable on Vercel but never leaks to prod (where it also 404s, since
+ * `generateStaticParams` derives from {@link getAllPosts}). Resolved through the
+ * shared `resolveDeploymentEnvironment` per the "VERCEL_ENV never decides alone"
+ * rule.
+ */
+export const draftsVisible = (): boolean =>
+  draftsVisibleIn(
+    resolveDeploymentEnvironment(process.env.VERCEL_ENV, process.env.NODE_ENV).name,
+  );
 
 /**
  * Server-only blog content layer. Reads the MDX files under
@@ -33,6 +47,11 @@ export interface PostMeta {
   /** Listing order — must agree with the `BLOG_SECTIONS` index. */
   order: number;
   keywords: string[];
+  /**
+   * A future-dated post not yet published. In production these are filtered out
+   * entirely; on preview/dev they render with a "not yet live" notice.
+   */
+  isDraft: boolean;
 }
 
 export interface Post extends PostMeta {
@@ -57,6 +76,7 @@ export const getPost = cache((slug: string): Post | null => {
       tags: Array.isArray(data['tags']) ? data['tags'].map(String) : [],
       order: Number(data['order'] ?? 999),
       keywords: Array.isArray(data['keywords']) ? data['keywords'].map(String) : [],
+      isDraft: !isPublished(String(data['date'] ?? '')),
       body: content,
       toc: extractToc(content),
     };
@@ -66,15 +86,17 @@ export const getPost = cache((slug: string): Post | null => {
 });
 
 /**
- * Every PUBLISHED post, newest first. Future-dated posts are omitted (see
- * {@link isPublished}) — which also removes them from `generateStaticParams`, so
- * with `dynamicParams = false` their URL 404s until the date lands. This is the
- * single seam that gates draft visibility; the detail route relies on it rather
- * than re-checking, so the rule lives in one place.
+ * Every VISIBLE post, newest first. In production, future-dated drafts are
+ * omitted — which also removes them from `generateStaticParams`, so with
+ * `dynamicParams = false` their URL 404s until the date lands. On preview/dev,
+ * drafts are kept (listed with a badge and reachable) so they can be reviewed
+ * before going live. This is the single seam that gates draft visibility; the
+ * detail route relies on it rather than re-checking, so the rule lives here.
  */
-export const getAllPosts = cache((): Post[] =>
-  BLOG_SLUGS.map((slug) => getPost(slug))
+export const getAllPosts = cache((): Post[] => {
+  const showDrafts = draftsVisible();
+  return BLOG_SLUGS.map((slug) => getPost(slug))
     .filter((p): p is Post => p !== null)
-    .filter((p) => isPublished(p.date))
-    .sort((a, b) => a.order - b.order),
-);
+    .filter((p) => showDrafts || !p.isDraft)
+    .sort((a, b) => a.order - b.order);
+});

--- a/packages/web/src/lib/blog/publish.spec.ts
+++ b/packages/web/src/lib/blog/publish.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isPublished } from './publish';
+import { isPublished, draftsVisibleIn } from './publish';
 
 const NOW = new Date('2026-08-15T12:00:00Z');
 
@@ -27,5 +27,17 @@ describe('isPublished', () => {
   it('fails open on an unparseable date so a typo never buries a real post', () => {
     expect(isPublished('not-a-date', NOW)).toBe(true);
     expect(isPublished('', NOW)).toBe(true);
+  });
+});
+
+describe('draftsVisibleIn', () => {
+  it('hides drafts in production only', () => {
+    expect(draftsVisibleIn('production')).toBe(false);
+  });
+
+  it('shows drafts on preview, development, and local', () => {
+    expect(draftsVisibleIn('preview')).toBe(true);
+    expect(draftsVisibleIn('development')).toBe(true);
+    expect(draftsVisibleIn('local')).toBe(true);
   });
 });

--- a/packages/web/src/lib/blog/publish.ts
+++ b/packages/web/src/lib/blog/publish.ts
@@ -25,3 +25,17 @@ export function isPublished(dateStr: string, now: Date = new Date()): boolean {
   const today = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
   return postDay <= today;
 }
+
+/**
+ * Whether unpublished drafts (future-dated posts) are LISTED and reachable in a
+ * given deployment environment. They are everywhere EXCEPT production, so a
+ * finished post can be read and shared on a Vercel **preview** deployment while
+ * staying hidden — and 404 — in prod. The caller resolves the environment with
+ * the shared `resolveDeploymentEnvironment` (which cross-checks `VERCEL_ENV`
+ * against `NODE_ENV`, so a stray `VERCEL_ENV=production` on a dev machine can't
+ * accidentally hide drafts locally, nor a preview build accidentally show them
+ * in prod).
+ */
+export function draftsVisibleIn(deploymentEnv: string): boolean {
+  return deploymentEnv !== 'production';
+}

--- a/packages/web/src/lib/blog/sections.ts
+++ b/packages/web/src/lib/blog/sections.ts
@@ -5,9 +5,10 @@
  * `src/content/blog/<id>.mdx` file (with matching frontmatter) AND adding its
  * entry here. The drift guard `sections.spec.ts` fails if the two disagree.
  *
- * `id` is the URL slug and the MDX filename stem. Order here is the LISTING order
- * on `/blog` (newest first); the post's own `date` frontmatter is the displayed
- * date, and `order` frontmatter must agree with this array's index.
+ * `id` is the URL slug and the MDX filename stem. The `/blog` index sorts posts
+ * by their `date` frontmatter (newest first — see `getAllPosts`); `order` here is
+ * the registry's own stable index, which the post's `order` frontmatter must
+ * agree with (`sections.spec.ts` guards the drift).
  */
 export interface BlogSection {
   /** URL slug and MDX filename stem. */


### PR DESCRIPTION
## What

A batch of blog changes on the shared blog branch. Three related things:

### 1. Draft preview on Vercel (the original change)
Future-dated posts were hidden in **every** environment. Now they're **listed, reachable, and tagged "not yet live"** on preview/dev, while staying hidden **and 404** in production. Resolved via the shared `resolveDeploymentEnvironment` (`draftsVisibleIn` / `draftsVisible`); `getAllPosts` gates on it, and the detail route guards with `notFound()` as defence in depth. Posts carry an `isDraft` flag; the detail page shows a subtle `DraftNotice` ("Preview — not yet live. Scheduled for …"), the card a "Not yet live" badge.

### 2. Date-sorted index + the scaling post dated
`getAllPosts` now sorts the `/blog` index by `date` (newest first, tie-broken by registry `order`). "Your agent's memory should scale from 6 → 60,000" is dated **2026-08-22** (no longer a draft — it publishes on the next prod deploy after merge), and its forward link from the on-ramp post is restored.

### 3. New post (draft): "Agent memory doesn't need embeddings — it needs a schema"
`content/blog/agent-memory-data-model.mdx`, **date-gated 2026-09-05** (previewable, not live). Design-rationale case for LoreKit's deterministic, no-embeddings data model — field-by-field record rationale, the scope grammar as the portable bit, structure-vs-similarity retrieval, honest limits, and an **invitation** (not a standard decree) to converge on a shared record shape + scope grammar. Three new figures (`scope-hierarchy`, `memory-record`, `structure-vs-similarity`).

## Notes
- Prose in the new post run through the humanizer.
- `draftsVisibleIn` covered in `publish.spec`; blog specs (MDX pipeline for every post + `sections.spec` drift guard) and web typecheck green; all SVGs validate with `xmllint`.
- No `llms.txt` impact (blog is self-contained); no config/contract changes.

## Publish state
- The **scaling post** goes live in prod on the next deploy after merge (dated today).
- The **data-model post** stays a hidden draft (2026-09-05) — previewable on this branch's Vercel preview, hidden in prod, until you set a real date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)