### PR TITLE
fix(ci): derive the load test's Supabase URL from PROJECT_REF, and make its tee step able to fail

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -22,6 +22,24 @@
 # 90 % of the requested one, which is the signal that the runner is the
 # bottleneck.
 #
+# ENVIRONMENT SECRETS (`preview` and `production` each need all three)
+#   SUPABASE_PROJECT_REF       — already present; deploy.yml and preview.yml use
+#                                it. The project URL is DERIVED from it below
+#                                rather than stored again: a second secret
+#                                holding the same project is a second thing to
+#                                get out of sync, and every other workflow in
+#                                this repo already builds its URLs this way.
+#   SUPABASE_ANON_KEY          — already present; signing a provisioned user in
+#                                uses the anon key.
+#   SUPABASE_SERVICE_ROLE_KEY  — NEW, and the one thing here that cannot be
+#                                derived. Provisioning and deleting users goes
+#                                through the Auth admin API, and the
+#                                `lorekit_db_query_stats()` snapshot is
+#                                service-role-only, so a weaker credential
+#                                cannot run this workflow at all. Copy it from
+#                                Supabase ▸ Project Settings ▸ API ▸ `service_role`
+#                                for the SAME project as SUPABASE_PROJECT_REF.
+#
 # Full design and method: docs/benchmarking.md.
 
 name: Load test
@@ -69,8 +87,21 @@ jobs:
       contents: read
     timeout-minutes: 30
 
+    # Derived ONCE for the whole job, so the pre-check, the run and the sweeper
+    # cannot disagree about which project they are pointing at. `SUPABASE_URL` is
+    # the script's env contract (a plain URL is the right local interface); the
+    # workflow's job is to build it from the ref this repo already stores.
+    #
+    # Only the two NON-secret values live at job scope. The keys stay on the
+    # steps that actually need them, so `checkout` and `setup-node` never see a
+    # service-role credential.
+    env:
+      SUPABASE_URL: https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co
+      TARGET: ${{ inputs.target || 'preview' }}
+
     steps:
-      - uses: actions/checkout@v7.0.1
+      - name: Check out the repository
+        uses: actions/checkout@v7.0.1
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -80,40 +111,59 @@ jobs:
       # Fail with a NAMED list rather than letting the script die on the first
       # missing value — mirrors deploy.yml's secret pre-check, because "which
       # secret" is the only question worth answering here.
+      #
+      # SUPABASE_PROJECT_REF is checked directly rather than through the derived
+      # SUPABASE_URL: with the ref unset the URL still interpolates to the
+      # syntactically valid `https://.supabase.co`, so a non-empty check on the
+      # URL would pass and the failure would resurface much later as a DNS error
+      # naming no secret at all.
       - name: Check the environment's secrets
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
         run: |
+          set -euo pipefail
           missing=""
-          [ -n "$SUPABASE_URL" ]              || missing="$missing SUPABASE_URL"
+          [ -n "$SUPABASE_PROJECT_REF" ]      || missing="$missing SUPABASE_PROJECT_REF"
           [ -n "$SUPABASE_SERVICE_ROLE_KEY" ] || missing="$missing SUPABASE_SERVICE_ROLE_KEY"
           [ -n "$SUPABASE_ANON_KEY" ]         || missing="$missing SUPABASE_ANON_KEY"
           if [ -n "$missing" ]; then
-            echo "::error::Missing secrets for the '${{ inputs.target || 'preview' }}' environment:$missing. Add them under Settings ▸ Environments."
+            echo "::error::Missing secrets for the '$TARGET' environment:$missing. Add them under Settings ▸ Environments ▸ $TARGET. SUPABASE_SERVICE_ROLE_KEY comes from Supabase ▸ Project Settings ▸ API ▸ service_role, for the same project as SUPABASE_PROJECT_REF; the other two are already used by deploy.yml."
             exit 1
           fi
+          # Deliberately NOT echoing the resolved project ref. It is stored as a
+          # secret, so Actions masks it and the line would read `project: ***` —
+          # worse than nothing, because it looks like a diagnostic. The job name
+          # (`Load test → <target>`) plus the `environment:` on the run page are
+          # what identify which deployment was driven. The same masking applies
+          # to the script's own `(https://***.supabase.co)` banner line.
+          echo "Secrets present for '$TARGET'."
 
       # The load test's own logic is unit-tested; run those first so a broken
       # percentile or a mis-built schedule fails in seconds rather than after
       # provisioning users against a real project.
       - name: Unit-test the load-test logic
         run: |
+          set -euo pipefail
           node --test scripts/load-test-lib.test.mjs
           node --test scripts/load-telemetry.test.mjs
 
       - name: Run the load test
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           # Absent → the run still prints its report and says the export was
           # skipped. A missing telemetry token must not fail a load test.
           LOREKIT_TELEMETRY_TOKEN: ${{ secrets.LOREKIT_TELEMETRY_TOKEN }}
         run: |
+          # `pipefail` is load-bearing, not boilerplate: GitHub's default shell
+          # is `bash -e`, which takes a pipeline's exit status from its LAST
+          # command. Without this, `node … | tee` reports tee's success and a
+          # load test that died mid-run would have gone GREEN.
+          set -euo pipefail
           node scripts/load-test.mjs \
-            --target "${{ inputs.target || 'preview' }}" \
+            --target "$TARGET" \
             --rps "${{ inputs.rps || '20' }}" \
             --duration "${{ inputs.duration || '120' }}" \
             --users "${{ inputs.users || '5' }}" \
@@ -121,9 +171,16 @@ jobs:
 
       # The report is the artefact worth keeping: the client percentiles and the
       # per-statement delta, on a run whose Dash0 trace may be sampled away.
+      # (The same text is `tee`-d to the log above — the artefact is for
+      # diffing two runs, not for reading this one.)
       - name: Upload the report
         if: always()
-        uses: actions/upload-artifact@v4
+        # v6, not v5: run 32580068106 warned that this action targets Node 20 and
+        # is being force-run on Node 24. `v5` is STILL `using: node20` — only v6
+        # declares node24 — so v5 would not have cleared the deprecation. Same
+        # three inputs in both. This workflow is the repo's only upload-artifact
+        # caller, so the bump is local.
+        uses: actions/upload-artifact@v6
         with:
           name: load-report-${{ inputs.target || 'preview' }}-${{ github.run_id }}
           path: load-report.txt
@@ -132,9 +189,16 @@ jobs:
       # Belt and braces. The script deletes its users in a `finally`, so this
       # only fires if the job was killed hard enough to skip that — a runner
       # timeout or a cancellation. Residue is real rows in a real project.
+      #
+      # Deliberately not `-e`: a failed sweep must not turn a green load test
+      # red, but it must say so with the exit code rather than swallowing it.
       - name: Sweep any residue
         if: always()
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: node scripts/load-test-cleanup.mjs || echo "::warning::Residue sweep failed; check for loadtest-* users."
+        run: |
+          set -uo pipefail
+          node scripts/load-test-cleanup.mjs && rc=0 || rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::Residue sweep exited $rc; check the '$TARGET' project for leftover loadtest-* users."
+          fi

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -158,6 +158,29 @@ Env: `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, `SUPABASE_ANON_KEY`, and
 optionally `LOREKIT_TELEMETRY_TOKEN` to export. A missing telemetry token
 degrades to "export skipped" and never fails the run.
 
+#### Environment secrets the workflow needs
+
+Both the `preview` and `production` GitHub Environments need all three. The
+workflow pre-checks them and fails with a **named** list, because "which secret"
+is the only useful question at that point.
+
+| Secret | Status | Where it comes from |
+|---|---|---|
+| `SUPABASE_PROJECT_REF` | already there — `deploy.yml` and `preview.yml` use it | the project's ref |
+| `SUPABASE_ANON_KEY` | already there — `deploy.yml` uses it | Supabase ▸ Project Settings ▸ API |
+| `SUPABASE_SERVICE_ROLE_KEY` | **must be added** | Supabase ▸ Project Settings ▸ API ▸ `service_role`, for the same project as the ref |
+
+`SUPABASE_URL` is **not** a secret — the workflow derives it as
+`https://${SUPABASE_PROJECT_REF}.supabase.co`, the way every other workflow here
+builds its URLs. Storing the project twice is two things to keep in sync, and
+the first dispatch of this workflow failed for exactly that reason: it asked for
+a `SUPABASE_URL` secret that had never existed in this repo.
+
+The service-role key is the one credential that genuinely cannot be avoided or
+weakened: provisioning and deleting users goes through the **Auth admin API**,
+and the `lorekit_db_query_stats()` snapshot is service-role-only. A `lk_rw_*`
+token cannot do either, so there is no lower-privilege version of this run.
+
 ### What a run does
 
 1. Provisions `--users` confirmed users through the Auth admin API and signs
@@ -278,6 +301,14 @@ on:
 - Stamp `X-LoreKit-Deployment-Environment: test` and a correlation id of
   `gh-run-<run_id>`, so the run filters apart in Dash0 and `?correlation_id=`
   scopes the usage read to it.
+- **Every `run:` block sets `set -euo pipefail`, and the `pipefail` is
+  load-bearing.** The drive step is `node scripts/load-test.mjs … | tee
+  load-report.txt`, and GitHub's default shell is `bash -e` — which takes a
+  pipeline's status from its **last** command. Without `pipefail` the step reads
+  `tee`'s success, so a load test that died mid-run reported **green**. The one
+  exception is the residue sweeper, which drops `-e` deliberately: a failed sweep
+  must not fail a good load test, so it captures the exit code and emits it as a
+  `::warning::` rather than swallowing it.
 
 ### Method
 


### PR DESCRIPTION
The load-test workflow from #528 failed on its first dispatch ([run 32580068106](https://github.com/mthines/lorekit/actions/runs/32580068106)). Fixing that, plus a worse bug in the same file found by auditing it.

## Why it failed

```
env:
  SUPABASE_URL:                (empty)
  SUPABASE_SERVICE_ROLE_KEY:   (empty)
  SUPABASE_ANON_KEY:           ***
##[error]Missing secrets for the 'preview' environment: SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY.
```

The pre-check did exactly its job — the secret **names** were wrong. `SUPABASE_URL` was invented by this workflow and exists nowhere else in the repo; the other 26 references build project URLs from `SUPABASE_PROJECT_REF`. It is now derived the same way, at job scope, so the pre-check, the drive step and the residue sweeper cannot disagree about which project they point at.

The ref is checked **directly** rather than through the derived URL: with the ref unset, `https://${{ secrets.SUPABASE_PROJECT_REF }}.supabase.co` still interpolates to a syntactically valid `https://.supabase.co`, so a non-empty test on the URL would pass and the failure would resurface much later as a DNS error naming no secret at all.

## The worse bug — not the one that failed the run

The drive step was:

```yaml
node scripts/load-test.mjs … | tee load-report.txt
```

GitHub's default shell is `bash -e`, which takes a pipeline's exit status from its **last** command. Verified locally:

```console
$ bash -e -c 'false | tee out.txt'; echo $?
0                                     # ← the step goes GREEN

$ bash -c 'set -euo pipefail; false | tee out.txt'; echo $?
1
```

So **a load test that died mid-run reported success** and uploaded a truncated report. Every `run:` block now sets `set -euo pipefail`. The residue sweeper drops `-e` on purpose — a failed sweep must not fail a good load test — but it now captures the exit code into the `::warning::` instead of swallowing it behind `|| echo`.

`pipefail` already appears in three other workflows here, and `| tee` appeared only in this one, so this was a local regression rather than a house style.

## Also from the audit

- **`upload-artifact@v4` → `v6`.** The run log warned twice that the action targets Node 20 and is being force-run on Node 24. My first instinct was `v5`; reading the actual `action.yml` showed **v5 is still `using: node20`** and only v6 declares `node24`, so the obvious bump would not have cleared it. Same three inputs (`name`, `path`, `if-no-files-found`), and this workflow is the repo's only `upload-artifact` caller.
- **Secrets moved off job scope** onto the three steps that use them, so `checkout` and `setup-node` never see a service-role credential. Only the two non-secret values (`SUPABASE_URL`, `TARGET`) stay at job scope, which is what gives the single derivation point.
- **The checkout step gained a `name:`** — every other step already had one.
- **Dropped an echo I had added** that would have printed `project: ***`: the ref is stored as a secret, so Actions masks it and the line would have looked like a diagnostic while saying nothing. The comment now records that the same masking applies to the script's own `https://***.supabase.co` banner.

## Reported and deliberately NOT changed

Both would make this file a lone deviation from repo convention:

- Actions stay **tag-pinned**, not SHA-pinned (28 × `checkout@v7.0.1`, 19 × `setup-node@v7`; SHA-pinning is the minority style here).
- `node-version: 20` matches the other 19 occurrences and is unrelated to the *action-runtime* deprecation the log warned about.

## `SUPABASE_SERVICE_ROLE_KEY` still has to be added by hand

This is the one thing the PR cannot fix. Provisioning and deleting users goes through the **Auth admin API**, and the `lorekit_db_query_stats()` snapshot is service-role-only — a `lk_rw_*` token can do neither, so there is no lower-privilege version of this run. Both the workflow header and the error message now name where to get it (Supabase ▸ Project Settings ▸ API ▸ `service_role`) and for which project.

Because `workflow_dispatch` runs the workflow file from the default branch, the fix only takes effect once this is merged.

## Verification

- The pre-check self-tested in all three states: the **exact** failing config from run 32580068106 (fails, names both), service-key-still-missing (fails, names one), fully configured (passes).
- The `pipefail` bug reproduced and the fix confirmed, as shown above.
- The sweeper's `rc`-capture tested on both paths: exit 3 → warning emitted, step exits 0; exit 0 → no warning.
- YAML re-parsed; every step named; all four `run:` blocks set shell options on their first line.
- 40 load-test unit tests pass.

**Caveat that stands:** the workflow still has not completed a real run end to end. Everything in #528 was verified against a strict local mock, and this run never got past the pre-check.

## Docs

`docs/benchmarking.md` gains the environment-secret table (which two already exist, which one is new, and why `SUPABASE_URL` is derived rather than stored) and the `pipefail` rationale under Method.

`llms.txt` not regenerated — no MCP tool, CLI command, REST route, config key, limit or dashboard surface changed. This is CI configuration and a contributor runbook.

https://claude.ai/code/session_01KgoxEsXNRCsr68b2P9cmTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgoxEsXNRCsr68b2P9cmTJ)_