### PR TITLE
fix(bench): decide the two decidable causes of a Supabase 401 before provisioning

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -181,6 +181,45 @@ weakened: provisioning and deleting users goes through the **Auth admin API**,
 and the `lorekit_db_query_stats()` snapshot is service-role-only. A `lk_rw_*`
 token cannot do either, so there is no lower-privilege version of this run.
 
+#### Legacy `service_role` JWT or the new `sb_secret_…` key?
+
+Supabase has two key generations, and both are offered in the dashboard during
+migration. **Either works here** — the scripts send the key in *both* the
+`apikey` header and `Authorization: Bearer`, which is the shape both generations
+accept — so the key TYPE is not what a `401` is telling you.
+
+| If legacy keys are… | Use |
+|---|---|
+| still enabled (the default) | either the legacy `service_role` JWT or `sb_secret_…` |
+| **disabled** on the project | `sb_secret_…` only — a legacy JWT then returns `Invalid API key` |
+
+Never `sb_publishable_…` or the `anon` JWT: those are the browser-safe keys and
+cannot reach `/auth/v1/admin`.
+
+#### Reading a `401 {"message":"Invalid API key"}`
+
+Supabase returns that same body for **four** different mistakes, so the response
+alone does not identify which. Three of them are not about the key's format at
+all, which is what makes the built-in hint ("Double check your `anon` or
+`service_role` API key") misleading — it points at the one thing that is usually
+fine.
+
+`checkServiceCredential()` in `scripts/load-test-lib.mjs` decides the two
+decidable ones **offline**, before the first request, by decoding the JWT's
+`role` and `ref` claims:
+
+| Cause | How it is caught |
+|---|---|
+| key is for **another project** | `ref` claim vs the URL's subdomain — the likeliest cause after any change to how the URL is derived |
+| **anon key in the service slot** (or the two swapped) | `role` claim |
+| key **revoked / rotated** | not decidable offline — reported after the 401 |
+| **legacy keys disabled** on the project | not decidable offline — reported after the 401 |
+
+An opaque `sb_secret_…` key carries no claims, so it warns ("cannot be checked
+offline") and always proceeds — a check that rejects a valid configuration is
+worse than the 401 it replaces. Self-hosted URLs yield no project ref, so no
+mismatch is ever asserted against them.
+
 ### What a run does
 
 1. Provisions `--users` confirmed users through the Auth admin API and signs

--- a/scripts/load-test-cleanup.mjs
+++ b/scripts/load-test-cleanup.mjs
@@ -30,6 +30,8 @@
  *   … --dry-run           # list what WOULD be deleted
  */
 
+import { checkServiceCredential } from './load-test-lib.mjs';
+
 /**
  * The one pattern that decides what is ours to touch.
  *
@@ -96,6 +98,12 @@ if (isMain) {
     const res = await fetch(`${supabaseUrl}/auth/v1/admin/users?page=${page}&per_page=200`, { headers: admin });
     if (!res.ok) {
       console.error(`✗ listing users failed: ${res.status} ${(await res.text()).slice(0, 200)}`);
+      // A 401 here reads as a bad key but is usually a MISMATCHED one, so say
+      // which before exiting — the sweeper runs `if: always()`, so this is
+      // often the only place the operator sees the credential explained.
+      for (const e of checkServiceCredential({ serviceKey, anonKey: '', supabaseUrl }).errors) {
+        console.error(`  → ${e}`);
+      }
       process.exit(1);
     }
     const body = await res.json();

--- a/scripts/load-test-lib.mjs
+++ b/scripts/load-test-lib.mjs
@@ -228,3 +228,110 @@ export function dbShare(results, queryDiff) {
   if (clientMs <= 0) return null;
   return { clientMs, dbMs, ratio: dbMs / clientMs };
 }
+
+// ── credential pre-flight ────────────────────────────────────────────────────
+
+/**
+ * Classify a Supabase API key WITHOUT calling anything.
+ *
+ * Supabase has two generations of key, and both are live on a project during
+ * migration, so the dashboard offers both and picking the wrong one is easy:
+ *
+ *   * legacy — a JWT (`eyJ…`) whose payload carries `role` (`anon` /
+ *     `service_role`) and `ref` (the project it belongs to).
+ *   * current — an opaque `sb_publishable_…` (replaces `anon`) or
+ *     `sb_secret_…` (replaces `service_role`). Nothing is decodable.
+ *
+ * The point of decoding rather than just trying the request: Supabase answers
+ * every one of "wrong project", "anon key in the service slot" and "key
+ * revoked" with the same `401 {"message":"Invalid API key"}`. That is a true
+ * statement and a useless diagnostic — it cost a CI round-trip to learn
+ * nothing. A legacy JWT is base64 and self-describing, so which of those it is
+ * can be settled locally, before the first byte goes out.
+ *
+ * Never throws and never returns the key. `format: 'unknown'` is the honest
+ * answer for anything unrecognised — a self-hosted or future key shape must not
+ * be reported as invalid.
+ */
+export function describeSupabaseKey(key) {
+  const raw = (key ?? '').trim();
+  if (!raw) return { format: 'absent' };
+  if (raw.startsWith('sb_secret_')) return { format: 'new-secret', privileged: true };
+  if (raw.startsWith('sb_publishable_')) return { format: 'new-publishable', privileged: false };
+
+  const parts = raw.split('.');
+  if (parts.length !== 3) return { format: 'unknown' };
+  try {
+    // Base64URL, and JWT payloads are unpadded — Buffer needs the padding back.
+    const pad = '='.repeat((4 - (parts[1].length % 4)) % 4);
+    const claims = JSON.parse(Buffer.from(parts[1].replace(/-/g, '+').replace(/_/g, '/') + pad, 'base64').toString('utf8'));
+    const role = typeof claims.role === 'string' ? claims.role : undefined;
+    return {
+      format: 'legacy-jwt',
+      role,
+      ref: typeof claims.ref === 'string' ? claims.ref : undefined,
+      privileged: role === 'service_role',
+    };
+  } catch {
+    return { format: 'unknown' };
+  }
+}
+
+/** The project ref in a hosted Supabase URL, or undefined for anything else. */
+export function projectRefFromUrl(url) {
+  const m = /^https?:\/\/([a-z0-9-]+)\.supabase\.(?:co|in)$/i.exec((url ?? '').trim().replace(/\/+$/, ''));
+  return m ? m[1].toLowerCase() : undefined;
+}
+
+/**
+ * Pre-flight the service-role credential against the URL it will be used on.
+ *
+ * Returns `{ errors, warnings }`. The split matters: an error is something that
+ * CANNOT work and is worth refusing before provisioning users against a real
+ * project; a warning is something merely unverifiable. An opaque `sb_secret_…`
+ * key is entirely unverifiable offline, and that is fine — it must pass.
+ *
+ * Deliberately conservative. A check that rejects a valid configuration is
+ * worse than the 401 it replaces, because the 401 at least came from the
+ * authority on the question.
+ */
+export function checkServiceCredential({ serviceKey, anonKey, supabaseUrl }) {
+  const errors = [];
+  const warnings = [];
+  const svc = describeSupabaseKey(serviceKey);
+  const anon = describeSupabaseKey(anonKey);
+  const urlRef = projectRefFromUrl(supabaseUrl);
+
+  // Unmistakable: a key that is documented as browser-safe cannot create users.
+  if (svc.format === 'new-publishable') {
+    errors.push('SUPABASE_SERVICE_ROLE_KEY holds a `sb_publishable_…` key. That is the browser-safe key (the `anon` replacement) and cannot reach /auth/v1/admin. Use the `sb_secret_…` key, or the legacy `service_role` JWT.');
+  }
+  if (svc.format === 'legacy-jwt' && svc.role && svc.role !== 'service_role') {
+    errors.push(`SUPABASE_SERVICE_ROLE_KEY holds a legacy JWT with role "${svc.role}", not "service_role". Copy the service_role key (Project Settings ▸ API), not the anon one.`);
+  }
+  // Both refs known and different: the key is valid, for another project. This
+  // is the failure that reads as "Invalid API key" and sends you hunting the
+  // key format when the key was never the problem.
+  if (svc.format === 'legacy-jwt' && svc.ref && urlRef && svc.ref !== urlRef) {
+    errors.push(`SUPABASE_SERVICE_ROLE_KEY belongs to project "${svc.ref}" but the target URL is project "${urlRef}". Copy the service_role key from the SAME project the ref points at — Supabase reports this as "Invalid API key", which looks like a bad key rather than a mismatched one.`);
+  }
+  if (anon.format === 'legacy-jwt' && anon.ref && urlRef && anon.ref !== urlRef) {
+    errors.push(`SUPABASE_ANON_KEY belongs to project "${anon.ref}" but the target URL is project "${urlRef}".`);
+  }
+  if (anon.privileged === true) {
+    errors.push('SUPABASE_ANON_KEY holds a privileged key (service_role / sb_secret). The keys look swapped.');
+  }
+
+  // Unverifiable rather than wrong — say so once and continue.
+  if (svc.format === 'new-secret') {
+    warnings.push('SUPABASE_SERVICE_ROLE_KEY is an opaque `sb_secret_…` key, so its project and role cannot be checked offline. A 401 from here means it is revoked, disabled, or from another project.');
+  }
+  if (svc.format === 'unknown') {
+    warnings.push('SUPABASE_SERVICE_ROLE_KEY is in an unrecognised format — neither a JWT nor an `sb_*` key. Continuing, but check it was pasted whole.');
+  }
+  if (svc.format === 'legacy-jwt' && !svc.ref) {
+    warnings.push('SUPABASE_SERVICE_ROLE_KEY is a legacy JWT with no `ref` claim, so it cannot be matched to the target project.');
+  }
+
+  return { errors, warnings };
+}

--- a/scripts/load-test-lib.test.mjs
+++ b/scripts/load-test-lib.test.mjs
@@ -5,9 +5,12 @@ import {
   DEFAULT_MIX,
   buildOpSequence,
   buildSchedule,
+  checkServiceCredential,
   dbShare,
+  describeSupabaseKey,
   diffQueryStats,
   percentile,
+  projectRefFromUrl,
   resolveTarget,
   summarize,
   totals,
@@ -258,4 +261,120 @@ test('a ratio above 1 is legal — that is what concurrency looks like', () => {
 test('no successful requests yields null rather than a divide by zero', () => {
   assert.equal(dbShare([{ op: 'x', status: 500, ms: 10 }], [{ totalMs: 5 }]), null);
   assert.equal(dbShare([], []), null);
+});
+
+// ── credential pre-flight ────────────────────────────────────────────────────
+
+/**
+ * These exist because of a real CI round-trip: run 32582427757 provisioned
+ * nothing and died on
+ *   POST /auth/v1/admin/users → 401 {"message":"Invalid API key"}
+ * which is the SAME response Supabase gives for a key from another project, an
+ * anon key in the service slot, and a revoked key. The 401 is true and useless;
+ * a legacy JWT is self-describing, so the distinction is decidable offline.
+ */
+
+/** Mint a legacy-shaped JWT. Only the payload is read, so the parts around it need not verify. */
+const legacyKey = (claims) =>
+  ['eyJhbGciOiJIUzI1NiJ9', Buffer.from(JSON.stringify(claims)).toString('base64url'), 'sig'].join('.');
+
+test('a legacy JWT is decoded to its role and project ref', () => {
+  const d = describeSupabaseKey(legacyKey({ role: 'service_role', ref: 'abcdefghijklmnopqrst' }));
+  assert.equal(d.format, 'legacy-jwt');
+  assert.equal(d.role, 'service_role');
+  assert.equal(d.ref, 'abcdefghijklmnopqrst');
+  assert.equal(d.privileged, true);
+});
+
+test('the two current key formats are told apart by privilege', () => {
+  assert.deepEqual(describeSupabaseKey('sb_secret_abc123'), { format: 'new-secret', privileged: true });
+  assert.deepEqual(describeSupabaseKey('sb_publishable_abc123'), { format: 'new-publishable', privileged: false });
+});
+
+test('an unrecognised key is `unknown`, never invalid', () => {
+  // A self-hosted or future key shape must not be reported as broken.
+  assert.equal(describeSupabaseKey('some-opaque-thing').format, 'unknown');
+  assert.equal(describeSupabaseKey('a.b.c').format, 'unknown'); // 3 parts, undecodable payload
+  assert.equal(describeSupabaseKey('').format, 'absent');
+  assert.equal(describeSupabaseKey(undefined).format, 'absent');
+});
+
+test('a project ref is read from a hosted URL only', () => {
+  assert.equal(projectRefFromUrl('https://pqokxlhvnosogizsjztg.supabase.co'), 'pqokxlhvnosogizsjztg');
+  assert.equal(projectRefFromUrl('https://pqokxlhvnosogizsjztg.supabase.co/'), 'pqokxlhvnosogizsjztg');
+  // Self-hosted: unknown rather than guessed, so no mismatch is ever asserted.
+  assert.equal(projectRefFromUrl('http://localhost:54321'), undefined);
+  assert.equal(projectRefFromUrl('https://supabase.example.com'), undefined);
+});
+
+test('a valid service_role JWT for the right project passes clean', () => {
+  const r = checkServiceCredential({
+    serviceKey: legacyKey({ role: 'service_role', ref: 'projectone' }),
+    anonKey: legacyKey({ role: 'anon', ref: 'projectone' }),
+    supabaseUrl: 'https://projectone.supabase.co',
+  });
+  assert.deepEqual(r.errors, []);
+  assert.deepEqual(r.warnings, []);
+});
+
+test('a key from ANOTHER project is named as a mismatch, not a bad key', () => {
+  const r = checkServiceCredential({
+    serviceKey: legacyKey({ role: 'service_role', ref: 'production' }),
+    anonKey: legacyKey({ role: 'anon', ref: 'previewproj' }),
+    supabaseUrl: 'https://previewproj.supabase.co',
+  });
+  assert.equal(r.errors.length, 1);
+  assert.match(r.errors[0], /belongs to project "production".*is project "previewproj"/);
+});
+
+test('an anon key in the service slot is rejected by role', () => {
+  const r = checkServiceCredential({
+    serviceKey: legacyKey({ role: 'anon', ref: 'projectone' }),
+    anonKey: legacyKey({ role: 'anon', ref: 'projectone' }),
+    supabaseUrl: 'https://projectone.supabase.co',
+  });
+  assert.equal(r.errors.length, 1);
+  assert.match(r.errors[0], /role "anon", not "service_role"/);
+});
+
+test('a publishable key in the service slot is rejected by format', () => {
+  const r = checkServiceCredential({
+    serviceKey: 'sb_publishable_xyz',
+    anonKey: 'sb_publishable_xyz',
+    supabaseUrl: 'https://projectone.supabase.co',
+  });
+  assert.equal(r.errors.length, 1);
+  assert.match(r.errors[0], /browser-safe key/);
+});
+
+test('swapped keys are caught even when both are for the right project', () => {
+  const r = checkServiceCredential({
+    serviceKey: legacyKey({ role: 'anon', ref: 'projectone' }),
+    anonKey: legacyKey({ role: 'service_role', ref: 'projectone' }),
+    supabaseUrl: 'https://projectone.supabase.co',
+  });
+  assert.equal(r.errors.length, 2); // wrong role in service slot AND privileged anon
+  assert.ok(r.errors.some((e) => /privileged key/.test(e)));
+});
+
+test('an opaque secret key WARNS but never blocks — it cannot be checked offline', () => {
+  const r = checkServiceCredential({
+    serviceKey: 'sb_secret_xyz',
+    anonKey: 'sb_publishable_xyz',
+    supabaseUrl: 'https://projectone.supabase.co',
+  });
+  assert.deepEqual(r.errors, []);
+  assert.equal(r.warnings.length, 1);
+  assert.match(r.warnings[0], /cannot be checked offline/);
+});
+
+test('a self-hosted URL asserts no mismatch', () => {
+  // The ref is unknowable from the URL, so a ref-bearing key must not be
+  // reported as belonging to the wrong project.
+  const r = checkServiceCredential({
+    serviceKey: legacyKey({ role: 'service_role', ref: 'anything' }),
+    anonKey: legacyKey({ role: 'anon', ref: 'anything' }),
+    supabaseUrl: 'http://localhost:54321',
+  });
+  assert.deepEqual(r.errors, []);
 });

--- a/scripts/load-test.mjs
+++ b/scripts/load-test.mjs
@@ -45,6 +45,7 @@ import {
   DEFAULT_MIX,
   buildOpSequence,
   buildSchedule,
+  checkServiceCredential,
   dbShare,
   diffQueryStats,
   resolveTarget,
@@ -386,6 +387,14 @@ if (!supabaseUrl) die('SUPABASE_URL is required.');
 if (!serviceKey) die('SUPABASE_SERVICE_ROLE_KEY is required — provisioning users needs the Auth admin API.');
 if (!anonKey) die('SUPABASE_ANON_KEY is required — signing a user in uses the anon key.');
 
+// Settle what can be settled offline. Supabase answers "wrong project", "anon
+// key in the service slot" and "revoked key" with the same
+// `401 {"message":"Invalid API key"}`, so a live 401 does not say which — and
+// finding out costs a CI round-trip that provisions nothing.
+const cred = checkServiceCredential({ serviceKey, anonKey, supabaseUrl });
+for (const w of cred.warnings) log(`  ! ${w}`);
+if (cred.errors.length) die(`credential check failed:\n  - ${cred.errors.join('\n  - ')}`);
+
 const run = {
   target,
   rps: Number(opts.rps),
@@ -418,7 +427,23 @@ if (target === 'production') {
 let users = [];
 try {
   log(`\n▸ Provisioning ${run.users} users`);
-  users = await provisionUsers({ supabaseUrl, serviceKey, anonKey, count: run.users, runId });
+  try {
+    users = await provisionUsers({ supabaseUrl, serviceKey, anonKey, count: run.users, runId });
+  } catch (err) {
+    // The pre-flight above already ruled out the two decidable causes of a 401
+    // (wrong project, wrong role). If one still arrives, the remaining causes
+    // are both invisible from here — so name them rather than leaving the
+    // operator with Supabase's "Double check your … API key" hint, which points
+    // at the key's FORMAT and is the one thing that is not wrong.
+    if (/→ 401\b/.test(err?.message ?? '') && cred.errors.length === 0) {
+      log('\n  The credential pre-flight passed, so the key is the right role for the right');
+      log('  project. A 401 here leaves two causes, neither visible offline:');
+      log('    1. The key was rotated or revoked — re-copy it from Project Settings ▸ API.');
+      log('    2. Legacy API keys are DISABLED on this project, which rejects a legacy');
+      log('       `service_role` JWT as "Invalid API key". Use the `sb_secret_…` key instead.');
+    }
+    throw err;
+  }
 
   log(`▸ Seeding ${opts.seed} lore rows per user`);
   const seeded = await seedLore({ endpoint, users, perUser: Number(opts.seed), runId, headers });


### PR DESCRIPTION
Follow-up to #536 (merged). That PR got the workflow far enough to make a real call; this one makes the call's failure legible.

## The failure

[Run 32582427757](https://github.com/mthines/lorekit/actions/runs/32582427757) passed the secret pre-check, derived the URL correctly, and died on the first real request:

```
POST …/auth/v1/admin/users → 401
{"hint":"Double check your Supabase `anon` or `service_role` API key.",
 "message":"Invalid API key"}
```

Supabase returns that **same body for four different mistakes**, so the response does not say which — and its hint points at the key's *format*, which is usually the one thing that is fine. Both scripts already send the key as both `apikey` and `Authorization: Bearer`, the shape a legacy `service_role` JWT and a current `sb_secret_…` key both accept, so the key generation was never the variable.

## Two of the four are decidable offline

A legacy key is a JWT, and its payload carries `role` and `ref`. So these need no network call:

| Cause | Decided by |
|---|---|
| key belongs to **another project** | `ref` claim vs the URL's subdomain — the likeliest cause straight after a change to how that URL is derived, which #536 was |
| **anon key in the service slot**, or the two swapped | `role` claim |

`describeSupabaseKey` / `projectRefFromUrl` / `checkServiceCredential` settle those before the first byte goes out, so the answer costs a local exit instead of a CI round-trip that provisions nothing:

```
✗ credential check failed:
  - SUPABASE_SERVICE_ROLE_KEY belongs to project "productionref" but the target URL
    is project "previewref". Copy the service_role key from the SAME project the ref
    points at — Supabase reports this as "Invalid API key", which looks like a bad
    key rather than a mismatched one.
```

The other two — a revoked key, or **legacy keys disabled** on the project — are invisible from here. So a 401 that survives a clean pre-flight now names them as the only remaining options, instead of repeating the misleading hint. The `if: always()` sweeper explains a 401 the same way, since on a failed run it is often the only step anyone reads.

## Deliberately conservative

A check that rejects a valid configuration is worse than the 401 it replaces — the 401 at least came from the authority on the question. So:

- an opaque `sb_secret_…` key carries no claims → **warns and proceeds**, never blocks
- an unrecognised shape is `unknown`, never `invalid` (a self-hosted or future key must not be called broken)
- a self-hosted URL yields no project ref, so no mismatch is ever asserted against one
- nothing prints the key — only its format, role and project ref

## Verification

- **11 new tests**, 59 across the three script suites. They cover each rejection *and* each must-not-reject: opaque secret key, unknown shape, self-hosted URL, and a correct key passing with zero output.
- End to end: a mismatched ref exits **1** with both projects named and issues **no HTTP**; matching refs pass silently through to provisioning.
- The 401 branch's condition is checked against the **verbatim** message from the failing run (and against a `403` and a `4010` to confirm the word boundary holds).

## Not verified

`supabase.com` is blocked by this sandbox's egress proxy, so the "either key generation works" claim rests on reading the header shape in our own scripts — not on Supabase's documentation. If `Authorization: Bearer sb_secret_…` turns out to be rejected by GoTrue (it may expect a user JWT there), the fix would be to send `sb_secret_` keys in `apikey` only. Worth knowing if the `sb_secret_` route is the one that ends up being needed.

## Docs

`docs/benchmarking.md` gains a legacy-vs-`sb_secret_` decision table (including that legacy keys being *disabled* is the one case that forces `sb_secret_`) and the four-row map from that single 401 body to its four distinct causes.

`llms.txt` not regenerated — no MCP tool, CLI command, REST route, config key or dashboard surface changed. Benchmark harness and contributor runbook only.

https://claude.ai/code/session_01KgoxEsXNRCsr68b2P9cmTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgoxEsXNRCsr68b2P9cmTJ)_