### PR TITLE
perf(edge): take the audit insert off the REST write response path

### DIFF
--- a/packages/mcp-core/src/audit-coverage.spec.ts
+++ b/packages/mcp-core/src/audit-coverage.spec.ts
@@ -181,8 +181,14 @@ describe('REST audit coverage', () => {
     (_key, route) => {
       const file = must(must(importsByFn, route.fn, 'imports'), route.handler, 'handler file');
       const source = readFileSync(file, 'utf8');
+      // `recordAuditDeferred` counts: it IS `recordAudit`, with the insert moved
+      // off the response path via `EdgeRuntime.waitUntil` (and falling back to
+      // awaiting where that hook is absent, so no row is ever dropped). The
+      // gate's question is "does this mutating route audit at all", and both
+      // spellings answer yes — but the alternation is deliberately narrow, so a
+      // handler that audits NOTHING still fails, which is the point.
       expect(
-        /\brecordAudit\s*\(/.test(source),
+        /\brecordAudit(Deferred)?\s*\(/.test(source),
         `${route.method} ${route.routePath} → ${route.handler} (${path.relative(repoRoot, file)}) ` +
           'is a mutating route but never calls recordAudit. Wire it up, or add it to AUDIT_EXEMPT with a reason.',
       ).toBe(true);

--- a/packages/mcp-core/src/edge-parity.spec.ts
+++ b/packages/mcp-core/src/edge-parity.spec.ts
@@ -59,10 +59,13 @@ function executableSource(file: string): string {
 // supabase/functions/_shared/audit.ts) but is deliberately ABSENT here: like
 // limits.ts, the edge copy is not import-free — it types the client as
 // `ReturnType<typeof createClient>` off an `npm:` specifier where mcp-core
-// types it as an imported `SupabaseClient`. Those two lines are the only
-// executable difference, but they are a real one, so a whole-file comparison
-// does not apply. buildAuditEntry/recordAudit are covered by audit.spec.ts on
-// the mcp-core copy.
+// types it as an imported `SupabaseClient`, so a whole-file comparison does not
+// apply. The edge copy additionally carries `recordAuditDeferred`, which hands
+// the insert to `EdgeRuntime.waitUntil` to keep it off the response path — a
+// runtime API that exists only on the edge and so has no mcp-core counterpart
+// to compare against. `buildAuditEntry` (the part that MUST stay
+// byte-consistent) and `recordAudit` are covered by audit.spec.ts on the
+// mcp-core copy.
 const MIRRORS: ReadonlyArray<readonly [string, string]> = [
   ['auth-token.ts', 'mcp/auth-token.ts'],
   ['created-at.ts', '_shared/created-at.ts'],

--- a/supabase/functions/_shared/audit.ts
+++ b/supabase/functions/_shared/audit.ts
@@ -58,6 +58,7 @@
  * RLS), so their inserts succeed regardless of `user_id`.
  */
 import { createClient } from 'npm:@supabase/supabase-js@2';
+import { background } from './background.ts';
 import { AUDIT_ACTIONS } from './schemas/audit.ts';
 import type { AuditAction } from './schemas/audit.ts';
 import type { DbClient } from './db-client.ts';
@@ -126,14 +127,6 @@ export async function recordAudit(
   } catch (err) {
     console.error(`[recordAudit] unexpected error for action=${input.action}:`, (err as Error).message);
   }
-}
-
-interface WaitUntilHost { waitUntil(p: Promise<unknown>): void }
-
-/** The runtime's background-task hook, when it has one. */
-function background(): WaitUntilHost | null {
-  const rt = (globalThis as { EdgeRuntime?: unknown }).EdgeRuntime as WaitUntilHost | undefined;
-  return rt && typeof rt.waitUntil === 'function' ? rt : null;
 }
 
 /**

--- a/supabase/functions/_shared/audit.ts
+++ b/supabase/functions/_shared/audit.ts
@@ -127,3 +127,54 @@ export async function recordAudit(
     console.error(`[recordAudit] unexpected error for action=${input.action}:`, (err as Error).message);
   }
 }
+
+interface WaitUntilHost { waitUntil(p: Promise<unknown>): void }
+
+/** The runtime's background-task hook, when it has one. */
+function background(): WaitUntilHost | null {
+  const rt = (globalThis as { EdgeRuntime?: unknown }).EdgeRuntime as WaitUntilHost | undefined;
+  return rt && typeof rt.waitUntil === 'function' ? rt : null;
+}
+
+/**
+ * `recordAudit`, taken OFF the response path.
+ *
+ * WHY THIS EXISTS
+ * `recordAudit` is called after the primary operation has already committed,
+ * and it returns `void` and never throws — so no caller can act on its result.
+ * Awaiting it therefore bought nothing and cost a full edge→PostgREST round
+ * trip on every mutation's response path. In the 2026-08-22 load test
+ * (run 32588442998) a REST write's p50 was 1120 ms against ~534 ms for a read,
+ * while ALL server-side SQL in the window totalled 11.75 ms per request — so
+ * the write penalty was round trips, not queries, and this is one of them.
+ *
+ * WHY IT FALLS BACK TO AWAITING, unlike `embed-on-write.ts`
+ * That module deliberately SKIPS when `waitUntil` is unavailable, because a
+ * missing embedding is recovered by the backfill (`embedding is null`). An
+ * audit row has no backfill: it is the only record that the action happened,
+ * and D1 (see the module header) makes the app layer solely responsible for
+ * writing it. Dropping one to save latency would trade a durability guarantee
+ * for a performance one, so on a runtime with no hook this returns the real
+ * promise and the caller's `await` behaves exactly as it did before.
+ *
+ * Callers therefore keep writing `await recordAuditDeferred(…)`: on the edge
+ * the await resolves immediately and the insert completes in the background;
+ * anywhere else it is today's behaviour, unchanged.
+ *
+ * ONE BEHAVIOURAL CHANGE worth knowing: the audit row is no longer guaranteed
+ * to be visible by the time the mutation's response reaches the client. Nothing
+ * reads it that way — the Audit Logs UI and `GET /audit` are review surfaces,
+ * not read-after-write consumers — but a test that mutates and then immediately
+ * asserts on `audit_log` would become racy, and should poll rather than assume.
+ */
+export function recordAuditDeferred(
+  db: DbClient,
+  input: AuditEntryInput,
+  userId: string | null,
+): Promise<void> {
+  const p = recordAudit(db, input, userId);
+  const rt = background();
+  if (!rt) return p;
+  rt.waitUntil(p);
+  return Promise.resolve();
+}

--- a/supabase/functions/_shared/background.ts
+++ b/supabase/functions/_shared/background.ts
@@ -1,0 +1,40 @@
+/**
+ * The runtime's background-task hook, detected in ONE place.
+ *
+ * `EdgeRuntime.waitUntil` keeps the isolate alive after the response has been
+ * returned, which is how work that the caller cannot act on — an audit row, a
+ * usage event, an embedding — stays off the response path. Three modules reached
+ * for it and each had grown its own copy of the same six-line feature test; this
+ * is that test, once.
+ *
+ * WHAT IS SHARED IS THE DETECTION, NOT THE POLICY.
+ *
+ * Every caller must still decide what to do when the hook is ABSENT, and the
+ * three existing answers are deliberately different because the data is
+ * different. Do not "simplify" them into one:
+ *
+ *   * `embed-on-write.ts` SKIPS. Awaiting would put provider latency back on
+ *     every write, and the backfill re-derives the row later (it selects on
+ *     `embedding is null`), so nothing is lost but time.
+ *   * `audit.ts` AWAITS. An audit row has no backfill and D1 makes the app layer
+ *     solely responsible for writing it, so latency is the thing to give up.
+ *   * `usage.ts` DROPS (`void p`). Plan-sizing analytics are best-effort by
+ *     construction and must never delay or fail the operation they measure.
+ *
+ * Returning the host rather than taking a promise is what keeps that choice with
+ * the caller: `embed-on-write` needs to know BEFORE it starts building a payload
+ * whether the work is worth doing at all.
+ *
+ * No imports, by construction — `edge-bare-specifier.spec.ts` fails the build on
+ * a bare specifier and the edge runtime is given no import map.
+ */
+
+export interface WaitUntilHost {
+  waitUntil(p: Promise<unknown>): void;
+}
+
+/** The runtime's background-task hook, or `null` where it has none. */
+export function background(): WaitUntilHost | null {
+  const rt = (globalThis as { EdgeRuntime?: unknown }).EdgeRuntime as WaitUntilHost | undefined;
+  return rt && typeof rt.waitUntil === 'function' ? rt : null;
+}

--- a/supabase/functions/_shared/embed-on-write.ts
+++ b/supabase/functions/_shared/embed-on-write.ts
@@ -19,19 +19,13 @@
 // Every failure is swallowed after being recorded on the span. There is no
 // retry here: a retry on the write path is just a slower way to fail, and the
 // backfill already retries by construction (it selects on `embedding is null`).
+import { background } from './background.ts';
 import { createTracedClient } from './otel.ts';
 import type { Span } from './otel.ts';
 import type { DbClient } from './api/auth.ts';
 import { embeddingInput, isEmbeddable, toVectorLiteral, resolveEmbeddingConfig } from './embedding.ts';
 import { embedTexts } from './embedding-client.ts';
 
-interface WaitUntilHost { waitUntil(p: Promise<unknown>): void }
-
-/** The runtime's background-task hook, when it has one. */
-function background(): WaitUntilHost | null {
-  const rt = (globalThis as { EdgeRuntime?: unknown }).EdgeRuntime as WaitUntilHost | undefined;
-  return rt && typeof rt.waitUntil === 'function' ? rt : null;
-}
 
 /**
  * Queue an embedding for a memory that was just written.

--- a/supabase/functions/_shared/usage.ts
+++ b/supabase/functions/_shared/usage.ts
@@ -13,6 +13,7 @@
  * is fire-and-forget, `getUserPlanName` fails open to null.
  */
 
+import { background } from './background.ts';
 import { createTracedClient, type Span } from './otel.ts';
 import type { DbClient } from './db-client.ts';
 
@@ -116,14 +117,13 @@ export function recordUsageEvent(
     // parameter is `Promise<unknown>` and never accepted a `PromiseLike`.
   })).then(() => { /* fire-and-forget */ }, () => { /* swallow */ });
 
-  const edgeRuntime = (globalThis as {
-    EdgeRuntime?: { waitUntil?: (p: Promise<unknown>) => void };
-  }).EdgeRuntime;
-  if (typeof edgeRuntime?.waitUntil === 'function') {
-    edgeRuntime.waitUntil(p);
-  } else {
-    void p;
-  }
+  // With no background hook the event is DROPPED, not awaited: plan-sizing
+  // analytics are best-effort by construction and must never delay the operation
+  // they measure. `audit.ts` makes the opposite call on the same hook, on
+  // purpose — see `background.ts` for why the three callers differ.
+  const host = background();
+  if (host) host.waitUntil(p);
+  else void p;
 }
 
 /**

--- a/supabase/functions/memories/handlers/create.ts
+++ b/supabase/functions/memories/handlers/create.ts
@@ -11,7 +11,7 @@ import { translateDbError } from '../../_shared/api/errors.ts';
 import { parseCreatedAt, CreatedAtError } from '../../_shared/created-at.ts';
 import { parseOrigin, OriginError } from '../../_shared/origin.ts';
 import { resolveKindHost } from '../../_shared/schemas/tags.ts';
-import { recordAudit } from '../../_shared/audit.ts';
+import { recordAuditDeferred } from '../../_shared/audit.ts';
 import { embedOnWrite } from '../../_shared/embed-on-write.ts';
 import type { DbClient } from '../../_shared/api/auth.ts';
 import type { Database } from '../../_shared/database.types.ts';
@@ -180,7 +180,15 @@ export async function handleCreate(
   // Audit AFTER the write succeeded. Same action/resource/target/metadata
   // shape as toolWrite, so the MCP and REST surfaces produce comparable rows.
   // recordAudit never throws, so a failed audit cannot fail the request.
-  await recordAudit(
+  //
+  // DEFERRED, so the insert is not a round trip on the response path: its
+  // result is `void` and unactionable, and the write it records has already
+  // committed. On the edge the await below resolves immediately and the insert
+  // finishes under `EdgeRuntime.waitUntil`; on a runtime without that hook it
+  // degrades to the awaited behaviour rather than dropping the row. See
+  // `_shared/audit.ts` → `recordAuditDeferred` for why that fallback differs
+  // from `embed-on-write.ts`'s deliberate skip.
+  await recordAuditDeferred(
     db,
     {
       action: row.inserted === false ? 'memory.update' : 'memory.create',


### PR DESCRIPTION
Iteration 1 of a measured optimization loop. Small on purpose: one round trip, on the one path the load test measures, so the next run reads as a clean signal.

## The number this targets

The first clean load-test run ([32588442998](https://github.com/mthines/lorekit/actions/runs/32588442998)):

```
op       count    ok   429   err      p50      p95      p99
list      1200  1200     0     0    534.1    875.4   1341.1
write      360   360     0     0   1120.5   1582.7   1922.2

db exec 28.21 s ÷ client wall 1649.02 s = 0.02
```

A write cost **~586 ms more than a read**, while *all* server-side SQL in the window came to **11.75 ms per request**. So the write penalty is round **trips**, not queries — the write path makes several sequential edge→PostgREST hops (rate-limit RPC, `memory_write` RPC, a `SELECT` to shape the response, audit, usage). This removes one.

Corroborating detail from the same run: the three read ops are latency-identical (532 / 534 / 546 ms p50) even though `search` does 2.6× the DB work of `list` (5.94 ms vs 2.25 ms). A 3.7 ms SQL difference moved p50 by 11 ms. There is a fixed per-hop cost dominating everything.

## The change

`recordAudit` returns `void`, never throws, and runs after the primary operation has already committed — so no caller can act on its result. The `await` bought nothing and cost a full hop before the response went out. `recordAuditDeferred` hands it to `EdgeRuntime.waitUntil` instead, the same hook `recordUsageEvent` and `embedOnWrite` already depend on.

**It does not copy `embed-on-write.ts`'s skip-when-unavailable behaviour, and that asymmetry is the point.** A missing embedding is recovered by the backfill (`embedding is null`); an audit row has no backfill, and D1 makes the app layer solely responsible for writing it. So with no `waitUntil` hook this returns the real promise and the caller's `await` behaves exactly as before — it gives up latency rather than a durability guarantee. Callers keep writing `await recordAuditDeferred(…)`: same shape, degrades correctly.

Applied to **`create.ts` only**. `update` / `remove` / `restore` / `purge` share the pattern and can follow once this is validated against real numbers.

## One behavioural change

The audit row is no longer guaranteed visible by the time the mutation's response reaches the client. Nothing consumes it that way — the Audit Logs UI and `GET /audit` are review surfaces, not read-after-write consumers — but **a test that mutates then immediately asserts on `audit_log` would become racy** and should poll. Called out in the helper's doc comment, not just here.

## Two gates made claims this would have falsified

Updated rather than worked around:

- **`audit-coverage.spec.ts`** matched `/\brecordAudit\s*\(/`, which the rename fails — it would have gone red, correctly. Widened to `/\brecordAudit(Deferred)?\s*\(/`, deliberately narrow. Self-tested to still **reject** a handler that audits nothing, a bare import, `myRecordAudit`, and `recordAuditDeferredLater`.
- **`edge-parity.spec.ts`** documented the client typing as "the only executable difference" between the two audit copies. There are now two, so the comment says so and why `waitUntil` has no mcp-core counterpart to compare against.

## Verification

- Edge typecheck ratchet: **0/0 across all 7 functions** (deno 2.9.5 locally).
- **113 tests** over the four audit / parity / bare-specifier gates.
- `nx affected -t typecheck,test` green — 4 projects.

## Not verified

Whether this actually moves write p50. That is what the follow-up run measures, at identical settings (20 rps / 120 s / 5 users) so the comparison is like-for-like. If the ~586 ms gap drops by roughly one hop, the round-trip hypothesis is confirmed and the remaining hops become the next target; if it doesn't move, the hypothesis is wrong and the extra `SELECT` or the edge runtime itself is where to look instead.

`llms.txt` not regenerated — no MCP tool, CLI command, REST route, config key or dashboard surface changed. Response bodies and status codes are byte-identical; only when the audit insert completes differs.

https://claude.ai/code/session_01KgoxEsXNRCsr68b2P9cmTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgoxEsXNRCsr68b2P9cmTJ)_