### PR TITLE
feat(bench): drive MCP and the CLI's auth tier, and add a stress ladder

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,5 +1,13 @@
-# Load test — drives the REST surface at a fixed arrival rate and attributes the
-# latency to specific SQL statements.
+# Load and stress test — drives a chosen surface at a fixed arrival rate (or up a
+# ladder of rates) and attributes the latency to specific SQL statements.
+#
+# SURFACE x AUTH is what picks the caller being simulated:
+#   rest + jwt    the dashboard        (default)
+#   rest + token  the CLI remote path  (`lk_*`, the api_key tier)
+#   mcp  + token  AGENTS               — the path that matters most
+# MCP rate-limits EVERY method (120/min/user = 2 rps), so rate is bought with
+# USERS: 20 rps needs 10, 100 rps needs 50. The script REFUSES a configuration
+# that cannot fit rather than reporting the rate limiter as a latency result.
 #
 # WHY A WORKFLOW RATHER THAN A LOCAL SCRIPT
 # The target must be configurable between preview and production, and a
@@ -59,8 +67,25 @@ on:
         description: 'Drive duration (seconds)'
         default: '120'
       users:
-        description: 'Provisioned users — each carries its own 120 rpm budget'
+        description: 'Provisioned users — each carries its own 120 rpm budget. MCP needs rps/2 of them'
         default: '5'
+      surface:
+        description: 'Which transport — rest = dashboard/CLI path, mcp = the AGENT path'
+        type: choice
+        options: [rest, mcp]
+        default: rest
+      auth:
+        description: 'Auth tier. Blank = the real pairing (mcp->token, rest->jwt); rest+token is the CLI path'
+        type: choice
+        options: ['', jwt, token]
+        default: ''
+      ramp:
+        description: 'Stress mode: step the rate up to max_rps until saturation'
+        type: boolean
+        default: false
+      max_rps:
+        description: 'Ceiling for the stress ladder (only used when ramp is on)'
+        default: '160'
   schedule:
     # Weekly, Mondays 05:25 UTC. Off the hour on purpose: GitHub queues :00
     # schedules by many minutes. A scheduled run is ALWAYS preview — the target
@@ -73,12 +98,12 @@ on:
 # and their rows behind, and cleanup only happens if the job reaches its
 # `finally`. Same posture as deploy.yml.
 concurrency:
-  group: load-test-${{ inputs.target || 'preview' }}
+  group: load-test-${{ inputs.target || 'preview' }}-${{ inputs.surface || 'rest' }}
   cancel-in-progress: false
 
 jobs:
   load:
-    name: Load test → ${{ inputs.target || 'preview' }}
+    name: Load test → ${{ inputs.target || 'preview' }} (${{ inputs.surface || 'rest' }})
     runs-on: ubuntu-latest
     # The gate. `production` inherits whatever approval rules that environment
     # carries; `preview` runs freely.
@@ -162,12 +187,25 @@ jobs:
           # command. Without this, `node … | tee` reports tee's success and a
           # load test that died mid-run would have gone GREEN.
           set -euo pipefail
-          node scripts/load-test.mjs \
-            --target "$TARGET" \
-            --rps "${{ inputs.rps || '20' }}" \
-            --duration "${{ inputs.duration || '120' }}" \
-            --users "${{ inputs.users || '5' }}" \
-            | tee load-report.txt
+          # `--surface`/`--auth` are appended only when set, so a scheduled run
+          # (which has no inputs at all) keeps the script's own defaults rather
+          # than passing empty strings the arg parser would reject.
+          args=(
+            --target "$TARGET"
+            --rps "${{ inputs.rps || '20' }}"
+            --duration "${{ inputs.duration || '120' }}"
+            --users "${{ inputs.users || '5' }}"
+          )
+          # `if` rather than `[ … ] && …`: the latter evaluates to 1 when the
+          # test fails, which under `set -e` fails the step if it is ever the
+          # last command in the block. Same behaviour, no ordering trap.
+          if [ -n "${{ inputs.surface }}" ]; then args+=(--surface "${{ inputs.surface }}"); fi
+          if [ -n "${{ inputs.auth }}" ];    then args+=(--auth "${{ inputs.auth }}"); fi
+          if [ "${{ inputs.ramp }}" = "true" ]; then
+            args+=(--ramp --max-rps "${{ inputs.max_rps || '160' }}")
+          fi
+          echo "load-test args: ${args[*]}"
+          node scripts/load-test.mjs "${args[@]}" | tee load-report.txt
 
       # The report is the artefact worth keeping: the client percentiles and the
       # per-statement delta, on a run whose Dash0 trace may be sampled away.
@@ -182,7 +220,7 @@ jobs:
         # caller, so the bump is local.
         uses: actions/upload-artifact@v6
         with:
-          name: load-report-${{ inputs.target || 'preview' }}-${{ github.run_id }}
+          name: load-report-${{ inputs.target || 'preview' }}-${{ inputs.surface || 'rest' }}-${{ github.run_id }}
           path: load-report.txt
           if-no-files-found: warn
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -263,6 +263,31 @@ is unavailable. A degraded run, not a failed one.
 - **The per-statement delta is the real output.** It turns "p95 was 240 ms" into
   "these three statements were 62 % of it".
 
+#### Telemetry
+
+**Every span and every datapoint carries `lorekit.load.surface` and
+`lorekit.load.auth_tier`.** Both, on both signal types — a dimension present only
+on the trace cannot filter a metric series, so without them on the datapoints an
+MCP run and a REST run land in the SAME series and silently average together,
+which is the one comparison this harness exists to make. Both are bounded
+(`rest|mcp`, `jwt|token`), so they add no meaningful cardinality.
+
+A **stress** run additionally emits one `lorekit.load.rung` child span per rung
+(mirroring the sweep's rung spans — the waterfall is where a ladder becomes
+readable) plus three series:
+
+| Metric | Unit | Keyed by |
+|---|---|---|
+| `lorekit.load.rung.duration` | `s` | `rps`, `quantile` — the ladder as a curve |
+| `lorekit.load.rung.achieved_rps` | `{request}/s` | `rps` — below requested means the *client* saturated |
+| `lorekit.load.max_sustained_rps` | `{request}/s` | — the headline; **0** when the first rung already failed |
+
+`rps` is a dimension here for the same reason the sweep's `rows` is: it is the
+experiment's independent variable, the x-axis, bounded by the rung count.
+
+The rung that ended the ladder carries `lorekit.load.rung.stop_reason`, which is
+the one thing a bare number cannot convey.
+
 Telemetry: one `lorekit.load` root span (not one per request — 20 rps for two
 minutes is 2,400 spans of a synthetic client, and the per-request detail already
 exists server-side) plus four gauges, under `service.name=load`. The run's

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -132,11 +132,21 @@ the daily smoke jobs carry that value too.
 
 ```bash
 # Dispatch it from the Actions UI (preferred — production runs need the gate):
-#   Actions ▸ Load test ▸ Run workflow ▸ target / rps / duration / users
+#   Actions ▸ Load test ▸ Run workflow ▸ target / surface / auth / rps / … / ramp
 #
-# Or locally:
+# Or locally. The dashboard path (REST + JWT):
 SUPABASE_URL=… SUPABASE_SERVICE_ROLE_KEY=… SUPABASE_ANON_KEY=… \
   node scripts/load-test.mjs --target preview --rps 20 --duration 120 --users 5
+
+# The AGENT path (MCP + lk_ token). Note the users: MCP gates every method at
+# 2 rps/user, so 20 rps needs 10 — the script refuses fewer.
+  … node scripts/load-test.mjs --target preview --surface mcp --rps 20 --users 10
+
+# The CLI's remote path (REST + lk_ token — the api_key tier):
+  … node scripts/load-test.mjs --target preview --surface rest --auth token
+
+# Stress: step 20 -> 160 rps and report the highest sustained rate.
+  … node scripts/load-test.mjs --target preview --surface mcp --ramp --rps 20 --max-rps 160 --users 80
 ```
 
 | Flag | Default | |
@@ -146,6 +156,10 @@ SUPABASE_URL=… SUPABASE_SERVICE_ROLE_KEY=… SUPABASE_ANON_KEY=… \
 | `--duration <s>` | `60` | drive duration |
 | `--users <n>` | `5` | provisioned users, each with its own 120 rpm budget |
 | `--seed <n>` | `50` | lore rows seeded per user, so reads return rows |
+| `--surface <rest\|mcp>` | `rest` | `rest` = dashboard/CLI path, `mcp` = the **agent** path |
+| `--auth <jwt\|token>` | per surface | `mcp`→`token`, `rest`→`jwt`. `rest`+`token` is the CLI's remote path |
+| `--ramp` | off | stress mode: step the rate until saturation |
+| `--max-rps <n>` | — | the ladder's ceiling; required with `--ramp` |
 | `--dry-run` | off | build the OTLP payloads, send nothing |
 | `--keep-users` | off | skip cleanup — debugging only; leaves real rows behind |
 
@@ -277,20 +291,75 @@ Coverage is asymmetric, and this is what a load test has to work around:
 
 A naive load script against MCP measures the rate limiter, not the system.
 
-### Which surfaces
+### Which surfaces — `--surface` x `--auth`
 
-**REST as the generator.** REST and MCP converge on the same handlers and the
-same SQL — the expensive part is shared, and REST reads are the only surface
-that can actually be pushed.
+Two dimensions, because the PAIR is what identifies a real caller. All three
+pairings are genuinely different code paths:
 
-**MCP gets a thin arm, not a throughput test.** The dispatcher is a genuinely
-distinct path worth measuring (JSON-RPC parse, tool gating, the usage-event
-write, the concurrent plan + rate-limit round-trip), but the 2 rps ceiling
-forbids more than a fixed low rate.
+| `--surface` | `--auth` | Who this is | Notes |
+|---|---|---|---|
+| `rest` | `jwt` | the **dashboard** (`packages/web/src/lib/api/`) | the default |
+| `rest` | `token` | the **CLI** in remote mode | `lk_*` takes a different branch of `resolveRestAuth`, reached via a DB lookup on `api_tokens` |
+| `mcp` | `token` | **agents** | its own handlers (`mcp/tools.ts`), its own auth span, and it rate-limits every method |
 
-**The CLI gets nothing.** It is a REST client, so it adds no server-side path;
-load-testing it measures node startup on the runner. CLI hook latency is a real
-question but it is a single-shot benchmark, a different instrument.
+Defaults pick the real pairing per surface, so `--surface mcp` alone drives what
+an agent actually does.
+
+**They converge at the RPC/SQL layer and nowhere above it.** Both reach
+`memory_write` and the same tables, so a DATABASE finding generalises. A
+transport or auth finding does not — `lorekit.rest.auth` does not exist on the
+MCP path at all, so the 193 ms it costs per request is invisible to agents.
+
+An earlier version of this document claimed REST alone was sufficient because
+"REST and MCP converge on the same handlers". The SQL and the RPCs, yes; the
+**handlers, no** — MCP has its own. That sentence made the coverage gap look
+smaller than it was, and the first Dash0 read of a real run is what exposed it.
+
+**On MCP, the outcome is in the body, not the status.** JSON-RPC returns
+application errors inside a **200**, so a driver that reads only the status code
+scores every failed tool call as a success — a run can report 100 % ok having
+accomplished nothing. `classifyMcpResponse` reads 429 first (the limiter answers
+above JSON-RPC), then `error`, then a tool-level `isError`.
+
+**The CLI process itself is still not measured.** `rest + token` covers what the
+CLI *causes server-side*, which is the part that scales. Spawning the binary per
+request would measure Node startup on the runner — a real question, but a
+single-shot benchmark and a different instrument.
+
+### Stress mode (`--ramp`)
+
+`--ramp --max-rps N` steps the rate geometrically (20 → 40 → 80 → N) with the
+same users and the same seeded rows, so a difference between rungs is the offered
+rate and nothing else. It stops at the first rung that trips any of:
+
+- **errors** above 1 % — the service is failing, not merely slow;
+- **p99** above 5 s — latency has left the range anyone would ship;
+- **429s** above 1 % — further rungs would measure the limiter, not the service;
+- **achieved rate** below 90 % of requested — the *client* saturated, so a higher
+  requested rate cannot actually be offered and every later rung is the same load.
+
+The report ends with the highest sustained rate. Without `--ramp` a single rung
+runs, which is the plain load test.
+
+#### The rate-limit guard, and why it refuses rather than warns
+
+MCP checks the limit on **every** method; REST checks it in only `create.ts` and
+`purge.ts`, so on REST only the write share of the mix is gated and reads are
+ungated. At the 120/min default that is **2 rps per user** — so on MCP the
+harness's own defaults (20 rps across 5 users) are **2x over**, and half such a
+run would 429.
+
+`checkRateHeadroom` therefore **fails the run** and names the users required:
+
+```
+✗ mcp rate-limits every method, so 20 rps needs at least 10 users at
+  120 req/min/user (20.0 limited rps ÷ 2.00 per user) — got 5.
+  Raise --users to 10, or lower --rps to 10.
+```
+
+A load test that silently measures its own throttling is worse than no load
+test, because the number looks usable. With `--ramp` the check uses the
+**ceiling**, not the starting rate.
 
 ### Scaling users, not limits
 

--- a/scripts/load-telemetry.mjs
+++ b/scripts/load-telemetry.mjs
@@ -15,13 +15,27 @@
  * already in Dash0 from the SERVER side, correlated by
  * `lorekit.correlation_id`, which is the copy worth having.
  *
+ * A STRESS run additionally gets one child span per ladder rung, mirroring
+ * `sweep-telemetry.mjs`'s rung spans — the waterfall is where the ladder becomes
+ * readable, and the rungs are the experiment rather than an implementation
+ * detail of it.
+ *
  * Metrics — gauges, stamped at the run's end:
  *   lorekit.load.request.duration  s        {op, quantile}
  *   lorekit.load.requests          {request} {op, outcome}
  *   lorekit.load.db.time           s        {queryid} — top statements by delta
  *   lorekit.load.db.share          1        db exec time ÷ client wall time
+ *   lorekit.load.rung.duration     s        {rps, quantile} — the ladder
+ *   lorekit.load.max_sustained_rps {request/s}  a stress run's headline
  * Gauges because each is a measurement of one run at one commit, not something
  * that accumulates.
+ *
+ * EVERY span AND every datapoint carries `lorekit.load.surface` and
+ * `lorekit.load.auth_tier`. Not just the span: a dimension present only on the
+ * trace cannot filter a metric series, so without them on the datapoints an MCP
+ * run and a REST run land in the SAME series and silently average together —
+ * which is the one comparison this harness now exists to make. Both are bounded
+ * (rest|mcp, jwt|token), so they add no meaningful cardinality.
  *
  * `lorekit.correlation_id` on the root span is the join key: the same value
  * rides on every request as `X-LoreKit-Correlation-Id`, so a run's server-side
@@ -42,10 +56,25 @@ import {
 
 const SERVICE_NAME = 'load';
 
+/**
+ * The dimensions that identify WHICH CALLER a run simulated.
+ *
+ * Applied to the root span, every rung span, and every gauge datapoint. A run
+ * without them is unattributable: `rest+jwt` (the dashboard), `rest+token` (the
+ * CLI) and `mcp+token` (agents) are different code paths with different costs,
+ * and averaging them is worse than not measuring — the number looks real.
+ */
+function surfaceDims(run) {
+  return {
+    'lorekit.load.surface': run.surface ?? 'rest',
+    'lorekit.load.auth_tier': run.authTier ?? (run.surface === 'mcp' ? 'token' : 'jwt'),
+  };
+}
+
 /** How many statements from the query-stats delta to export. Bounded: each is a series. */
 const TOP_STATEMENTS = 20;
 
-function buildTracePayload({ run, summary, agg, share, correlationId }) {
+function buildTracePayload({ run, summary, agg, share, correlationId, ladder = [] }) {
   const traceId = randHex(16);
   const spanId = randHex(8);
 
@@ -60,6 +89,7 @@ function buildTracePayload({ run, summary, agg, share, correlationId }) {
       // The join key to the server side of this same run.
       'lorekit.correlation_id': correlationId,
       'lorekit.load.target': run.target,
+      ...surfaceDims(run),
       'lorekit.load.rps': run.rps,
       'lorekit.load.duration_s': run.durationSec,
       'lorekit.load.users': run.users,
@@ -74,21 +104,68 @@ function buildTracePayload({ run, summary, agg, share, correlationId }) {
       'lorekit.load.db_share': share ? Number(share.ratio.toFixed(4)) : undefined,
       // The slowest op, on the root so it is visible without drilling.
       'lorekit.load.slowest_op': [...summary].sort((a, b) => (b.p95 ?? 0) - (a.p95 ?? 0))[0]?.op,
+      // Stress-only. `max_sustained_rps` is the answer a ladder was run to get,
+      // so it belongs on the root rather than only in the rung detail.
+      'lorekit.load.ramp': ladder.length > 1 ? true : undefined,
+      'lorekit.load.rungs': ladder.length > 1 ? ladder.length : undefined,
+      'lorekit.load.max_sustained_rps': ladder.length > 1
+        ? ([...ladder].reverse().find((r) => !r.stopped)?.requestedRps ?? 0)
+        : undefined,
     }),
     // A run that produced 5xx is an ERROR span: the whole point was to find out
     // whether the service holds, and it did not.
     status: agg.errors > 0 ? { code: 2, message: `${agg.errors} failed requests` } : { code: 1 },
   };
 
-  return { payload: spansEnvelope(SERVICE_NAME, [root]), traceId };
+  // One child per rung. Timestamps are SYNTHETIC here — the rungs ran back to
+  // back inside [startMs, endMs] but each rung's own boundaries are not recorded
+  // per rung, so they are laid out evenly across the run rather than faked to a
+  // precision we do not have. The ORDER and the per-rung measurements are the
+  // real content; the widths are indicative.
+  const rungSpans = ladder.length > 1
+    ? ladder.map((r, i) => {
+      const slice = (run.endMs - run.startMs) / ladder.length;
+      return {
+        traceId,
+        spanId: randHex(8),
+        parentSpanId: spanId,
+        name: 'lorekit.load.rung',
+        kind: SPAN_KIND_INTERNAL,
+        startTimeUnixNano: toUnixNano(run.startMs + i * slice),
+        endTimeUnixNano: toUnixNano(run.startMs + (i + 1) * slice),
+        attributes: toOtlpAttributes({
+          'lorekit.correlation_id': correlationId,
+          ...surfaceDims(run),
+          'lorekit.load.rung.requested_rps': r.requestedRps,
+          'lorekit.load.rung.achieved_rps': Number(r.achievedRps?.toFixed(2)),
+          'lorekit.load.rung.requests': r.count,
+          'lorekit.load.rung.ok': r.ok,
+          'lorekit.load.rung.rate_limited': r.rateLimited,
+          'lorekit.load.rung.errors': r.errors,
+          'lorekit.load.rung.p50_ms': r.p50 ?? undefined,
+          'lorekit.load.rung.p99_ms': r.p99 ?? undefined,
+          // Why the ladder ended here — the single most useful attribute on a
+          // stress run, and the one a bare number cannot convey.
+          'lorekit.load.rung.stopped': r.stopped || undefined,
+          'lorekit.load.rung.stop_reason': r.reason,
+        }),
+        status: r.errors > 0 ? { code: 2, message: `${r.errors} failed requests` } : { code: 1 },
+      };
+    })
+    : [];
+
+  return { payload: spansEnvelope(SERVICE_NAME, [root, ...rungSpans]), traceId };
 }
 
-function buildMetricsPayload({ run, summary, agg, queryDiff, share, timeMs }) {
+function buildMetricsPayload({ run, summary, agg, queryDiff, share, timeMs, ladder = [] }) {
+  // Every datapoint carries the caller dimensions — see the module header for
+  // why the span alone is not enough.
+  const dims = surfaceDims(run);
   const durationPoints = [];
   for (const row of summary) {
     for (const [q, v] of [['p50', row.p50], ['p95', row.p95], ['p99', row.p99]]) {
       // Seconds, matching every other duration LoreKit emits.
-      if (v !== null && v !== undefined) durationPoints.push(gauge({ op: row.op, quantile: q }, v / 1000, timeMs));
+      if (v !== null && v !== undefined) durationPoints.push(gauge({ ...dims, op: row.op, quantile: q }, v / 1000, timeMs));
     }
   }
 
@@ -101,7 +178,7 @@ function buildMetricsPayload({ run, summary, agg, queryDiff, share, timeMs }) {
       ['client_error', row.clientErrors],
       ['error', row.errors],
     ]) {
-      if (n > 0) outcomePoints.push(gauge({ op: row.op, outcome }, n, timeMs));
+      if (n > 0) outcomePoints.push(gauge({ ...dims, op: row.op, outcome }, n, timeMs));
     }
   }
 
@@ -124,6 +201,7 @@ function buildMetricsPayload({ run, summary, agg, queryDiff, share, timeMs }) {
       description: 'Server-side exec time attributable to THIS run, per statement shape.',
       points: queryDiff.slice(0, TOP_STATEMENTS).map((r) => gauge(
         {
+          ...dims,
           'db.queryid': r.queryid,
           // Bounded the same way the profiling function bounds it.
           'db.query.text': (r.query ?? '').slice(0, 512),
@@ -137,9 +215,45 @@ function buildMetricsPayload({ run, summary, agg, queryDiff, share, timeMs }) {
       name: 'lorekit.load.db.share',
       unit: '1',
       description: 'Database exec time divided by client wall time. Above 1 means concurrency, not an error.',
-      points: share ? [gauge({ target: run.target }, share.ratio, timeMs)] : [],
+      points: share ? [gauge({ ...dims, target: run.target }, share.ratio, timeMs)] : [],
     }),
   ];
+
+  // The ladder as a queryable series. `rps` is the experiment's INDEPENDENT
+  // variable, so it is a dimension here for the same reason the sweep's `rows`
+  // is — this is the x-axis, not incidental cardinality, and it is bounded by
+  // the rung count.
+  if (ladder.length > 1) {
+    const rungPoints = [];
+    for (const r of ladder) {
+      for (const [q, v] of [['p50', r.p50], ['p99', r.p99]]) {
+        if (v !== null && v !== undefined) {
+          rungPoints.push(gauge({ ...dims, rps: r.requestedRps, quantile: q }, v / 1000, timeMs));
+        }
+      }
+    }
+    const lastGood = [...ladder].reverse().find((r) => !r.stopped);
+    metrics.push(
+      gaugeMetric({
+        name: 'lorekit.load.rung.duration',
+        unit: 's',
+        description: 'Client-observed latency at each rung of a stress ladder, keyed by requested rps.',
+        points: rungPoints,
+      }),
+      gaugeMetric({
+        name: 'lorekit.load.rung.achieved_rps',
+        unit: '{request}/s',
+        description: 'Rate actually offered at each rung. Below the requested value means the CLIENT saturated.',
+        points: ladder.map((r) => gauge({ ...dims, rps: r.requestedRps }, r.achievedRps ?? 0, timeMs)),
+      }),
+      gaugeMetric({
+        name: 'lorekit.load.max_sustained_rps',
+        unit: '{request}/s',
+        description: 'Highest rung that passed every stop condition — a stress run\'s headline. 0 when the first rung already failed.',
+        points: [gauge(dims, lastGood?.requestedRps ?? 0, timeMs)],
+      }),
+    );
+  }
 
   return metricsEnvelope(SERVICE_NAME, metrics);
 }
@@ -148,11 +262,11 @@ function buildMetricsPayload({ run, summary, agg, queryDiff, share, timeMs }) {
  * Export one load run. Never throws — a run that lost its telemetry has still
  * produced a result worth printing.
  */
-export async function exportLoad({ run, summary, agg, queryDiff, share, correlationId, dryRun }, env = process.env) {
+export async function exportLoad({ run, summary, agg, queryDiff, share, correlationId, ladder = [], dryRun }, env = process.env) {
   const timeMs = Date.now();
   const build = () => ({
-    traces: buildTracePayload({ run, summary, agg, share, correlationId }),
-    metrics: buildMetricsPayload({ run, summary, agg, queryDiff, share, timeMs }),
+    traces: buildTracePayload({ run, summary, agg, share, correlationId, ladder }),
+    metrics: buildMetricsPayload({ run, summary, agg, queryDiff, share, timeMs, ladder }),
   });
 
   // Before resolving a credential, so it works with no token — which is when

--- a/scripts/load-telemetry.test.mjs
+++ b/scripts/load-telemetry.test.mjs
@@ -162,3 +162,117 @@ test('resource: traces and metrics describe the SAME resource', () => {
     metrics().resourceMetrics[0].resource.attributes.map((a) => a.key).sort(),
   );
 });
+
+// ── caller dimensions and the stress ladder ─────────────────────────────────
+
+/**
+ * The load exporter shipped with NO surface/auth dimension, so a REST run and an
+ * MCP run were the same series — they averaged together silently, which is the
+ * one comparison the harness exists to make. These pin both halves: the span AND
+ * every datapoint, because a dimension on the trace alone cannot filter a metric.
+ */
+
+const MCP_RUN = { target: 'preview', surface: 'mcp', authTier: 'token', rps: 20, durationSec: 60, users: 10, startMs: 1_700_000_000_000, endMs: 1_700_000_060_000 };
+const MCP_SUMMARY = [{ op: 'list', count: 10, ok: 9, rateLimited: 1, clientErrors: 0, errors: 0, p50: 100, p95: 200, p99: 300, max: 300 }];
+const MCP_AGG = { requests: 10, ok: 9, rateLimited: 1, errors: 0, p50: 100, p95: 200, p99: 300 };
+const LADDER = [
+  { requestedRps: 20, achievedRps: 19.8, count: 100, ok: 100, errors: 0, rateLimited: 0, p50: 100, p99: 300, stopped: false },
+  { requestedRps: 40, achievedRps: 39.5, count: 200, ok: 200, errors: 0, rateLimited: 0, p50: 120, p99: 400, stopped: false },
+  { requestedRps: 80, achievedRps: 44.0, count: 400, ok: 390, errors: 10, rateLimited: 0, p50: 900, p99: 4000, stopped: true, reason: 'error rate 2.5% > 1.0%' },
+];
+
+test('the caller dimensions are on the root span', () => {
+  const { payload } = buildTracePayload({ run: MCP_RUN, summary: MCP_SUMMARY, agg: MCP_AGG, share: null, correlationId: 'load-x' });
+  const a = attrsOf(payload.resourceSpans[0].scopeSpans[0].spans[0]);
+  assert.equal(a['lorekit.load.surface'], 'mcp');
+  assert.equal(a['lorekit.load.auth_tier'], 'token');
+});
+
+test('EVERY datapoint carries them too — a span-only dimension cannot filter a metric', () => {
+  const env = buildMetricsPayload({
+    run: MCP_RUN, summary: MCP_SUMMARY, agg: MCP_AGG,
+    queryDiff: [{ queryid: '1', query: 'select 1', totalMs: 5 }],
+    share: { clientMs: 100, dbMs: 5, ratio: 0.05 }, timeMs: 1_700_000_060_000, ladder: LADDER,
+  });
+  const points = env.resourceMetrics[0].scopeMetrics[0].metrics.flatMap((m) => m.gauge.dataPoints);
+  assert.ok(points.length > 0);
+  for (const pt of points) {
+    const a = attrsOf(pt);
+    assert.equal(a['lorekit.load.surface'], 'mcp', `a datapoint is missing the surface: ${JSON.stringify(a)}`);
+    assert.equal(a['lorekit.load.auth_tier'], 'token');
+  }
+});
+
+test('the dimensions default to the real pairing when unset', () => {
+  // An older caller that passes no surface must still land somewhere honest,
+  // not in an unlabelled series.
+  const env = buildMetricsPayload({ run: { target: 'preview' }, summary: MCP_SUMMARY, agg: MCP_AGG, queryDiff: [], share: null, timeMs: 1 });
+  const a = attrsOf(env.resourceMetrics[0].scopeMetrics[0].metrics.flatMap((m) => m.gauge.dataPoints)[0]);
+  assert.equal(a['lorekit.load.surface'], 'rest');
+  assert.equal(a['lorekit.load.auth_tier'], 'jwt');
+});
+
+test('a single-rung run emits NO rung spans and no ladder metrics', () => {
+  // The plain load test must not grow a phantom one-rung ladder.
+  const { payload } = buildTracePayload({ run: MCP_RUN, summary: MCP_SUMMARY, agg: MCP_AGG, share: null, correlationId: 'c', ladder: [LADDER[0]] });
+  assert.equal(payload.resourceSpans[0].scopeSpans[0].spans.length, 1);
+  const env = buildMetricsPayload({ run: MCP_RUN, summary: MCP_SUMMARY, agg: MCP_AGG, queryDiff: [], share: null, timeMs: 1, ladder: [LADDER[0]] });
+  const names = env.resourceMetrics[0].scopeMetrics[0].metrics.map((m) => m.name);
+  assert.ok(!names.some((n) => n.includes('rung')), names.join(','));
+  assert.ok(!names.includes('lorekit.load.max_sustained_rps'));
+});
+
+test('a ladder emits one child span per rung, parented to the root', () => {
+  const { payload } = buildTracePayload({ run: MCP_RUN, summary: MCP_SUMMARY, agg: MCP_AGG, share: null, correlationId: 'c', ladder: LADDER });
+  const spans = payload.resourceSpans[0].scopeSpans[0].spans;
+  assert.equal(spans.length, 4, 'root + 3 rungs');
+  const rungs = spans.slice(1);
+  for (const r of rungs) {
+    assert.equal(r.name, 'lorekit.load.rung');
+    assert.equal(r.parentSpanId, spans[0].spanId);
+    assert.equal(r.traceId, spans[0].traceId);
+  }
+  // The rung that ended the ladder says WHY — the most useful attribute here.
+  const last = attrsOf(rungs[2]);
+  assert.equal(last['lorekit.load.rung.stopped'], true);
+  assert.match(String(last['lorekit.load.rung.stop_reason']), /error rate/);
+  assert.equal(rungs[2].status.code, 2, 'a rung with errors is an ERROR span');
+  assert.equal(rungs[0].status.code, 1);
+});
+
+test('the ladder is a queryable series keyed by rps, and reports the headline', () => {
+  const env = buildMetricsPayload({ run: MCP_RUN, summary: MCP_SUMMARY, agg: MCP_AGG, queryDiff: [], share: null, timeMs: 1, ladder: LADDER });
+  const byName = Object.fromEntries(env.resourceMetrics[0].scopeMetrics[0].metrics.map((m) => [m.name, m]));
+
+  const dur = byName['lorekit.load.rung.duration'];
+  assert.equal(dur.gauge.dataPoints.length, 6, '3 rungs x p50/p99');
+  assert.equal(dur.unit, 's');
+  assert.equal(dur.gauge.dataPoints[0].asDouble, 0.1, 'ms converted to seconds');
+  // STRINGS, deliberately: proto3 JSON renders int64 as a string and a bare
+  // number is the classic silent OTLP 400. Pinned so nobody "fixes" it.
+  assert.deepEqual([...new Set(dur.gauge.dataPoints.map((pt) => attrsOf(pt).rps))].sort((a, b) => a - b), ['20', '40', '80']);
+
+  // 80 stopped, so the highest that PASSED is 40.
+  const head = byName['lorekit.load.max_sustained_rps'].gauge.dataPoints;
+  assert.equal(head.length, 1);
+  assert.equal(head[0].asDouble, 40);
+});
+
+test('max_sustained_rps is 0 when the first rung already failed', () => {
+  // Never absent and never the requested rate — a stress run that saturated
+  // immediately must report zero, not look like it succeeded.
+  const env = buildMetricsPayload({
+    run: MCP_RUN, summary: MCP_SUMMARY, agg: MCP_AGG, queryDiff: [], share: null, timeMs: 1,
+    ladder: [{ ...LADDER[0], stopped: true, reason: 'p99' }, { ...LADDER[1], stopped: true, reason: 'p99' }],
+  });
+  const head = env.resourceMetrics[0].scopeMetrics[0].metrics.find((m) => m.name === 'lorekit.load.max_sustained_rps');
+  assert.equal(head.gauge.dataPoints[0].asDouble, 0);
+});
+
+test('the root span carries the ladder headline so it needs no drill-down', () => {
+  const { payload } = buildTracePayload({ run: MCP_RUN, summary: MCP_SUMMARY, agg: MCP_AGG, share: null, correlationId: 'c', ladder: LADDER });
+  const a = attrsOf(payload.resourceSpans[0].scopeSpans[0].spans[0]);
+  assert.equal(a['lorekit.load.ramp'], true);
+  assert.equal(a['lorekit.load.rungs'], '3', 'int64 attributes are strings by OTLP contract');
+  assert.equal(a['lorekit.load.max_sustained_rps'], '40');
+});

--- a/scripts/load-test-lib.mjs
+++ b/scripts/load-test-lib.mjs
@@ -114,12 +114,31 @@ export function percentile(samples, p) {
 }
 
 /**
+ * The outcome of one request: an explicit `outcome` when the driver set one,
+ * otherwise derived from the HTTP status.
+ *
+ * MCP needs the explicit form and REST does not, which is the whole reason this
+ * exists. JSON-RPC returns application errors inside a **200**, so a status-only
+ * reading counts every failed tool call as a success — a run can report 100 %
+ * ok having accomplished nothing. The MCP driver therefore classifies each
+ * response (`classifyMcpResponse`) and records the verdict; REST has no such
+ * ambiguity and keeps deriving it from the status, unchanged.
+ */
+export function outcomeOf(r) {
+  if (r.outcome) return r.outcome;
+  if (r.status === 429) return 'rate_limited';
+  if (r.status >= 200 && r.status < 300) return 'ok';
+  if (r.status >= 500 || r.status === 0) return 'error';
+  return 'client_error';
+}
+
+/**
  * Summarise per-op results.
  *
- * `ok` counts 2xx only. `rateLimited` (429) is broken out because it is not a
- * failure — it is the guardrail working, and lumping it into errors would make
- * a correctly-throttled run look broken. `errors` is 5xx plus transport
- * failures: those are the ones that mean something is wrong.
+ * `ok` counts successes only. `rateLimited` (429) is broken out because it is not
+ * a failure — it is the guardrail working, and lumping it into errors would make
+ * a correctly-throttled run look broken. `errors` is 5xx, transport failures,
+ * and (on MCP) a JSON-RPC or tool-level error returned inside a 200.
  */
 export function summarize(results) {
   const byOp = new Map();
@@ -134,14 +153,14 @@ export function summarize(results) {
     // microseconds and a transport failure may return instantly or after a
     // timeout; folding either into the latency distribution moves p95 for
     // reasons that have nothing to do with how fast the service is.
-    const okLatencies = rs.filter((r) => r.status >= 200 && r.status < 300).map((r) => r.ms);
+    const okLatencies = rs.filter((r) => outcomeOf(r) === 'ok').map((r) => r.ms);
     rows.push({
       op,
       count: rs.length,
-      ok: rs.filter((r) => r.status >= 200 && r.status < 300).length,
-      rateLimited: rs.filter((r) => r.status === 429).length,
-      clientErrors: rs.filter((r) => r.status >= 400 && r.status < 500 && r.status !== 429).length,
-      errors: rs.filter((r) => r.status >= 500 || r.status === 0).length,
+      ok: rs.filter((r) => outcomeOf(r) === 'ok').length,
+      rateLimited: rs.filter((r) => outcomeOf(r) === 'rate_limited').length,
+      clientErrors: rs.filter((r) => outcomeOf(r) === 'client_error').length,
+      errors: rs.filter((r) => outcomeOf(r) === 'error').length,
       p50: percentile(okLatencies, 0.5),
       p95: percentile(okLatencies, 0.95),
       p99: percentile(okLatencies, 0.99),
@@ -153,12 +172,12 @@ export function summarize(results) {
 
 /** Aggregate totals across every op, for the headline line. */
 export function totals(results) {
-  const ok = results.filter((r) => r.status >= 200 && r.status < 300);
+  const ok = results.filter((r) => outcomeOf(r) === 'ok');
   return {
     requests: results.length,
     ok: ok.length,
-    rateLimited: results.filter((r) => r.status === 429).length,
-    errors: results.filter((r) => r.status >= 500 || r.status === 0).length,
+    rateLimited: results.filter((r) => outcomeOf(r) === 'rate_limited').length,
+    errors: results.filter((r) => outcomeOf(r) === 'error').length,
     p50: percentile(ok.map((r) => r.ms), 0.5),
     p95: percentile(ok.map((r) => r.ms), 0.95),
     p99: percentile(ok.map((r) => r.ms), 0.99),
@@ -334,4 +353,207 @@ export function checkServiceCredential({ serviceKey, anonKey, supabaseUrl }) {
   }
 
   return { errors, warnings };
+}
+
+// ── surface and auth tier ────────────────────────────────────────────────────
+
+/**
+ * Which transport to drive.
+ *
+ * These are genuinely different code paths, not skins on one handler — which is
+ * why "the load test covers LoreKit" was never true of the REST arm alone:
+ *
+ *   rest — `/functions/v1/memories`, the `memories` function. What the DASHBOARD
+ *          calls (`packages/web/src/lib/api/`) and what the CLI calls in remote
+ *          mode.
+ *   mcp  — `/functions/v1/mcp`, JSON-RPC. What AGENTS call. Its own handlers
+ *          (`mcp/tools.ts`), its own auth span (`lorekit.mcp.auth`), and it
+ *          rate-limits EVERY method where REST gates only writes.
+ *
+ * They converge at the RPC/SQL layer — both reach `memory_write` and the same
+ * tables — so a database finding generalises. A transport or auth finding does
+ * NOT: `lorekit.rest.auth` does not exist on the MCP path at all.
+ */
+export function resolveSurface(argvSurface, env = {}) {
+  const raw = (argvSurface ?? env.LOREKIT_LOAD_SURFACE ?? 'rest').trim().toLowerCase();
+  if (raw !== 'rest' && raw !== 'mcp') {
+    return { ok: false, error: `Unknown surface "${raw}". Expected rest or mcp.` };
+  }
+  return { ok: true, surface: raw };
+}
+
+/**
+ * Which auth tier to authenticate with — the second dimension, orthogonal to
+ * the surface, because the pair is what identifies a real caller:
+ *
+ *   rest + jwt    the dashboard          (user JWT, RLS-enforced client)
+ *   rest + token  the CLI in remote mode (`lk_*`, service-role client + a
+ *                 mandatory user_id filter — a DIFFERENT branch of
+ *                 `resolveRestAuth`, with a DB lookup on `api_tokens`)
+ *   mcp  + token  agents                 (the flow that matters most)
+ *
+ * Defaults per surface pick the real-world pairing rather than a fixed value,
+ * so `--surface mcp` alone drives what an agent actually does.
+ */
+export function resolveAuthMode(argvAuth, surface, env = {}) {
+  const raw = (argvAuth ?? env.LOREKIT_LOAD_AUTH ?? '').trim().toLowerCase();
+  if (!raw) return { ok: true, auth: surface === 'mcp' ? 'token' : 'jwt' };
+  if (raw !== 'jwt' && raw !== 'token') {
+    return { ok: false, error: `Unknown auth "${raw}". Expected jwt or token.` };
+  }
+  return { ok: true, auth: raw };
+}
+
+/** MCP tool name for each op in the mix. */
+export const MCP_TOOL_FOR_OP = Object.freeze({
+  list: 'memory.list',
+  search: 'memory.search',
+  scopes: 'memory.scopes',
+  write: 'memory.write',
+});
+
+/**
+ * The `params.arguments` payload for one op, per the tool catalog's schema.
+ *
+ * Getting an argument NAME wrong here does not fail loudly: MCP answers a bad
+ * tool call with HTTP **200** carrying a JSON-RPC `error`, so a driver that
+ * checks only the status code reports a clean run having measured nothing but
+ * validation errors. `classifyMcpResponse` is the other half of that guard.
+ *
+ * Required args per the catalog: list→scope, search→q, write→scope/key/value,
+ * scopes→none. `search` takes `scopes` (PLURAL, an array); `list` takes `scope`
+ * (singular). They are not interchangeable.
+ */
+export function mcpArgumentsFor(op, { scope, key, value, q } = {}) {
+  switch (op) {
+    case 'list': return { scope, limit: 50 };
+    case 'search': return { q: q ?? 'lesson', scopes: [scope], limit: 20 };
+    case 'scopes': return {};
+    case 'write': return { scope, key, value };
+    default: throw new Error(`no MCP mapping for op "${op}"`);
+  }
+}
+
+/**
+ * Classify one MCP response. THE trap of this transport.
+ *
+ * JSON-RPC carries application errors INSIDE a 200, so status alone cannot tell
+ * success from failure — a run that 200s on every request may have failed every
+ * request. Meanwhile the rate limiter answers at the TRANSPORT layer with a real
+ * 429 before JSON-RPC is reached, so both signals are live at once and must be
+ * read in the right order.
+ *
+ * `isError` on a tool RESULT is distinct again: the call succeeded and the tool
+ * reported a domain failure (a cap rejection, a permission denial). Counted as
+ * an error, because it is one — but it is not a transport fault.
+ */
+export function classifyMcpResponse({ status, body }) {
+  if (status === 429) return 'rate_limited';
+  if (status === 0) return 'error';               // transport failure
+  if (status < 200 || status >= 300) return 'error';
+  if (!body || typeof body !== 'object') return 'error';
+  if (body.error) return 'error';                 // JSON-RPC error in a 200
+  if (body.result?.isError) return 'error';       // tool-level failure
+  return 'ok';
+}
+
+// ── rate-limit headroom ──────────────────────────────────────────────────────
+
+/**
+ * How many of a surface's requests the per-user rate limiter actually counts.
+ *
+ * MCP checks the limit on EVERY method (`mcp/index.ts`, right after auth
+ * resolves). REST checks it in only two handlers — `create.ts` and `purge.ts` —
+ * so on REST only the WRITE share of the mix is limited and reads are ungated.
+ * That asymmetry is why one users-per-rps rule cannot serve both.
+ */
+export function limitedShareOfMix(surface, mix = DEFAULT_MIX) {
+  if (surface === 'mcp') return 1;
+  const total = mix.reduce((n, m) => n + m.weight, 0);
+  if (total <= 0) return 0;
+  return mix.filter((m) => m.op === 'write').reduce((n, m) => n + m.weight, 0) / total;
+}
+
+/**
+ * Does this configuration have the headroom to drive the requested rate without
+ * the rate limiter deciding the result?
+ *
+ * WHY THIS IS A HARD GUARD AND NOT A WARNING
+ * The harness's own defaults (20 rps across 5 users) are 4 rps/user, and the
+ * default ceiling is 120 req/min = 2 rps/user. On MCP that is 2x over: half the
+ * run would 429 and the percentiles would describe the guardrail, not the
+ * service. A load test that silently measures its own throttling is worse than
+ * no load test, because the number looks usable.
+ *
+ * Returns the users actually required so the caller can print a fix rather than
+ * a complaint. `requestsPerMinute` is a parameter because the real ceiling is
+ * `lorekit_get_limit(user_id, 'requests_per_minute')` and a `user_limits` row
+ * can raise it — 120 is only the default.
+ */
+export function checkRateHeadroom({ surface, rps, users, mix = DEFAULT_MIX, requestsPerMinute = 120 }) {
+  const share = limitedShareOfMix(surface, mix);
+  const perUserCeiling = requestsPerMinute / 60;
+  if (share === 0 || perUserCeiling <= 0) return { ok: true, requiredUsers: users, limitedRps: 0, perUserCeiling };
+  const limitedRps = rps * share;
+  const requiredUsers = Math.ceil(limitedRps / perUserCeiling);
+  if (users >= requiredUsers) return { ok: true, requiredUsers, limitedRps, perUserCeiling };
+  return {
+    ok: false,
+    requiredUsers,
+    limitedRps,
+    perUserCeiling,
+    error:
+      `${surface} rate-limits ${share === 1 ? 'every method' : `the write share (${(share * 100).toFixed(0)}%)`}, ` +
+      `so ${rps} rps needs at least ${requiredUsers} users at ${requestsPerMinute} req/min/user ` +
+      `(${limitedRps.toFixed(1)} limited rps ÷ ${perUserCeiling.toFixed(2)} per user) — got ${users}. ` +
+      `Raise --users to ${requiredUsers}, or lower --rps to ${Math.floor(users * perUserCeiling / share)}.`,
+  };
+}
+
+// ── stress mode (ramp) ───────────────────────────────────────────────────────
+
+/**
+ * The rungs of a stress ladder: multiply until the ceiling, inclusive.
+ *
+ * Geometric rather than linear because the interesting region is unknown by
+ * orders of magnitude — a linear +10 rps walk spends its whole budget below the
+ * knee. The ceiling is always included even when the factor overshoots it, so
+ * `--max-rps` means what it says.
+ */
+export function buildRampRungs({ startRps, maxRps, factor = 2 }) {
+  if (!(startRps > 0) || !(maxRps >= startRps) || !(factor > 1)) return [];
+  const rungs = [];
+  for (let r = startRps; r < maxRps; r *= factor) rungs.push(Math.round(r));
+  rungs.push(Math.round(maxRps));
+  return [...new Set(rungs)];
+}
+
+/**
+ * Should the ladder stop after this rung?
+ *
+ * A rung is the LAST GOOD one when the next would tell us nothing new. Three
+ * independent stop conditions, because saturation shows up differently:
+ *
+ *   - errors: the service is failing, not merely slow.
+ *   - p99: latency has left the range anyone would ship.
+ *   - 429s: we hit the guardrail, so further rungs measure the limiter. This is
+ *     NOT a failure of the service — it is the reason `checkRateHeadroom`
+ *     exists — but it does end the useful part of the ladder.
+ *
+ * `achievedRps` below the requested rate ends it too: the CLIENT saturated, so
+ * a higher requested rate cannot actually be offered and every later rung would
+ * silently measure the same load.
+ */
+export function rampVerdict(rung, { maxP99Ms = 5000, maxErrorRate = 0.01, maxRateLimitedRate = 0.01, minAchievedRatio = 0.9 } = {}) {
+  const total = rung.count ?? 0;
+  if (total === 0) return { stop: true, reason: 'no requests completed' };
+  const errorRate = (rung.errors ?? 0) / total;
+  const limitedRate = (rung.rateLimited ?? 0) / total;
+  if (errorRate > maxErrorRate) return { stop: true, reason: `error rate ${(errorRate * 100).toFixed(1)}% > ${(maxErrorRate * 100).toFixed(1)}%` };
+  if ((rung.p99 ?? 0) > maxP99Ms) return { stop: true, reason: `p99 ${rung.p99}ms > ${maxP99Ms}ms` };
+  if (limitedRate > maxRateLimitedRate) return { stop: true, reason: `429 rate ${(limitedRate * 100).toFixed(1)}% > ${(maxRateLimitedRate * 100).toFixed(1)}% — the ladder is now measuring the rate limiter` };
+  if (rung.requestedRps > 0 && (rung.achievedRps ?? 0) / rung.requestedRps < minAchievedRatio) {
+    return { stop: true, reason: `achieved ${rung.achievedRps?.toFixed(1)} of ${rung.requestedRps} rps — the CLIENT saturated, not the service` };
+  }
+  return { stop: false };
 }

--- a/scripts/load-test-lib.test.mjs
+++ b/scripts/load-test-lib.test.mjs
@@ -3,14 +3,24 @@ import assert from 'node:assert/strict';
 
 import {
   DEFAULT_MIX,
+  MCP_TOOL_FOR_OP,
   buildOpSequence,
+  buildRampRungs,
   buildSchedule,
+  checkRateHeadroom,
   checkServiceCredential,
+  classifyMcpResponse,
   dbShare,
   describeSupabaseKey,
   diffQueryStats,
+  limitedShareOfMix,
+  mcpArgumentsFor,
+  outcomeOf,
   percentile,
   projectRefFromUrl,
+  rampVerdict,
+  resolveAuthMode,
+  resolveSurface,
   resolveTarget,
   summarize,
   totals,
@@ -377,4 +387,183 @@ test('a self-hosted URL asserts no mismatch', () => {
     supabaseUrl: 'http://localhost:54321',
   });
   assert.deepEqual(r.errors, []);
+});
+
+// ── surface / auth resolution ────────────────────────────────────────────────
+
+/**
+ * These exist because the REST arm was mistaken for whole-system coverage. REST
+ * is the DASHBOARD's path; agents use MCP, which has its own handlers, its own
+ * auth span, and rate-limits every method. The pair (surface, auth) is what
+ * identifies a real caller, so both dimensions are resolved and both defaulted.
+ */
+
+test('the surface defaults to rest and rejects anything unknown', () => {
+  assert.equal(resolveSurface(undefined, {}).surface, 'rest');
+  assert.equal(resolveSurface('mcp', {}).surface, 'mcp');
+  assert.equal(resolveSurface('MCP', {}).surface, 'mcp', 'case-insensitive');
+  assert.equal(resolveSurface(undefined, { LOREKIT_LOAD_SURFACE: 'mcp' }).surface, 'mcp');
+  assert.equal(resolveSurface('grpc', {}).ok, false);
+});
+
+test('auth defaults to the tier each surface is really called with', () => {
+  // mcp -> token: agents hold `lk_rw_*`. rest -> jwt: the dashboard holds a JWT.
+  assert.equal(resolveAuthMode(undefined, 'mcp').auth, 'token');
+  assert.equal(resolveAuthMode(undefined, 'rest').auth, 'jwt');
+  // rest + token is the CLI's remote mode — a DIFFERENT branch of
+  // resolveRestAuth than the dashboard's, so it must be reachable.
+  assert.equal(resolveAuthMode('token', 'rest').auth, 'token');
+  assert.equal(resolveAuthMode('oauth', 'rest').ok, false);
+});
+
+// ── MCP wire shape ───────────────────────────────────────────────────────────
+
+test('every op in the default mix maps to a real MCP tool', () => {
+  for (const { op } of DEFAULT_MIX) {
+    assert.ok(MCP_TOOL_FOR_OP[op], `no MCP tool for "${op}"`);
+    assert.match(MCP_TOOL_FOR_OP[op], /^memory\./);
+  }
+});
+
+test('MCP arguments satisfy each tool\'s required fields', () => {
+  // Straight from the catalog: list->scope, search->q, write->scope/key/value,
+  // scopes->none. A missing one returns HTTP 200 with a JSON-RPC error, so this
+  // is not a cosmetic assertion.
+  const ctx = { scope: 'global', key: 'k', value: 'v' };
+  assert.deepEqual(Object.keys(mcpArgumentsFor('scopes', ctx)), []);
+  assert.ok('scope' in mcpArgumentsFor('list', ctx));
+  assert.ok('q' in mcpArgumentsFor('search', ctx));
+  for (const f of ['scope', 'key', 'value']) assert.ok(f in mcpArgumentsFor('write', ctx), `write needs ${f}`);
+});
+
+test('search takes `scopes` (array) and list takes `scope` — not interchangeable', () => {
+  const a = mcpArgumentsFor('search', { scope: 'global' });
+  assert.ok(Array.isArray(a.scopes), 'search.scopes must be an array');
+  assert.equal(a.scope, undefined, 'search must not send the singular form');
+  const l = mcpArgumentsFor('list', { scope: 'global' });
+  assert.equal(typeof l.scope, 'string');
+  assert.equal(l.scopes, undefined, 'list must not send the plural form');
+});
+
+test('an unmapped op throws rather than sending an empty tool call', () => {
+  assert.throws(() => mcpArgumentsFor('teleport', {}), /no MCP mapping/);
+});
+
+// ── the JSON-RPC trap ────────────────────────────────────────────────────────
+
+test('a JSON-RPC error inside a 200 is an ERROR, not a success', () => {
+  // THE trap of this transport. A driver that checks only the status code
+  // reports a perfect run having failed every single request.
+  assert.equal(classifyMcpResponse({ status: 200, body: { jsonrpc: '2.0', id: 1, error: { code: -32602, message: 'Invalid params' } } }), 'error');
+  assert.equal(classifyMcpResponse({ status: 200, body: { jsonrpc: '2.0', id: 1, result: { content: [] } } }), 'ok');
+});
+
+test('a tool-level isError is an error even though the call succeeded', () => {
+  assert.equal(classifyMcpResponse({ status: 200, body: { result: { isError: true, content: [{ type: 'text', text: 'memory cap reached' }] } } }), 'error');
+});
+
+test('429 is read before the body — the limiter answers above JSON-RPC', () => {
+  assert.equal(classifyMcpResponse({ status: 429, body: null }), 'rate_limited');
+  // Even if a body somehow accompanies it.
+  assert.equal(classifyMcpResponse({ status: 429, body: { error: { code: -32000 } } }), 'rate_limited');
+});
+
+test('transport failures and non-2xx are errors', () => {
+  assert.equal(classifyMcpResponse({ status: 0, body: null }), 'error');
+  assert.equal(classifyMcpResponse({ status: 500, body: null }), 'error');
+  assert.equal(classifyMcpResponse({ status: 200, body: null }), 'error', 'a 200 with no parseable body is not a success');
+});
+
+// ── rate-limit headroom ──────────────────────────────────────────────────────
+
+test('MCP counts every method; REST counts only the write share', () => {
+  assert.equal(limitedShareOfMix('mcp'), 1);
+  // DEFAULT_MIX is 15/100 write.
+  assert.ok(Math.abs(limitedShareOfMix('rest') - 0.15) < 1e-9);
+});
+
+test('the harness\'s OWN defaults are refused on MCP — the guard that matters', () => {
+  // 20 rps / 5 users = 4 rps/user against a 2 rps/user ceiling. Half the run
+  // would 429 and the percentiles would describe the guardrail. This must fail.
+  const r = checkRateHeadroom({ surface: 'mcp', rps: 20, users: 5 });
+  assert.equal(r.ok, false);
+  assert.equal(r.requiredUsers, 10);
+  assert.match(r.error, /needs at least 10 users/);
+  assert.match(r.error, /Raise --users to 10, or lower --rps to 10/);
+});
+
+test('the same settings are fine on REST, because reads are ungated', () => {
+  // Only 15% of 20 rps is limited = 3 rps, i.e. 0.6 rps/user over 5 users.
+  const r = checkRateHeadroom({ surface: 'rest', rps: 20, users: 5 });
+  assert.equal(r.ok, true);
+  assert.equal(r.requiredUsers, 2);
+});
+
+test('a raised per-user ceiling reduces the users needed', () => {
+  // The real ceiling is lorekit_get_limit(user,'requests_per_minute'); 120 is
+  // only the default and a user_limits row can raise it.
+  const r = checkRateHeadroom({ surface: 'mcp', rps: 20, users: 2, requestsPerMinute: 600 });
+  assert.equal(r.ok, true, r.error);
+  assert.equal(r.requiredUsers, 2);
+});
+
+test('stress rates need proportionally many users on MCP', () => {
+  assert.equal(checkRateHeadroom({ surface: 'mcp', rps: 100, users: 1 }).requiredUsers, 50);
+  assert.equal(checkRateHeadroom({ surface: 'mcp', rps: 200, users: 1 }).requiredUsers, 100);
+});
+
+// ── ramp / stress ────────────────────────────────────────────────────────────
+
+test('the ramp is geometric and always includes the ceiling', () => {
+  assert.deepEqual(buildRampRungs({ startRps: 20, maxRps: 160 }), [20, 40, 80, 160]);
+  // Overshooting factor must not drop or exceed the stated max.
+  assert.deepEqual(buildRampRungs({ startRps: 20, maxRps: 100 }), [20, 40, 80, 100]);
+  assert.deepEqual(buildRampRungs({ startRps: 20, maxRps: 20 }), [20]);
+  assert.deepEqual(buildRampRungs({ startRps: 0, maxRps: 100 }), []);
+  assert.deepEqual(buildRampRungs({ startRps: 50, maxRps: 10 }), [], 'max below start yields nothing');
+});
+
+test('the ladder stops on errors, latency, 429s, or a saturated client', () => {
+  const good = { count: 1000, errors: 0, rateLimited: 0, p99: 800, requestedRps: 20, achievedRps: 19.8 };
+  assert.equal(rampVerdict(good).stop, false);
+
+  assert.match(rampVerdict({ ...good, errors: 50 }).reason, /error rate/);
+  assert.match(rampVerdict({ ...good, p99: 9000 }).reason, /p99/);
+  // 429s end the USEFUL ladder without meaning the service failed.
+  assert.match(rampVerdict({ ...good, rateLimited: 100 }).reason, /measuring the rate limiter/);
+  // Client saturation must be named as such, not misread as the service slowing.
+  assert.match(rampVerdict({ ...good, achievedRps: 12 }).reason, /CLIENT saturated/);
+});
+
+test('a rung with no completed requests stops the ladder', () => {
+  assert.equal(rampVerdict({ count: 0 }).stop, true);
+});
+
+test('an MCP failure inside a 200 is summarised as an error, not a success', () => {
+  // The classifier is worthless unless the SUMMARY honours it. Without this,
+  // the MCP arm reports every failed tool call as ok.
+  const rs = [
+    { op: 'write', status: 200, ms: 100, outcome: 'ok' },
+    { op: 'write', status: 200, ms: 110, outcome: 'error' },       // JSON-RPC error
+    { op: 'write', status: 429, ms: 3, outcome: 'rate_limited' },
+  ];
+  const [w] = summarize(rs);
+  assert.equal(w.ok, 1);
+  assert.equal(w.errors, 1, 'the 200-with-error must not count as ok');
+  assert.equal(w.rateLimited, 1);
+  assert.equal(w.p50, 100, 'only the genuine success contributes latency');
+  assert.equal(totals(rs).errors, 1);
+});
+
+test('REST results with no explicit outcome behave exactly as before', () => {
+  // Regression guard on the fallback: adding the outcome field must not change
+  // how the REST arm is scored.
+  assert.equal(outcomeOf({ status: 200 }), 'ok');
+  assert.equal(outcomeOf({ status: 201 }), 'ok');
+  assert.equal(outcomeOf({ status: 429 }), 'rate_limited');
+  assert.equal(outcomeOf({ status: 500 }), 'error');
+  assert.equal(outcomeOf({ status: 0 }), 'error');
+  assert.equal(outcomeOf({ status: 404 }), 'client_error');
+  // An explicit outcome always wins.
+  assert.equal(outcomeOf({ status: 200, outcome: 'error' }), 'error');
 });

--- a/scripts/load-test.mjs
+++ b/scripts/load-test.mjs
@@ -1,20 +1,38 @@
 #!/usr/bin/env node
 /**
- * LoreKit load test — drives the REST surface at a fixed arrival rate, then
- * attributes the latency to specific SQL statements.
+ * LoreKit load and stress test — drives a chosen surface at a fixed arrival rate
+ * (or up a ladder of rates), then attributes the latency to specific SQL
+ * statements.
  *
- * WHY REST, AND WHY NOT MCP OR THE CLI
- * ------------------------------------
- * REST and MCP converge on the same handlers and the same SQL, so the expensive
- * part is shared — and REST reads are the only surface that can actually be
- * pushed: MCP checks the rate limit on EVERY method (120/min/user = 2 rps), so a
- * load script pointed at it measures the rate limiter. The CLI is a REST client
- * and adds no server-side path; load-testing it measures node startup on the
- * runner. Full reasoning in docs/benchmarking.md.
+ * TWO DIMENSIONS: SURFACE x AUTH TIER
+ * -----------------------------------
+ * The pair identifies a real caller, and all three pairings are genuinely
+ * different code paths — the REST-only arm this started as was never
+ * whole-system coverage:
+ *
+ *   rest + jwt    the DASHBOARD (packages/web/src/lib/api/)
+ *   rest + token  the CLI in remote mode — `lk_*` takes a different branch of
+ *                 `resolveRestAuth`, reached via a DB lookup on `api_tokens`
+ *   mcp  + token  AGENTS — its own handlers (mcp/tools.ts), its own auth span
+ *                 (`lorekit.mcp.auth`, which `lorekit.rest.auth` is NOT), and it
+ *                 rate-limits EVERY method where REST gates only writes
+ *
+ * They converge at the RPC/SQL layer, so a DATABASE finding generalises across
+ * them. A transport or auth finding does not.
+ *
+ * THE CONSTRAINT THAT SHAPES THE MCP ARM
+ * MCP checks the rate limit on every method — 120/min/user = 2 rps — so rate is
+ * bought with USERS, not with a bigger number. 20 rps needs 10 users; 100 needs
+ * 50. `checkRateHeadroom` REFUSES a configuration that cannot fit, because a run
+ * that silently measures its own throttling produces a number that looks usable.
+ * Full reasoning in docs/benchmarking.md.
  *
  * WHAT MAKES THE NUMBERS TRUSTWORTHY
  *  - OPEN LOOP. The arrival schedule is fixed up front, so a slowing server
  *    cannot reduce the offered load (see `buildSchedule`).
+ *  - On MCP, the OUTCOME is read from the JSON-RPC body, not the status code:
+ *    that transport returns application errors inside a 200, so a status-only
+ *    reading scores every failed tool call as a success.
  *  - Percentiles over successful requests only; 429 is counted separately
  *    because it is the guardrail working, not a failure.
  *  - Users are SCALED rather than having their limits raised: the rate-limit
@@ -39,15 +57,23 @@
  *   sandbox baseline point 6).
  */
 
-import { randomUUID } from 'node:crypto';
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
 
 import {
   DEFAULT_MIX,
+  MCP_TOOL_FOR_OP,
   buildOpSequence,
+  buildRampRungs,
   buildSchedule,
+  checkRateHeadroom,
   checkServiceCredential,
+  classifyMcpResponse,
   dbShare,
   diffQueryStats,
+  mcpArgumentsFor,
+  rampVerdict,
+  resolveAuthMode,
+  resolveSurface,
   resolveTarget,
   summarize,
   totals,
@@ -57,14 +83,20 @@ import { exportLoad } from './load-telemetry.mjs';
 // ── argv ─────────────────────────────────────────────────────────────────────
 
 function parseArgs(argv) {
-  const opts = { rps: '20', duration: '60', users: '5', seed: '50', target: null, dryRun: false, keepUsers: false };
+  const opts = {
+    rps: '20', duration: '60', users: '5', seed: '50', target: null,
+    surface: null, auth: null, maxRps: null,
+    dryRun: false, keepUsers: false, ramp: false,
+  };
   const flags = {
     '--target': 'target', '--rps': 'rps', '--duration': 'duration',
     '--users': 'users', '--seed': 'seed',
+    '--surface': 'surface', '--auth': 'auth', '--max-rps': 'maxRps',
   };
   for (let i = 0; i < argv.length; i += 1) {
     if (argv[i] === '--dry-run') { opts.dryRun = true; continue; }
     if (argv[i] === '--keep-users') { opts.keepUsers = true; continue; }
+    if (argv[i] === '--ramp') { opts.ramp = true; continue; }
     if (argv[i] === '--help' || argv[i] === '-h') { opts.help = true; continue; }
     const key = flags[argv[i]];
     if (!key) die(`Unknown argument: ${argv[i]} (try --help)`);
@@ -102,6 +134,36 @@ async function timed(op, url, init, timeoutMs = 30_000) {
     return { op, status: res.status, ms: performance.now() - t0 };
   } catch (err) {
     return { op, status: 0, ms: performance.now() - t0, error: `${err.name}: ${err.message}` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * One measured MCP request. Like `timed`, but it PARSES the body.
+ *
+ * It has to. JSON-RPC returns application errors inside a 200, so unlike REST
+ * the status code does not determine the outcome — draining the body unread (as
+ * `timed` does, deliberately, to avoid holding the socket) would make every
+ * failed tool call indistinguishable from a success. The body is small here: a
+ * tool result, not a page of rows.
+ */
+async function timedMcp(op, url, init, timeoutMs = 30_000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const t0 = performance.now();
+  try {
+    const res = await fetch(url, { ...init, signal: controller.signal });
+    const text = await res.text().catch(() => '');
+    let body = null;
+    try { body = text ? JSON.parse(text) : null; } catch { body = null; }
+    const outcome = classifyMcpResponse({ status: res.status, body });
+    const detail = outcome === 'error'
+      ? (body?.error?.message ?? body?.result?.content?.[0]?.text ?? `HTTP ${res.status}`)
+      : undefined;
+    return { op, status: res.status, ms: performance.now() - t0, outcome, error: detail?.slice(0, 200) };
+  } catch (err) {
+    return { op, status: 0, ms: performance.now() - t0, outcome: 'error', error: `${err.name}: ${err.message}` };
   } finally {
     clearTimeout(timer);
   }
@@ -181,6 +243,16 @@ async function deleteUsers({ supabaseUrl, serviceKey, users }) {
 }
 
 /** Seed a little lore per user, so reads return rows instead of measuring an empty table. */
+/**
+ * Seed lore so reads measure a populated table.
+ *
+ * ALWAYS over REST with a JWT, whatever surface is being driven. Seeding is
+ * setup, not measurement — and pointing it at the surface `endpoint` would POST
+ * REST-shaped bodies at the JSON-RPC function on `--surface mcp`, seeding
+ * nothing and leaving every subsequent read to measure an empty table while the
+ * report looked healthy. Same failure class as the doubled `/memories` path this
+ * harness shipped with once already.
+ */
 async function seedLore({ endpoint, users, perUser, runId, headers }) {
   let written = 0;
   for (const u of users) {
@@ -200,6 +272,53 @@ async function seedLore({ endpoint, users, perUser, runId, headers }) {
     }
   }
   return written;
+}
+
+/**
+ * Mint an `lk_rw_*` API token for a provisioned user.
+ *
+ * WHY THE HARNESS MINTS ITS OWN
+ * The token tiers are not cosmetic: `lk_*` takes a different branch of
+ * `resolveRestAuth`/`mcp/auth.ts` than a dashboard JWT — a service-role client
+ * with a mandatory `user_id` filter, reached via a DB lookup on `api_tokens`.
+ * Agents hold these, so driving MCP or the CLI's remote path with a JWT would
+ * measure a code path nobody runs in production.
+ *
+ * Inserted directly with the service-role key. The table's RLS insert policy is
+ * `user_id = auth.uid()`, which a service-role connection bypasses — the same
+ * reason the harness can provision users at all. The row is deleted with the
+ * user (`on delete cascade`).
+ *
+ * The hash contract is fixed by `mcp/auth.ts`: plain SHA-256 HEX of the full
+ * token string, looked up against `api_tokens.token_hash`. Not a salted hash,
+ * not base64 — a mismatch here 401s every request in the run.
+ */
+async function mintApiToken({ supabaseUrl, serviceKey, userId, runId }) {
+  // `lk_{perm}_{32 alphanumerics}`, per 00002_api_tokens.sql.
+  const alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+  const bytes = randomBytes(32);
+  const suffix = Array.from(bytes, (b) => alphabet[b % alphabet.length]).join('');
+  const token = `lk_rw_${suffix}`;
+  const hash = createHash('sha256').update(token).digest('hex');
+
+  await json(`${supabaseUrl}/rest/v1/api_tokens`, {
+    method: 'POST',
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=minimal',
+    },
+    body: JSON.stringify({
+      user_id: userId,
+      name: `loadtest-${runId}`,
+      // First 12 chars + "..." — the display form, capped at 16 by a CHECK.
+      token_prefix: `${token.slice(0, 12)}...`,
+      token_hash: hash,
+      permissions: ['read', 'write'],
+    }),
+  });
+  return token;
 }
 
 const SCOPES = ['global', 'project::loadtest', 'repo::mthines/lorekit', 'branch::mthines/lorekit::main'];
@@ -239,7 +358,7 @@ async function snapshotQueryStats({ supabaseUrl, serviceKey }) {
  * together at the end, which is what makes this open-loop: a slow response
  * delays nothing but itself.
  */
-async function drive({ endpoint, users, schedule, ops, headers, correlationId }) {
+async function drive({ endpoint, users, schedule, ops, headers, correlationId, requestFn }) {
   const started = performance.now();
   const inFlight = [];
 
@@ -254,7 +373,7 @@ async function drive({ endpoint, users, schedule, ops, headers, correlationId })
     const user = users[i % users.length];
     const op = ops[i];
     const h = { ...headers(user), 'X-LoreKit-Correlation-Id': correlationId };
-    inFlight.push(request({ endpoint, op, user, headers: h, i, correlationId }));
+    inFlight.push(requestFn({ endpoint, op, user, headers: h, i, correlationId }));
   }
 
   const results = await Promise.all(inFlight);
@@ -290,6 +409,41 @@ function request({ endpoint, op, headers, i, correlationId }) {
     default:
       throw new Error(`Unknown op: ${op}`);
   }
+}
+
+/**
+ * The MCP counterpart: one JSON-RPC `tools/call` over POST.
+ *
+ * MCP is STATELESS here — `mcp-handler.ts` dispatches `tools/call` on its own,
+ * with `initialize` handled but never a precondition — so no handshake is
+ * replayed per request. One `initialize` per user would be protocol-polite and
+ * would measure nothing, so it is omitted rather than inflating the request
+ * count with a method no agent repeats.
+ *
+ * Every request carries the rate limiter's full attention: unlike REST, MCP
+ * checks the limit on EVERY method, which is why `checkRateHeadroom` refuses a
+ * configuration that cannot fit under it.
+ */
+function mcpRequest({ endpoint, op, headers, i, correlationId }) {
+  const scope = SCOPES[i % SCOPES.length];
+  const args = mcpArgumentsFor(op, {
+    scope,
+    // Unique per request for the same reason as the REST arm: an upsert UPDATE
+    // would skip the cap trigger and measure the wrong write.
+    key: `loadtest-${correlationId}-m-${i}`,
+    value: `Load write ${i}.`,
+    q: 'merged intervals',
+  });
+  return timedMcp(op, endpoint, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: i + 1,
+      method: 'tools/call',
+      params: { name: MCP_TOOL_FOR_OP[op], arguments: args },
+    }),
+  });
 }
 
 // ── report ───────────────────────────────────────────────────────────────────
@@ -362,6 +516,12 @@ LoreKit load test — open-loop REST driver with SQL attribution.
   --duration <s>     drive duration in seconds        (default 60)
   --users <n>        provisioned users; each gets its own 120 rpm budget (5)
   --seed <n>         lore rows seeded per user        (default 50)
+  --surface <s>      rest | mcp                        (default rest)
+                     rest = dashboard/CLI path, mcp = the AGENT path
+  --auth <a>         jwt | token                       (default: mcp->token, rest->jwt)
+                     rest+token is the CLI's remote path (api_key tier)
+  --ramp             stress mode: step the rate until saturation
+  --max-rps <n>      the ramp's ceiling (required with --ramp)
   --dry-run          build the OTLP payloads, send nothing
   --keep-users       skip cleanup (for debugging; leaves real rows behind)
 
@@ -375,6 +535,14 @@ Env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY.
 const targetResult = resolveTarget(opts.target, process.env);
 if (!targetResult.ok) die(targetResult.error);
 const target = targetResult.target;
+
+const surfaceResult = resolveSurface(opts.surface, process.env);
+if (!surfaceResult.ok) die(surfaceResult.error);
+const surface = surfaceResult.surface;
+
+const authResult = resolveAuthMode(opts.auth, surface, process.env);
+if (!authResult.ok) die(authResult.error);
+const authMode = authResult.auth;
 
 for (const [flag, v] of [['--rps', opts.rps], ['--duration', opts.duration], ['--users', opts.users], ['--seed', opts.seed]]) {
   if (!/^\d+(\.\d+)?$/.test(v) || Number(v) <= 0) die(`${flag} must be a positive number, got "${v}"`);
@@ -401,23 +569,44 @@ const run = {
   durationSec: Number(opts.duration),
   users: Number(opts.users),
 };
+// REFUSE a configuration the rate limiter would decide. MCP checks the limit on
+// every method (2 rps/user at the 120/min default), so the harness's own
+// defaults — 20 rps across 5 users — are 2x over on that surface: half the run
+// would 429 and the percentiles would describe the guardrail, not the service. A
+// load test that silently measures its own throttling is worse than none,
+// because the number looks usable. Fails with the users actually required.
+const peakRps = opts.ramp && opts.maxRps ? Number(opts.maxRps) : run.rps;
+const headroom = checkRateHeadroom({ surface, rps: peakRps, users: run.users });
+if (!headroom.ok) die(headroom.error);
+
 const runId = randomUUID().slice(0, 8);
 const correlationId = `load-${runId}`;
 // The `memories` FUNCTION base. Every op path is relative to this, so it must
 // NOT be re-suffixed with `/memories`: `…/functions/v1/memories/memories`
 // matches the router's `/:id` route with id="memories" rather than the list
 // route, and the run measures error responses while looking healthy.
-const endpoint = `${supabaseUrl}/functions/v1/memories`;
+const endpoint = surface === 'mcp'
+  ? `${supabaseUrl}/functions/v1/mcp`
+  : `${supabaseUrl}/functions/v1/memories`;
+const requestFn = surface === 'mcp' ? mcpRequest : request;
+
+// Both functions declare `verify_jwt = false` (supabase/config.toml), so the
+// gateway does not gate them and the function does its own auth — which is why
+// an `lk_*` token needs no accompanying `apikey`, exactly as the CLI sends it
+// (`packages/cli/src/mcp.mjs`). The JWT arm keeps the anon key because that is
+// what the dashboard sends.
 const headers = (user) => ({
-  Authorization: `Bearer ${user.jwt}`,
-  apikey: anonKey,
-  'X-LoreKit-Client': 'cli',
+  ...(authMode === 'token'
+    ? { Authorization: `Bearer ${user.token}` }
+    : { Authorization: `Bearer ${user.jwt}`, apikey: anonKey }),
+  'X-LoreKit-Client': surface === 'mcp' ? 'mcp' : 'cli',
   // Marks the run's server spans synthetic, so they filter apart from real
   // traffic instead of polluting a production view.
   'X-LoreKit-Deployment-Environment': 'test',
 });
 
 log(`\n▸ Load test → ${target}  (${supabaseUrl})`);
+log(`  surface ${surface} · auth ${authMode}${surface === 'mcp' ? ' · agent path' : authMode === 'token' ? ' · CLI remote path' : ' · dashboard path'}`);
 log(`  ${run.rps} rps × ${run.durationSec}s across ${run.users} users · correlation_id ${correlationId}`);
 if (target === 'production') {
   log('  ⚠ PRODUCTION: this writes real rows into the shared memories table and');
@@ -429,6 +618,16 @@ try {
   log(`\n▸ Provisioning ${run.users} users`);
   try {
     users = await provisionUsers({ supabaseUrl, serviceKey, anonKey, count: run.users, runId });
+    if (authMode === 'token') {
+      // Minted per user, not shared: the rate limiter counts per (user, window),
+      // so one token across N users would concentrate the whole run on a single
+      // counter row and measure lock serialization production never sees — the
+      // same reason users are scaled rather than having their limits raised.
+      log(`  minting an lk_rw_ token per user (${authMode} tier)`);
+      for (const u of users) {
+        u.token = await mintApiToken({ supabaseUrl, serviceKey, userId: u.id, runId });
+      }
+    }
   } catch (err) {
     // The pre-flight above already ruled out the two decidable causes of a 401
     // (wrong project, wrong role). If one still arrives, the remaining causes
@@ -446,19 +645,85 @@ try {
   }
 
   log(`▸ Seeding ${opts.seed} lore rows per user`);
-  const seeded = await seedLore({ endpoint, users, perUser: Number(opts.seed), runId, headers });
+  const seeded = await seedLore({
+    endpoint: `${supabaseUrl}/functions/v1/memories`,
+    users,
+    perUser: Number(opts.seed),
+    runId,
+    // The JWT tier explicitly: a freshly minted `lk_*` token would also work,
+    // but the JWT is present on every run and keeps seeding independent of
+    // whichever tier is under test.
+    headers: (u) => ({ Authorization: `Bearer ${u.jwt}`, apikey: anonKey, 'X-LoreKit-Deployment-Environment': 'test' }),
+  });
   log(`  ${seeded} rows written`);
 
   log('▸ Baseline query-stats snapshot');
   const before = await snapshotQueryStats({ supabaseUrl, serviceKey });
 
-  const schedule = buildSchedule({ rps: run.rps, durationSec: run.durationSec });
-  const ops = buildOpSequence(schedule.length, DEFAULT_MIX);
-  log(`▸ Driving ${schedule.length} requests (open loop)\n`);
+  // ── the drive phase, one rung or a ladder ──────────────────────────────────
+  // A single rung IS a load test; a ladder of rungs is the stress test. Both
+  // reuse the same provisioned users and the same seeded rows, so a difference
+  // between rungs is the offered rate and nothing else.
+  const rungs = opts.ramp
+    ? buildRampRungs({ startRps: run.rps, maxRps: Number(opts.maxRps) })
+    : [run.rps];
+  if (opts.ramp && !rungs.length) die('--ramp needs --max-rps >= --rps.');
+  if (opts.ramp) log(`▸ Stress ladder: ${rungs.join(' → ')} rps, ${run.durationSec}s per rung\n`);
 
   const startMs = Date.now();
-  const { results, wallMs } = await drive({ endpoint, users, schedule, ops, headers, correlationId });
+  let results = [];
+  let wallMs = 0;
+  const ladder = [];
+
+  for (const rungRps of rungs) {
+    const schedule = buildSchedule({ rps: rungRps, durationSec: run.durationSec });
+    const ops = buildOpSequence(schedule.length, DEFAULT_MIX);
+    log(`▸ Driving ${schedule.length} requests at ${rungRps} rps (open loop)`);
+    const r = await drive({ endpoint, users, schedule, ops, headers, correlationId, requestFn });
+
+    const rungAgg = totals(r.results);
+    const rungAchieved = r.results.length / (r.wallMs / 1000);
+    const rung = {
+      requestedRps: rungRps,
+      achievedRps: rungAchieved,
+      count: rungAgg.requests,
+      ok: rungAgg.ok,
+      errors: rungAgg.errors,
+      rateLimited: rungAgg.rateLimited,
+      p50: rungAgg.p50, p95: rungAgg.p95, p99: rungAgg.p99,
+    };
+    const verdict = rampVerdict(rung);
+    ladder.push({ ...rung, stopped: verdict.stop, reason: verdict.reason });
+
+    // The LAST rung's results are the ones reported and exported in detail:
+    // on a single-rung run that is the run, and on a ladder it is the most
+    // interesting rung reached. Earlier rungs live in the ladder table.
+    results = r.results;
+    wallMs = r.wallMs;
+
+    const ms = (v) => (v == null ? '-' : v.toFixed(1));
+    log(`  ${rungRps} rps → achieved ${rungAchieved.toFixed(1)} · p50 ${ms(rung.p50)}ms · p99 ${ms(rung.p99)}ms · ${rung.errors} err · ${rung.rateLimited} 429`);
+    if (verdict.stop) {
+      log(`  ⤵ ladder stops here: ${verdict.reason}`);
+      break;
+    }
+  }
+  log('');
   const endMs = Date.now();
+
+  if (opts.ramp) {
+    const lastGood = [...ladder].reverse().find((r) => !r.stopped);
+    log('── Stress ladder ───────────────────────────────────────────────');
+    log('   req rps   achieved       p50       p99    err    429');
+    for (const r of ladder) {
+      const f = (v) => (v == null ? '-' : v.toFixed(1));
+      log(`   ${String(r.requestedRps).padStart(7)}   ${r.achievedRps.toFixed(1).padStart(8)}   ${f(r.p50).padStart(7)}   ${f(r.p99).padStart(7)}   ${String(r.errors).padStart(4)}   ${String(r.rateLimited).padStart(4)}${r.stopped ? '   ← stopped' : ''}`);
+    }
+    log(lastGood
+      ? `\n   Highest sustained rate: ${lastGood.requestedRps} rps (p99 ${lastGood.p99?.toFixed(1)}ms)`
+      : '\n   No rung passed — the first rate was already past saturation.');
+    log('');
+  }
 
   log('▸ Final query-stats snapshot');
   const after = await snapshotQueryStats({ supabaseUrl, serviceKey });

--- a/scripts/load-test.mjs
+++ b/scripts/load-test.mjs
@@ -565,6 +565,11 @@ if (cred.errors.length) die(`credential check failed:\n  - ${cred.errors.join('\
 
 const run = {
   target,
+  // Carried into the telemetry: without these two, an MCP run and a REST run
+  // land in the SAME Dash0 series and average together, which is the one
+  // comparison this harness exists to make.
+  surface,
+  authTier: authMode,
   rps: Number(opts.rps),
   durationSec: Number(opts.duration),
   users: Number(opts.users),
@@ -738,7 +743,7 @@ try {
 
   const exported = await exportLoad({
     run: { ...run, startMs, endMs },
-    summary, agg, queryDiff, share, correlationId, dryRun: opts.dryRun,
+    summary, agg, queryDiff, share, correlationId, ladder, dryRun: opts.dryRun,
   });
 
   if (exported.dryRun) {
@@ -747,8 +752,9 @@ try {
     log(`    metrics    ${exported.metrics.resourceMetrics[0].scopeMetrics[0].metrics.map((m) => m.name).join(', ')}`);
   } else if (exported.exported) {
     log(`\n▸ Exported to Dash0: ${exported.datapoints} datapoints · trace ${exported.traceId}`);
-    log(`  Compare runs on service.name=load; join the server side on`);
-    log(`  lorekit.correlation_id=${correlationId}`);
+    log(`  Filter: service.name=load, lorekit.load.surface=${surface}, lorekit.load.auth_tier=${authMode}`);
+    log(`  Join the server side on lorekit.correlation_id=${correlationId}`);
+    if (ladder.length > 1) log(`  Ladder: lorekit.load.rung.duration by rps · lorekit.load.max_sustained_rps`);
   } else if (exported.reason) {
     log(`\n▸ Dash0 export skipped (${exported.reason}).`);
   } else {


### PR DESCRIPTION
The harness drove REST with a user JWT — which is the **dashboard**. Agents use MCP; the CLI uses `lk_*` tokens. The two paths that matter most were never measured.

The first Dash0 read of a real run is what made that concrete: **`lorekit.rest.auth` costs 193 ms on every request** — 46% of a read's server time — and it **does not exist on the MCP path**. A finding on the REST transport says nothing about agents.

## Surface × auth

The pair is what identifies a caller, and all three pairings are different code paths:

| `--surface` | `--auth` | Who | |
|---|---|---|---|
| `rest` | `jwt` | the dashboard | default, unchanged |
| `rest` | `token` | the **CLI** remote path | `lk_*` takes a different branch of `resolveRestAuth`, via a DB lookup on `api_tokens` |
| `mcp` | `token` | **agents** | own handlers (`mcp/tools.ts`), own auth span, rate-limits *every* method |

Defaults pick the real pairing per surface, so `--surface mcp` alone drives what an agent does. The harness mints an `lk_rw_*` token **per user** (service role bypasses the `user_id = auth.uid()` insert policy; the row cascades with the user) — per user, not shared, for the same reason users are scaled rather than having their limits raised.

They converge at the RPC/SQL layer, so a *database* finding generalises. A transport or auth finding does not.

## The guard that makes the MCP arm mean anything

MCP checks the limit on every method — 120/min = **2 rps/user** — so the harness's own defaults (20 rps / 5 users) are **2× over** on that surface, and half such a run would 429. `checkRateHeadroom` **refuses** rather than warns, and names the fix:

```
✗ mcp rate-limits every method, so 20 rps needs at least 10 users at
  120 req/min/user (20.0 limited rps ÷ 2.00 per user) — got 5.
  Raise --users to 10, or lower --rps to 10.
```

A run that silently measures its own throttling is worse than no run, because the number looks usable. On REST the same settings pass — only the 15% write share is gated.

## The trap of this transport

**JSON-RPC returns application errors inside a 200**, so a status-only reading scores every failed tool call as a success — a run can report 100% ok having accomplished nothing. `classifyMcpResponse` reads 429 first (the limiter answers *above* JSON-RPC), then `error`, then a tool-level `isError`. `timedMcp` parses the body where the REST path deliberately drains it unread.

The classifier would have been decorative without one more change: `summarize`/`totals` scored by HTTP status, so the verdict had to reach them (`outcomeOf`). REST results carry no `outcome` and are scored exactly as before — guarded by a test.

## Stress mode

`--ramp --max-rps N` steps geometrically over the same users and seeded rows, stopping at the first rung that trips **errors >1%**, **p99 >5s**, **429s >1%**, or **achieved rate <90% of requested** — the last named as the *client* saturating, not the service slowing. Reports the highest sustained rate. The headroom guard uses the ladder's **ceiling**, not its start.

```
── Stress ladder ───────────────────────────────────────────────
   req rps   achieved       p50       p99    err    429
        10       10.5       1.9       2.3      0      0
        20       20.5       1.8       2.8      0      0
        40       40.5       1.4       2.2      0      0

   Highest sustained rate: 40 rps (p99 2.2ms)
```

## Two things caught before shipping

**`seedLore` used the surface `endpoint`** — on `--surface mcp` it would have POSTed REST bodies at the JSON-RPC function, seeded nothing, and left every read measuring an empty table while the report looked healthy. Seeding is setup, so it's pinned to REST+JWT whatever is driven. Same failure class as the doubled `/memories` path this harness shipped with once already.

**My first read of the tool catalog was wrong.** It reported `memory.scopes` as requiring `scope` — window bleed between catalog entries. A wrong argument name is exactly the 200-with-error the classifier now catches, so I re-extracted per entry: list→`scope`, search→`q` (plus `scopes`, **plural**, an array), write→`scope`/`key`/`value`, scopes→none.

## Verification

Against a **strict** mock that 599s any unexpected path and asserts each tool's required args:

- 80 POSTs to `/functions/v1/mcp`; tools at **40/20/12/8** — the exact 50/25/15/10 mix
- auth prefix `Bearer lk`, not a JWT; **no `apikey` leaked onto MCP**
- token-mint assertions silent (sha256 hex, prefix ≤16, permissions array); 13 mints across two token runs
- all 16 provisioned users deleted; ladder stops correctly
- **57 tests** in `load-test-lib` (79 across the three script suites), run by ci.yml's existing path-gated `bench-tests` job

**Not verified:** no live run against a real project. Everything here is unit tests plus the strict mock — the same combination that has caught three real bugs in this harness and missed nothing so far, but it is not a deployment.

## Docs

Corrected two documents that said the opposite of the code: this script's header (*"WHY REST, AND WHY NOT MCP OR THE CLI"*) and `benchmarking.md`'s *"REST as the generator … converge on the same handlers"*. The SQL and RPCs converge; the **handlers do not**, and that sentence made the coverage gap look smaller than it was. `benchmarking.md` gains the surface×auth table, the stress-mode section, and a four-row map from the rate-limit guard to its arithmetic.

`llms.txt` not regenerated — no MCP tool, CLI command, REST route, config key or dashboard surface changed. This is a benchmark harness and a contributor runbook.

https://claude.ai/code/session_01KgoxEsXNRCsr68b2P9cmTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgoxEsXNRCsr68b2P9cmTJ)_