### PR TITLE
feat(ci): install the PR relevance memory caller

### DIFF
--- a/.github/workflows/pr-relevance-memory.yml
+++ b/.github/workflows/pr-relevance-memory.yml
@@ -1,0 +1,55 @@
+# PR relevance memory — feeds the reviewer agents' learning loop.
+#
+# Records how each PR review comment was resolved into LoreKit, under this repo's scope. The
+# `reviewer` / `pr-reviewer` agents read those records at the start of every run: a finding shape
+# this repo keeps declining gets suppressed, one that reliably gets fixed gets reinforced. Without
+# it the same dismissed nitpick comes back on every PR, because nothing ever records the dismissal.
+#
+#   thread resolved -> relevant/fixed, or not-relevant/wont-fix on a 👎 or a "by design" reply
+#   PR merged       -> threads still open with no fix and no decline become ignored-at-merge
+#
+# The logic lives in mthines/agent-skills and updates without touching this file; this caller is
+# only the event wiring. Read-only on GitHub — its one side effect is the LoreKit write. Requires
+# the LOREKIT_API_KEY repo secret; without it the run logs that it is unconfigured and skips the
+# write rather than failing.
+#
+# Source: mthines/agent-skills/plugins/pr-relevance-memory/templates/pr-relevance-caller.yml
+# Docs:   mthines/agent-skills/agents/shared/rules/comment-relevance-memory.md
+
+name: PR relevance memory
+
+on:
+  pull_request_review_thread:
+    types: [resolved]
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  thread-resolved:
+    name: Record resolved thread
+    if: github.event_name == 'pull_request_review_thread'
+    uses: mthines/agent-skills/.github/workflows/reviewer-comment-relevance.yml@main
+    with:
+      mode: thread-resolved
+      pr_number: ${{ github.event.pull_request.number }}
+      comment_id: ${{ github.event.thread.comments[0].id }}
+      comment_path: ${{ github.event.thread.comments[0].path }}
+      comment_line: ${{ github.event.thread.comments[0].line }}
+      comment_body: ${{ github.event.thread.comments[0].body }}
+      comment_created_at: ${{ github.event.thread.comments[0].created_at }}
+    secrets:
+      lorekit_api_key: ${{ secrets.LOREKIT_API_KEY }}
+
+  pr-merged:
+    name: Sweep open threads at merge
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    uses: mthines/agent-skills/.github/workflows/reviewer-comment-relevance.yml@main
+    with:
+      mode: pr-merged
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      lorekit_api_key: ${{ secrets.LOREKIT_API_KEY }}


### PR DESCRIPTION
## Summary

Installs the `pr-relevance-memory` caller, wiring this repo into the reviewer agents' learning loop.

On a resolved review thread it records whether the comment was fixed or declined; on a merge it sweeps threads left open as `ignored-at-merge`. The `reviewer` / `pr-reviewer` agents read those records at the start of every run, so a finding shape this repo keeps declining stops being re-raised, and one that reliably gets fixed gets reinforced. Nothing records that today — which is why the same dismissed nitpick can come back on every PR.

Read-only on GitHub. Its one side effect is the LoreKit write.

## What's in the diff

One file, `.github/workflows/pr-relevance-memory.yml`. The body is the canonical template from `mthines/agent-skills/plugins/pr-relevance-memory/templates/pr-relevance-caller.yml`, verified identical after YAML normalisation (comment header aside) — so there's no local fork of it to drift. The classification logic lives in `agent-skills` and updates without touching this file; this is only the event wiring.

## Merge order — this one goes second

> [!IMPORTANT]
> **mthines/agent-skills#132 must merge first.** The reusable workflow this calls does not exist on `agent-skills@main` yet.

A `uses:` that can't resolve is not skipped — GitHub **fails the run**. Merging this first would put a red annotation on every merge and every resolved thread here until the companion lands. Nothing would be *blocked* (both triggers fire post-merge, so no PR gates on them), but it's persistent red noise rather than silence.

## Also needed: the `LOREKIT_API_KEY` secret

**Settings → Secrets and variables → Actions → New repository secret.**

This one genuinely does degrade quietly: without the secret the run logs that it is unconfigured and skips the write, so it can merge before the key is provisioned. It just won't record anything until then.

## Verification

- All 12 workflow YAML files parse.
- Semantic equality with the canonical template confirmed via a normalising comparator — which I self-tested against a known-different file first, because the naive version silently reported "identical" when *both* sides errored to empty output.
- The recorder behind the reusable workflow was exercised through its exact invocation path over in #132; every failure mode exits 0.

## Docs

No user-facing docs surface applies — this adds no MCP tool, REST route, CLI command, config key, limit, or dashboard surface. It's repo-internal CI wiring for the review agents, and the behaviour it enables is documented in `agent-skills` (`agents/shared/rules/comment-relevance-memory.md`), linked from a header comment in the file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XqTahFjhFvX5WbecaTBBTe)_