### PR TITLE
fix(bench): make the load-test workflow's own default dispatch runnable

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -9,6 +9,14 @@
 # USERS: 20 rps needs 10, 100 rps needs 50. The script REFUSES a configuration
 # that cannot fit rather than reporting the rate limiter as a latency result.
 #
+# WHICH IS WHY `users` DEFAULTS TO `auto`. It previously defaulted to 5 while
+# `max_rps` defaulted to 160 — so the obvious stress dispatch (pick mcp, tick
+# ramp, leave the rest alone) was refused by construction, every time. A default
+# combination that cannot run is a bad default, not operator error. `auto` derives
+# the minimum, and the script prints what it picked. `max_rps` is 40 rather than
+# 160 for the same reason: on MCP, 160 would silently mean provisioning 80 users
+# and seeding all of them before a single measurement.
+#
 # WHY A WORKFLOW RATHER THAN A LOCAL SCRIPT
 # The target must be configurable between preview and production, and a
 # production run needs a human in the loop. GitHub Environments already give us
@@ -67,8 +75,8 @@ on:
         description: 'Drive duration (seconds)'
         default: '120'
       users:
-        description: 'Provisioned users — each carries its own 120 rpm budget. MCP needs rps/2 of them'
-        default: '5'
+        description: 'Provisioned users, or "auto" to derive the minimum the peak rate needs (MCP needs rps/2)'
+        default: auto
       surface:
         description: 'Which transport — rest = dashboard/CLI path, mcp = the AGENT path'
         type: choice
@@ -84,8 +92,8 @@ on:
         type: boolean
         default: false
       max_rps:
-        description: 'Ceiling for the stress ladder (only used when ramp is on)'
-        default: '160'
+        description: 'Ceiling for the stress ladder (only used when ramp is on). On MCP this drives the user count: 160 rps means 80 users, and 80 users means a long seed phase'
+        default: '40'
   schedule:
     # Weekly, Mondays 05:25 UTC. Off the hour on purpose: GitHub queues :00
     # schedules by many minutes. A scheduled run is ALWAYS preview — the target

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -154,7 +154,7 @@ SUPABASE_URL=… SUPABASE_SERVICE_ROLE_KEY=… SUPABASE_ANON_KEY=… \
 | `--target <preview\|production>` | **none** | Required. `production` must be typed in full |
 | `--rps <n>` | `20` | arrival rate |
 | `--duration <s>` | `60` | drive duration |
-| `--users <n>` | `5` | provisioned users, each with its own 120 rpm budget |
+| `--users <n\|auto>` | `5` | provisioned users, each with its own 120 rpm budget. `auto` derives the minimum the **peak** rate needs |
 | `--seed <n>` | `50` | lore rows seeded per user, so reads return rows |
 | `--surface <rest\|mcp>` | `rest` | `rest` = dashboard/CLI path, `mcp` = the **agent** path |
 | `--auth <jwt\|token>` | per surface | `mcp`→`token`, `rest`→`jwt`. `rest`+`token` is the CLI's remote path |
@@ -384,7 +384,22 @@ run would 429.
 
 A load test that silently measures its own throttling is worse than no load
 test, because the number looks usable. With `--ramp` the check uses the
-**ceiling**, not the starting rate.
+**ceiling**, not the starting rate — and says so, naming `--max-rps` rather than
+`--rps`, because lowering the starting rate would not help: the ladder climbs to
+the ceiling and fails at the same rung.
+
+**`--users auto` is the other way out**, and it is why the workflow now defaults
+to it. `users: 5` with `max_rps: 160` on `--surface mcp` was refused by
+construction, so the obvious stress dispatch — pick mcp, tick ramp, leave the
+rest alone — always failed ([run 32643090759](https://github.com/mthines/lorekit/actions/runs/32643090759)).
+A default combination that cannot run is a bad default, not operator error.
+
+`auto` is opt-in rather than the silent behaviour because **the cost is real and
+invisible**: user count drives the SEED phase, which already dominated wall clock
+at 5 users. On MCP, 160 rps means 80 users, and seeding 80 users is tens of
+minutes before a single measurement. The script prints what it picked and warns
+above 20. `maxRpsForUsers` is the inverse if you would rather pick the users and
+derive the ceiling: on MCP it is simply `users x 2`.
 
 ### Scaling users, not limits
 

--- a/scripts/load-test/load-test-lib.mjs
+++ b/scripts/load-test/load-test-lib.mjs
@@ -490,7 +490,15 @@ export function limitedShareOfMix(surface, mix = DEFAULT_MIX) {
  * `lorekit_get_limit(user_id, 'requests_per_minute')` and a `user_limits` row
  * can raise it — 120 is only the default.
  */
-export function checkRateHeadroom({ surface, rps, users, mix = DEFAULT_MIX, requestsPerMinute = 120 }) {
+export function checkRateHeadroom({
+  surface, rps, users, mix = DEFAULT_MIX, requestsPerMinute = 120,
+  // Which flag actually carried `rps`. On a ramp the binding constraint is the
+  // CEILING, not the starting rate, so advising "lower --rps" is advice that
+  // cannot work: the ladder would still climb to --max-rps and fail again. Run
+  // 32643090759 hit exactly that — refused for a 160 rps ceiling and told to
+  // lower a flag that was already at 20.
+  rateFlag = '--rps',
+} = {}) {
   const share = limitedShareOfMix(surface, mix);
   const perUserCeiling = requestsPerMinute / 60;
   if (share === 0 || perUserCeiling <= 0) return { ok: true, requiredUsers: users, limitedRps: 0, perUserCeiling };
@@ -506,7 +514,57 @@ export function checkRateHeadroom({ surface, rps, users, mix = DEFAULT_MIX, requ
       `${surface} rate-limits ${share === 1 ? 'every method' : `the write share (${(share * 100).toFixed(0)}%)`}, ` +
       `so ${rps} rps needs at least ${requiredUsers} users at ${requestsPerMinute} req/min/user ` +
       `(${limitedRps.toFixed(1)} limited rps ÷ ${perUserCeiling.toFixed(2)} per user) — got ${users}. ` +
-      `Raise --users to ${requiredUsers}, or lower --rps to ${Math.floor(users * perUserCeiling / share)}.`,
+      `Raise --users to ${requiredUsers} (or pass --users auto), ` +
+      `or lower ${rateFlag} to ${maxRpsForUsers({ surface, users, mix, requestsPerMinute })}.`,
+  };
+}
+
+/**
+ * The highest arrival rate `users` can offer without the rate limiter deciding
+ * the result — the inverse of `checkRateHeadroom`.
+ *
+ * On MCP this is simply `users x 2` at the default ceiling, which is worth
+ * internalising before designing a run: a 160 rps ladder needs 80 users, and
+ * seeding 80 users is tens of minutes of setup before any measurement happens.
+ * Rate on that surface is bought with provisioning time, not with a bigger flag.
+ */
+export function maxRpsForUsers({ surface, users, mix = DEFAULT_MIX, requestsPerMinute = 120 }) {
+  const share = limitedShareOfMix(surface, mix);
+  const perUserCeiling = requestsPerMinute / 60;
+  if (share === 0) return Infinity;
+  return Math.floor((users * perUserCeiling) / share);
+}
+
+/**
+ * Resolve `--users`, including the `auto` form.
+ *
+ * `auto` derives the MINIMUM user count the requested peak rate needs. It exists
+ * because the workflow's own default inputs could not run: `users: 5` with
+ * `max_rps: 160` on `--surface mcp` is refused by construction, so the obvious
+ * dispatch — pick mcp, tick ramp, leave the rest alone — always failed. A
+ * default combination that cannot run is a bad default, not operator error.
+ *
+ * It is opt-in rather than the silent behaviour because the cost is real and
+ * invisible: user count drives the SEED phase, which already dominated wall
+ * clock at 5 users. The caller gets told what it picked and what that implies.
+ */
+export function resolveUsers({ users, surface, peakRps, mix = DEFAULT_MIX, requestsPerMinute = 120 }) {
+  const raw = String(users ?? '').trim().toLowerCase();
+  if (raw !== 'auto') {
+    if (!/^\d+$/.test(raw) || Number(raw) <= 0) {
+      return { ok: false, error: `--users must be a positive integer or "auto", got "${users}"` };
+    }
+    return { ok: true, users: Number(raw), auto: false };
+  }
+  const share = limitedShareOfMix(surface, mix);
+  const perUserCeiling = requestsPerMinute / 60;
+  if (share === 0 || perUserCeiling <= 0) return { ok: true, users: 1, auto: true };
+  return {
+    ok: true,
+    auto: true,
+    // At least one: a rate low enough to need zero users still needs somebody
+    // to make the requests.
+    users: Math.max(1, Math.ceil((peakRps * share) / perUserCeiling)),
   };
 }
 

--- a/scripts/load-test/load-test-lib.test.mjs
+++ b/scripts/load-test/load-test-lib.test.mjs
@@ -20,7 +20,9 @@ import {
   projectRefFromUrl,
   rampVerdict,
   resolveAuthMode,
+  maxRpsForUsers,
   resolveSurface,
+  resolveUsers,
   resolveTarget,
   summarize,
   totals,
@@ -489,7 +491,9 @@ test('the harness\'s OWN defaults are refused on MCP — the guard that matters'
   assert.equal(r.ok, false);
   assert.equal(r.requiredUsers, 10);
   assert.match(r.error, /needs at least 10 users/);
-  assert.match(r.error, /Raise --users to 10, or lower --rps to 10/);
+  // Both escape routes, asserted separately so adding a third does not break it.
+  assert.match(r.error, /Raise --users to 10/);
+  assert.match(r.error, /lower --rps to 10/);
 });
 
 test('the same settings are fine on REST, because reads are ungated', () => {
@@ -566,4 +570,87 @@ test('REST results with no explicit outcome behave exactly as before', () => {
   assert.equal(outcomeOf({ status: 404 }), 'client_error');
   // An explicit outcome always wins.
   assert.equal(outcomeOf({ status: 200, outcome: 'error' }), 'error');
+});
+
+// ── the run that failed, and the two bugs it exposed ────────────────────────
+
+/**
+ * Run 32643090759 dispatched the workflow's OWN defaults with surface=mcp and
+ * ramp=true: `--rps 20 --users 5 --ramp --max-rps 160`. Two separate problems.
+ */
+
+test('the refusal names --max-rps on a ramp, not --rps', () => {
+  // BUG 1. The guard checked the CEILING (160) and correctly demanded 80 users,
+  // then advised "lower --rps to 10" — advice that cannot work, because the
+  // ladder would still climb to --max-rps and fail again at the same rung.
+  const r = checkRateHeadroom({ surface: 'mcp', rps: 160, users: 5, rateFlag: '--max-rps' });
+  assert.equal(r.ok, false);
+  assert.equal(r.requiredUsers, 80);
+  assert.match(r.error, /lower --max-rps to 10/);
+  assert.ok(!/lower --rps/.test(r.error), 'must not advise the flag that was not binding');
+});
+
+test('the refusal still names --rps when there is no ramp', () => {
+  const r = checkRateHeadroom({ surface: 'mcp', rps: 20, users: 5 });
+  assert.match(r.error, /lower --rps to 10/);
+});
+
+test('the refusal offers `--users auto` as the other way out', () => {
+  assert.match(checkRateHeadroom({ surface: 'mcp', rps: 160, users: 5 }).error, /--users auto/);
+});
+
+test('maxRpsForUsers is the inverse of the guard', () => {
+  // On mcp it is simply users x 2 at the default ceiling.
+  assert.equal(maxRpsForUsers({ surface: 'mcp', users: 5 }), 10);
+  assert.equal(maxRpsForUsers({ surface: 'mcp', users: 80 }), 160);
+  // Whatever it returns must PASS the guard, and one more must fail it.
+  for (const users of [1, 5, 17, 80]) {
+    const max = maxRpsForUsers({ surface: 'mcp', users });
+    assert.equal(checkRateHeadroom({ surface: 'mcp', rps: max, users }).ok, true, `${users} users should sustain ${max} rps`);
+    assert.equal(checkRateHeadroom({ surface: 'mcp', rps: max + 1, users }).ok, false, `${users} users should NOT sustain ${max + 1} rps`);
+  }
+});
+
+test('rest sustains far more per user, because only writes are gated', () => {
+  // 15% write share, so 5 users x 2 rps / 0.15.
+  assert.equal(maxRpsForUsers({ surface: 'rest', users: 5 }), 66);
+});
+
+test('--users auto derives the minimum the PEAK rate needs', () => {
+  // BUG 2. `users: 5` + `max_rps: 160` + surface mcp was the workflow's default
+  // combination and could never run. `auto` makes that dispatch valid.
+  assert.deepEqual(resolveUsers({ users: 'auto', surface: 'mcp', peakRps: 160 }), { ok: true, auto: true, users: 80 });
+  assert.deepEqual(resolveUsers({ users: 'auto', surface: 'mcp', peakRps: 20 }), { ok: true, auto: true, users: 10 });
+  // rest needs far fewer for the same rate.
+  assert.equal(resolveUsers({ users: 'auto', surface: 'rest', peakRps: 160 }).users, 12);
+});
+
+test('whatever auto picks, the guard accepts it — that is the point', () => {
+  for (const surface of ['mcp', 'rest']) {
+    for (const peakRps of [1, 20, 160, 500]) {
+      const u = resolveUsers({ users: 'auto', surface, peakRps }).users;
+      assert.equal(
+        checkRateHeadroom({ surface, rps: peakRps, users: u }).ok, true,
+        `auto gave ${u} users for ${peakRps} rps on ${surface}, which the guard then refused`,
+      );
+    }
+  }
+});
+
+test('auto never returns zero users', () => {
+  // A rate low enough to need no users still needs somebody to make requests.
+  assert.equal(resolveUsers({ users: 'auto', surface: 'rest', peakRps: 1 }).users, 1);
+  assert.equal(resolveUsers({ users: 'auto', surface: 'mcp', peakRps: 1 }).users, 1);
+});
+
+test('an explicit --users is passed through, and case-insensitive AUTO works', () => {
+  assert.deepEqual(resolveUsers({ users: '7', surface: 'mcp', peakRps: 4 }), { ok: true, users: 7, auto: false });
+  assert.equal(resolveUsers({ users: 'AUTO', surface: 'mcp', peakRps: 20 }).auto, true);
+  assert.equal(resolveUsers({ users: ' auto ', surface: 'mcp', peakRps: 20 }).auto, true);
+});
+
+test('a nonsense --users is rejected, not coerced', () => {
+  for (const bad of ['0', '-3', 'many', '', '2.5', undefined]) {
+    assert.equal(resolveUsers({ users: bad, surface: 'mcp', peakRps: 20 }).ok, false, `"${bad}" must be refused`);
+  }
 });

--- a/scripts/load-test/load-test.mjs
+++ b/scripts/load-test/load-test.mjs
@@ -74,6 +74,7 @@ import {
   rampVerdict,
   resolveAuthMode,
   resolveSurface,
+  resolveUsers,
   resolveTarget,
   summarize,
   totals,
@@ -514,7 +515,9 @@ LoreKit load test — open-loop REST driver with SQL attribution.
                                   typed in full.
   --rps <n>          arrival rate                     (default 20)
   --duration <s>     drive duration in seconds        (default 60)
-  --users <n>        provisioned users; each gets its own 120 rpm budget (5)
+  --users <n|auto>   provisioned users; each gets its own 120 rpm budget (5).
+                     "auto" derives the minimum the peak rate needs — on mcp
+                     that is rps/2, and every user costs a seed phase
   --seed <n>         lore rows seeded per user        (default 50)
   --surface <s>      rest | mcp                        (default rest)
                      rest = dashboard/CLI path, mcp = the AGENT path
@@ -544,7 +547,9 @@ const authResult = resolveAuthMode(opts.auth, surface, process.env);
 if (!authResult.ok) die(authResult.error);
 const authMode = authResult.auth;
 
-for (const [flag, v] of [['--rps', opts.rps], ['--duration', opts.duration], ['--users', opts.users], ['--seed', opts.seed]]) {
+// `--users` is deliberately absent: it accepts the literal `auto` as well as a
+// number, so `resolveUsers` validates it below.
+for (const [flag, v] of [['--rps', opts.rps], ['--duration', opts.duration], ['--seed', opts.seed]]) {
   if (!/^\d+(\.\d+)?$/.test(v) || Number(v) <= 0) die(`${flag} must be a positive number, got "${v}"`);
 }
 
@@ -563,6 +568,16 @@ const cred = checkServiceCredential({ serviceKey, anonKey, supabaseUrl });
 for (const w of cred.warnings) log(`  ! ${w}`);
 if (cred.errors.length) die(`credential check failed:\n  - ${cred.errors.join('\n  - ')}`);
 
+// The PEAK rate the run will reach, which is what the rate limiter has to
+// accommodate — on a ladder that is the ceiling, not the starting rate.
+const peakRps = opts.ramp && opts.maxRps ? Number(opts.maxRps) : Number(opts.rps);
+// Which flag carries it, so a refusal below names the flag that would actually
+// help. Advising "lower --rps" on a ramp is advice that cannot work.
+const rateFlag = opts.ramp && opts.maxRps ? '--max-rps' : '--rps';
+
+const usersResult = resolveUsers({ users: opts.users, surface, peakRps });
+if (!usersResult.ok) die(usersResult.error);
+
 const run = {
   target,
   // Carried into the telemetry: without these two, an MCP run and a REST run
@@ -572,16 +587,25 @@ const run = {
   authTier: authMode,
   rps: Number(opts.rps),
   durationSec: Number(opts.duration),
-  users: Number(opts.users),
+  users: usersResult.users,
 };
+
+if (usersResult.auto) {
+  log(`  --users auto → ${run.users} (the minimum ${peakRps} rps needs on ${surface})`);
+  // Said out loud because it is the cost this flag hides: seeding is per user
+  // and already dominated wall clock at 5.
+  if (run.users > 20) {
+    log(`  ! ${run.users} users means seeding ${run.users} x ${opts.seed} rows before any measurement — expect a long setup.`);
+  }
+}
+
 // REFUSE a configuration the rate limiter would decide. MCP checks the limit on
-// every method (2 rps/user at the 120/min default), so the harness's own
-// defaults — 20 rps across 5 users — are 2x over on that surface: half the run
-// would 429 and the percentiles would describe the guardrail, not the service. A
-// load test that silently measures its own throttling is worse than none,
-// because the number looks usable. Fails with the users actually required.
-const peakRps = opts.ramp && opts.maxRps ? Number(opts.maxRps) : run.rps;
-const headroom = checkRateHeadroom({ surface, rps: peakRps, users: run.users });
+// every method (2 rps/user at the 120/min default), so 20 rps across 5 users is
+// 2x over on that surface: half the run would 429 and the percentiles would
+// describe the guardrail, not the service. A load test that silently measures
+// its own throttling is worse than none, because the number looks usable.
+// Unreachable when `--users auto` resolved the count, by construction.
+const headroom = checkRateHeadroom({ surface, rps: peakRps, users: run.users, rateFlag });
 if (!headroom.ok) die(headroom.error);
 
 const runId = randomUUID().slice(0, 8);


### PR DESCRIPTION
[Run 32643090759](https://github.com/mthines/lorekit/actions/runs/32643090759) dispatched the workflow with `surface=mcp` and `ramp=true`, leaving everything else default, and was refused:

```
--rps 20 --duration 120 --users 5 --ramp --max-rps 160
✗ mcp rate-limits every method, so 160 rps needs at least 80 users at
  120 req/min/user (160.0 limited rps ÷ 2.00 per user) — got 5.
  Raise --users to 80, or lower --rps to 10.
```

**The guard was right to refuse.** Two things around it were not.

## Bug 1 — the advice named a flag that could not help

The binding constraint was the ladder's **ceiling** (160), but the message said *"lower `--rps` to 10"* — and `--rps` was already 20. Lowering it changes nothing: the ladder still climbs to `--max-rps` and fails at the same rung.

`checkRateHeadroom` now takes the flag that actually carried the rate, so a ramp refusal says `--max-rps`:

```
✗ … got 5. Raise --users to 80 (or pass --users auto), or lower --max-rps to 10.
```

## Bug 2 — the workflow's own default inputs could not run

`users: 5` with `max_rps: 160` is refused *by construction* on MCP, so the obvious stress dispatch — pick mcp, tick ramp, leave the rest alone — failed every time. **A default combination that cannot run is a bad default, not operator error.**

- `users` now defaults to **`auto`**, which derives the minimum the *peak* rate needs
- `max_rps` drops **160 → 40**, because on MCP a 160 rps ceiling silently means provisioning 80 users and seeding all of them before one measurement

`auto` is **opt-in rather than silent**, because the cost it hides is real: user count drives the seed phase, which already dominated wall clock at 5 users. The script says what it picked, and warns above 20:

```
  --users auto → 80 (the minimum 160 rps needs on mcp)
  ! 80 users means seeding 80 x 50 rows before any measurement — expect a long setup.
```

`maxRpsForUsers` is the inverse, exported for the operator who would rather pick the users and derive the ceiling — on MCP it's simply `users × 2`.

## Verification

Against the strict mock, reproducing the exact failing dispatch:

| | |
|---|---|
| explicit `--users 5`, `--max-rps 160` | still refused — now naming `--max-rps` |
| the new defaults (`auto`, `40`) | **runs** — auto resolves 20 users, ladder completes, 40 rps sustained |
| `auto` at a 160 ceiling | resolves 80 users **and warns** about the seed phase |

11 new tests (66 in `load-test-lib`), including a property test that whatever `auto` picks, `checkRateHeadroom` then **accepts** — the two cannot disagree — and that `auto` never returns zero users.

One existing test pinned the old message verbatim and is updated: it now asserts the two escape routes separately, so adding a third won't break it.

## Note

`nx affected` runs nothing for this change — `scripts/**` is outside the graph, which is what the path-gated `bench-tests` job in `ci.yml` exists for, and it already runs `load-test-lib.test.mjs`.

Still no live run against a real project: the verification is unit tests plus the strict mock.

https://claude.ai/code/session_01KgoxEsXNRCsr68b2P9cmTJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KgoxEsXNRCsr68b2P9cmTJ)_