### PR TITLE
fix(cli): resolve scope::key shorthand when the key contains ::

### DIFF
--- a/packages/cli/src/commands/show.mjs
+++ b/packages/cli/src/commands/show.mjs
@@ -10,7 +10,10 @@
 //                            you can copy-paste a key directly from list output)
 //   show <scope> <key>     — the explicit two-positional form
 //   show --scope <s> --key <k>
-//                          — flags win; the only way to name a key containing `::`
+//                          — flags win; an explicit override that skips the `::`
+//                            split (the shorthand already carries a namespaced
+//                            key, since the split lands at the first valid-scope
+//                            prefix — see `resolveScopeArg`)
 //
 // Uses each store's real `read({scope, key})` method (both stores expose it),
 // not a filtered `list` — a single-record lookup is what `read` is for, and it
@@ -60,8 +63,9 @@ export async function show(args) {
   // Positional shapes (all resolved by the shared, validity-gated parser):
   //   show <scope::key>            — canonical shorthand, mirrors `list` output
   //   show <scope> <key>           — explicit two-positional form
-  //   show --scope <s> --key <k>   — flags win; the escape hatch for a key
-  //                                  containing `::`
+  //   show --scope <s> --key <k>   — flags win; an explicit override that skips
+  //                                  the `::` split (the shorthand handles a
+  //                                  namespaced key on its own now)
   const positionals = args._.slice(1);
   const { scope, key, consumed } = resolveScopeKeyArgs(positionals, {
     scope: args.scope,

--- a/packages/cli/src/shared/lessons-pure.mjs
+++ b/packages/cli/src/shared/lessons-pure.mjs
@@ -122,23 +122,29 @@ export function isScopeString(s) {
 // Split a single `<scope>::<key>` argument, or fall back to treating the whole
 // argument as a scope.
 //
-// The rule: split at the LAST `::` and take it as `<scope>::<key>` ONLY when the
-// left side is itself a COMPLETE valid scope — otherwise the whole arg is the
-// scope. Splitting on the last `::` (not the first) keeps a multi-segment scope
-// whole (`repo::owner/name::key` → scope `repo::owner/name`, key `key`); gating
-// on a valid left side means a bare `repo::owner/name` is NOT mis-split, because
-// its left part `repo` is not a valid scope. This is the fix for the prior
-// first-`::` split, which turned `link repo::acme/widget` into scope="repo" plus
-// a bogus `acme/widget` key — breaking the shorthand for EVERY non-`global`
-// scope. A malformed arg falls through to the scope, never a fabricated key.
+// The rule: scan the `::` boundaries left-to-right and split at the FIRST one
+// whose left side is a COMPLETE valid scope — otherwise the whole arg is the
+// scope. Because `::` is RESERVED as the segment separator (no scope segment may
+// contain it, enforced by `scopeIssue`), no valid scope is a `::`-boundary
+// prefix of another, so the earliest valid-scope prefix is unambiguously THE
+// scope and everything after it is the key — even a key that itself contains
+// `::` (a namespaced key like `implement-suggestion-lessons::documenting-…`).
+//
+// This first-valid scan superseded a plain last-`::` split, which broke exactly
+// that case: `global::foo-lessons::bar` split at the last `::` gave the left
+// side `global::foo-lessons`, not a valid scope, so the whole arg fell through
+// to the scope and `scopeIssue` rejected it. Gating on a valid left side is what
+// keeps a bare `repo::owner/name` from mis-splitting (its `repo` prefix is not a
+// valid scope) and a multi-segment scope whole (`branch::o/n::main::key` → scope
+// `branch::o/n::main`, key `key`, since the shorter prefixes are all invalid). A
+// malformed arg falls through to the scope, never a fabricated key.
 //
 // `isScope` is injected rather than closed over so the module stays trivially
 // testable with a stub predicate; callers pass `isScopeString`.
 export function resolveScopeArg(arg, isScope = isScopeString) {
   const s = typeof arg === 'string' ? arg.trim() : '';
   if (!s) return { scope: null, key: null };
-  const idx = s.lastIndexOf('::');
-  if (idx !== -1) {
+  for (let idx = s.indexOf('::'); idx !== -1; idx = s.indexOf('::', idx + 2)) {
     const left = s.slice(0, idx).trim();
     const right = s.slice(idx + 2).trim();
     if (right && isScope(left)) return { scope: left, key: right };

--- a/packages/cli/test/scope-args.test.mjs
+++ b/packages/cli/test/scope-args.test.mjs
@@ -73,7 +73,7 @@ test('resolveScopeArg: a bare valid scope is never mis-split into a bogus key', 
   });
 });
 
-test('resolveScopeArg: the shorthand splits at the LAST `::`, keeping the scope whole', () => {
+test('resolveScopeArg: the shorthand splits at the FIRST valid-scope prefix, keeping the scope whole', () => {
   assert.deepEqual(resolveScopeArg('global::my-key'), { scope: 'global', key: 'my-key' });
   assert.deepEqual(resolveScopeArg('repo::owner/name::my-key'), {
     scope: 'repo::owner/name',
@@ -83,6 +83,23 @@ test('resolveScopeArg: the shorthand splits at the LAST `::`, keeping the scope 
     scope: 'branch::owner/name::main',
     key: 'my-key',
   });
+});
+
+test('resolveScopeArg: a key that itself contains `::` is kept whole after the scope', () => {
+  // THE regression `lorekit show global::foo-lessons::bar` hit. A namespaced key
+  // makes the arg three `::` segments; a last-`::` split took the left side
+  // `global::foo-lessons` — not a valid scope — so the whole arg fell through
+  // and `scopeIssue` reported "unrecognized scope type". Splitting at the FIRST
+  // valid-scope prefix keeps the namespaced key intact.
+  assert.deepEqual(
+    resolveScopeArg('global::implement-suggestion-lessons::documenting-a-workaround'),
+    { scope: 'global', key: 'implement-suggestion-lessons::documenting-a-workaround' },
+  );
+  assert.deepEqual(resolveScopeArg('repo::owner/name::foo-lessons::bar::baz'), {
+    scope: 'repo::owner/name',
+    key: 'foo-lessons::bar::baz',
+  });
+  assert.deepEqual(resolveScopeArg('global::a::b::c'), { scope: 'global', key: 'a::b::c' });
 });
 
 test('resolveScopeArg: an unresolvable arg becomes the scope, never a fabricated key', () => {
@@ -109,6 +126,14 @@ test('resolveScopeKeyArgs: one positional is the shorthand, and reports consumin
   assert.deepEqual(resolveScopeKeyArgs(['repo::owner/name::my-key']), {
     scope: 'repo::owner/name',
     key: 'my-key',
+    consumed: 1,
+  });
+  // A namespaced key (its own `::`) survives the single-positional shorthand —
+  // the copy-pasteable form `list`/`show` print. This is the exact path
+  // `lorekit show global::foo-lessons::bar` takes.
+  assert.deepEqual(resolveScopeKeyArgs(['global::implement-suggestion-lessons::documenting']), {
+    scope: 'global',
+    key: 'implement-suggestion-lessons::documenting',
     consumed: 1,
   });
 });
@@ -185,9 +210,9 @@ test('resolveScopeKeyArgs: no positionals and no flags yields an empty scope', (
 });
 
 test('resolveScopeKeyArgs: both flags win and consume NO positional', () => {
-  // The escape hatch: a key containing `::` is unrepresentable in the
-  // single-token form (the split would claim part of it as the scope), so the
-  // flags must bypass the parse entirely.
+  // The explicit override: naming both halves bypasses the `::` split entirely.
+  // The shorthand now carries a namespaced key on its own, but the flags stay
+  // the unambiguous way to assert a scope and key without any parsing.
   assert.deepEqual(
     resolveScopeKeyArgs(['ignored'], { scope: 'global', key: 'loop::aw-lessons' }),
     { scope: 'global', key: 'loop::aw-lessons', consumed: 0 },
@@ -225,6 +250,30 @@ test('resolveScopeKeyArgs trims surrounding whitespace on both halves', () => {
     key: 'my-key',
     consumed: 2,
   });
+});
+
+// ── command-level invariant: the shorthand always resolves to a VALID scope ───
+
+test('a copy-pasted `scope::key` shorthand always resolves to a scope that passes scopeIssue', () => {
+  // The exact property `show`/`write`/`link` depend on: they run
+  // `resolveScopeKeyArgs` and then `scopeIssue(scope)`, so a shorthand that
+  // parses into an INVALID scope is the user-visible "unrecognized scope type"
+  // error — the regression `lorekit show global::foo-lessons::bar` produced.
+  // Namespaced keys (their own `::`) are the case that broke; every canonical
+  // scope must survive one.
+  const cases = [
+    'global::exact-string-edit-fails',
+    'global::implement-suggestion-lessons::documenting-a-workaround',
+    'global::a::b::c',
+    'project::widget::some-lessons::deep-key',
+    'repo::owner/name::foo-lessons::bar',
+    'branch::owner/name::main::foo-lessons::bar',
+  ];
+  for (const arg of cases) {
+    const { scope, key } = resolveScopeKeyArgs([arg]);
+    assert.equal(scopeIssue(scope), null, `shorthand ${arg} → invalid scope ${scope}`);
+    assert.ok(key, `shorthand ${arg} → missing key`);
+  }
 });
 
 // ── re-export parity ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

`lorekit show global::implement-suggestion-lessons::documenting-…` failed with `Error: invalid scope … — unrecognized scope type`, even though the lesson exists. Any key that is itself namespaced with `::` was unreachable through the copy-pasteable `scope::key` shorthand that `list`/`show` print.

## Why

`resolveScopeArg` (shared by `show`, `write`, `link`) split at the **last** `::`. For `global::foo-lessons::bar` that left side is `global::foo-lessons`, not a valid scope, so the whole string fell through to being treated as the scope and `scopeIssue` rejected it. A key with no `::` happened to split on `global` and worked, which is why the first key in the same session resolved and the second did not.

## Fix

Scan `::` boundaries left-to-right and split at the **first** one whose left side is a complete valid scope. Because `::` is reserved as the segment separator (no scope segment may contain it, enforced by `scopeIssue`), no valid scope is a `::`-boundary prefix of another, so the earliest valid-scope prefix is unambiguously the scope and everything after it is the key — including a key that contains `::`. Multi-segment scopes (`repo::owner/name::key`, `branch::o/n::main::key`) still resolve because their shorter prefixes are all invalid.

## Regression signal

Three tests in `scope-args.test.mjs`, including a command-level invariant: every canonical scope with a namespaced key resolves via `resolveScopeKeyArgs` to a scope that passes `scopeIssue`. Reintroducing a last-`::` split turns it red in `nx test cli`.

Verified end to end: the previously failing `lorekit show` now prints the lesson.

## Docs

No user-facing doc change. This restores documented shorthand behavior; `--scope`/`--key` remain a valid explicit override (docs never claimed they were the only way). Corrected two now-stale source comments in `show.mjs`.