### PR TITLE
observability: trustworthy error signal + hook heartbeat

### DIFF
--- a/docs/otel.md
+++ b/docs/otel.md
@@ -389,8 +389,13 @@ stdout as their host's protocol, so a span each would be a firehose of
 near-identical traces and an awaited 1500 ms export on the agent's critical path
 — but leaving them silent meant the CLI's highest-volume traffic was the traffic
 nobody could see. The counter carries the same identity attributes the traced
-commands do; `meterCommand` starts the export before the command runs and awaits
-it after, so it overlaps the command's own work.
+commands do. The two commands are counted at different times: `mcp` is a
+long-lived stdio server, so its count fires **before** run (a post-run count on a
+killed server would never report); `hook` is short-lived and counted **after**
+run, so the counter can carry the health dimensions the fire reports
+(`lorekit.hook.event` + `lorekit.hook.outcome`). A hook always exits 0, so those
+dimensions are the only signal a broken or degrading hook (an unusable store, a
+swallowed lesson-lookup error) produces.
 
 Attributes on `lorekit.cli.*` spans + counter points (deliberately narrow — this
 runs on end-users' machines, so **no path, cwd, token, endpoint, repo, or scope
@@ -404,6 +409,8 @@ account-linkable dimension and its opt-out):
 | `lorekit.cli.exit_code` | `0` | Command exit code |
 | `lorekit.cli.flag.<name>` | `true` | Only when set; allow-list: `global`, `project`, `deep`, `yes`, `force`, `no-hooks`, `json`, `link` |
 | `lorekit.cli.hooks_mode` | `all` | `install` only. Bounded: `all` \| `read-only` \| `none` \| `custom` — which hook wiring the run resolved to (from the flag, the prompt, or the detected state). Counts the CHOICE, not the `--no-hooks` flag |
+| `lorekit.hook.event` | `SessionStart` | `hook` counter only. The host hook event that fired (`SessionStart`, `Stop`, `UserPromptSubmit`, …) — a bounded set defined by the host framework |
+| `lorekit.hook.outcome` | `ok` | `hook` counter only. Bounded: `ok` \| `store_unavailable` (no usable store to read/query) \| `degraded` (a store lookup threw and was swallowed; the host still got output) \| `crash` (an unexpected throw the outer guard caught). The heartbeat that makes a silently-failing hook visible |
 | `user.id` | `a1b2…` / `install:9f3c…` | The LoreKit account once known, else the install id prefixed `install:` — see below |
 
 ### CLI identity

--- a/packages/cli/src/commands/hook.mjs
+++ b/packages/cli/src/commands/hook.mjs
@@ -36,6 +36,32 @@ import { codex } from '../adapters/codex.mjs';
 
 const ADAPTERS = { claude, cursor, codex };
 
+/**
+ * Bounded health vocabulary for the hook heartbeat. The hook always exits 0, so
+ * these are the only witness that a fire did its work: `ok` (ran clean),
+ * `store_unavailable` (no usable store to read/query), `degraded` (a store
+ * lookup threw and was swallowed — the host still got its output), `crash` (an
+ * unexpected throw the outer guard caught). Kept small so `lorekit.hook.outcome`
+ * stays a low-cardinality metric label.
+ */
+const HOOK_OUTCOME = Object.freeze({
+  OK: 'ok',
+  STORE_UNAVAILABLE: 'store_unavailable',
+  DEGRADED: 'degraded',
+  CRASH: 'crash',
+});
+
+/**
+ * Map the mutable meter run() fills in to the bounded, non-PII counter
+ * dimensions. `event` is the host hook event (SessionStart / Stop / …), itself a
+ * small set; both labels are safe for a metric.
+ */
+function hookMeterAttrs(meter) {
+  const attrs = { 'lorekit.hook.outcome': meter.outcome };
+  if (meter.event) attrs['lorekit.hook.event'] = meter.event;
+  return attrs;
+}
+
 function readStdin() {
   return new Promise((resolve) => {
     let data = '';
@@ -48,15 +74,22 @@ function readStdin() {
 }
 
 export async function hook(args) {
+  // The meter run() fills in as it goes. Returned alongside the exit code so the
+  // metric-only dispatch (`meterCommand`) can count this fire with its health —
+  // the hook always exits 0, so this is the only signal a broken or degrading
+  // hook produces.
+  const meter = { event: null, outcome: HOOK_OUTCOME.OK };
   // Guarded so any unexpected error still exits 0 (never break the host agent).
   try {
-    return await run(args);
+    const exitCode = await run(args, meter);
+    return { exitCode, meter: hookMeterAttrs(meter) };
   } catch {
-    return 0;
+    meter.outcome = HOOK_OUTCOME.CRASH;
+    return { exitCode: 0, meter: hookMeterAttrs(meter) };
   }
 }
 
-async function run(args) {
+async function run(args, meter) {
   const adapter = ADAPTERS[args.adapter];
   if (!adapter) {
     // Unknown adapter: stay silent, don't disrupt the host.
@@ -80,6 +113,8 @@ async function run(args) {
   recordFixture(args.adapter, event, raw);
 
   if (!event) return 0;
+
+  meter.event = event;
 
   const intent = adapter.intentFor(event);
   if (intent === 'noop') return 0;
@@ -110,6 +145,8 @@ async function run(args) {
       ? control.hooksInstructions.SessionStart : null;
     if (!store) {
       // No store: emit a minimal header + instruction when present, then return.
+      // A SessionStart that cannot read lore is the highest-value failure to see.
+      meter.outcome = HOOK_OUTCOME.STORE_UNAVAILABLE;
       if (sessionInstruction) {
         emit(formatLessons(null, { repoScope: null }, { instruction: sessionInstruction }));
       }
@@ -163,7 +200,7 @@ async function run(args) {
 
     try {
       const store = createStore(control);
-      if (!store) return 0;
+      if (!store) { meter.outcome = HOOK_OUTCOME.STORE_UNAVAILABLE; return 0; }
       const lessons = await promptLessonsFromStore(store, scope, terms, {
         // Delta only. Includes the SessionStart set, because "already shown"
         // has to mean shown by anything — a hook that only remembered its own
@@ -183,7 +220,9 @@ async function run(args) {
       }));
     } catch {
       // Best-effort, like every other branch: the user's turn proceeds either
-      // way, and a store hiccup must never cost them their prompt.
+      // way, and a store hiccup must never cost them their prompt — but record
+      // that the lookup degraded so a store that always throws is visible.
+      meter.outcome = HOOK_OUTCOME.DEGRADED;
     }
     return 0;
   }
@@ -210,6 +249,7 @@ async function run(args) {
       }
     } catch {
       // best-effort — never break the host
+      meter.outcome = HOOK_OUTCOME.DEGRADED;
     }
     return 0;
   }
@@ -224,6 +264,7 @@ async function run(args) {
     let relevant = null;
     try {
       const store = createStore(control);
+      if (!store) meter.outcome = HOOK_OUTCOME.STORE_UNAVAILABLE;
       if (store) {
         // QUERY the store across the scope hierarchy for lessons matching this
         // failure — not a post-filter of the SessionStart-injected set, which
@@ -235,6 +276,7 @@ async function run(args) {
       }
     } catch {
       relevant = null; // never let a lesson lookup break the failure nudge
+      meter.outcome = HOOK_OUTCOME.DEGRADED;
     }
     const nudge = failureNudge(parsed.toolName, scope, control);
     emit(relevant ? `${relevant}\n\n${nudge}` : nudge);

--- a/packages/cli/src/telemetry/telemetry.mjs
+++ b/packages/cli/src/telemetry/telemetry.mjs
@@ -655,25 +655,28 @@ function normalizeExitCode(result) {
  * Run a MACHINE-facing command (`hook`, `mcp`) and count the invocation —
  * counter only, no span. Returns the command's exit code unchanged.
  *
- * The export is STARTED BEFORE the command runs and awaited after, so it
- * overlaps the command's own work instead of being serialized behind it. That
- * ordering is what makes this affordable on `hook`, which fires several times
- * per agent turn: by the time there is anything to await, the POST has usually
- * already completed, and {@link METERED_TIMEOUT_MS} caps the worst case.
+ * The two commands are counted at DIFFERENT times, for a reason specific to
+ * each:
  *
- * It also makes the count robust for `mcp`, which is a LONG-LIVED stdio server —
- * `run()` does not return until the server exits, and a killed server would
- * never have reported at all if the export waited for it. Since the counter
- * reports the invocation rather than its outcome (a machine-facing command's
- * verdict belongs to its stdout contract, which the host reads), there is
- * nothing to learn by waiting.
+ *   • `mcp` is a LONG-LIVED stdio server — `run()` does not return until the
+ *     server exits, and a killed server would never report at all if the export
+ *     waited for it. So its count fires BEFORE run and is awaited after, which
+ *     also overlaps the export with the server's own startup. It carries no
+ *     outcome: a server's verdict belongs to its stdout contract.
+ *   • `hook` is short-lived and fires several times per agent turn. It is
+ *     counted AFTER run so the counter can carry the health dimensions run
+ *     reports (`lorekit.hook.event` + `lorekit.hook.outcome`) — the difference
+ *     between a healthy hook and one silently degrading (an unusable store, a
+ *     swallowed lookup error) that a bare invocation ping cannot show. The extra
+ *     latency is run's own duration (a hook is tens of ms); the
+ *     {@link METERED_TIMEOUT_MS} export cap dominates either way.
  *
  * Nothing here can affect the command: the exit code is passed through
  * untouched, and every telemetry failure is swallowed.
  *
  * @param {string} command  `hook` | `mcp`
  * @param {string} version  CLI version
- * @param {() => Promise<number>} run  the command handler
+ * @param {() => Promise<number | { exitCode?: number, meter?: object }>} run  the command handler
  */
 export async function meterCommand(command, version, run) {
   let config;
@@ -688,15 +691,26 @@ export async function meterCommand(command, version, run) {
   // cost nothing at all: no identity read, no timer, no promise.
   if (!config.enabled) return normalizeExitCode(await run());
 
-  // `.catch` attached IMMEDIATELY, before any await: an unawaited rejecting
-  // promise is an unhandled rejection, which on a machine-facing command would
-  // print to stderr and pollute a host's log.
-  const pending = countInvocation(config, command, version).catch(() => {});
-  try {
-    return normalizeExitCode(await run());
-  } finally {
-    await pending;
+  // Long-lived server: count before run (see docblock). `.catch` attached
+  // IMMEDIATELY, before any await: an unawaited rejecting promise is an
+  // unhandled rejection, which on a machine-facing command would print to
+  // stderr and pollute a host's log.
+  if (command === 'mcp') {
+    const pending = countInvocation(config, command, version).catch(() => {});
+    try {
+      return normalizeExitCode(await run());
+    } finally {
+      await pending;
+    }
   }
+
+  // Short-lived hook: count after run so the counter carries what run reported.
+  // A `meter` object on the result is the health payload; anything else (a bare
+  // exit code) counts with no extra dimensions.
+  const result = await run();
+  const meter = (result && typeof result === 'object' && result.meter) ? result.meter : {};
+  await countInvocation(config, command, version, meter).catch(() => {});
+  return normalizeExitCode(result);
 }
 
 /**

--- a/packages/cli/test/telemetry-identity.test.mjs
+++ b/packages/cli/test/telemetry-identity.test.mjs
@@ -295,3 +295,79 @@ test('meterCommand propagates a thrown command error unchanged', async () => {
     else process.env.LOREKIT_TELEMETRY = prev;
   }
 });
+
+/**
+ * Run `body` with export ENABLED (a non-default OTLP endpoint enables without a
+ * token) and `global.fetch` captured, so the metrics POST can be inspected
+ * without a real collector. LOREKIT_HOME is redirected to a throwaway dir so the
+ * identity resolution the enabled path performs never touches the real store.
+ */
+async function withEnabledExport(body) {
+  const prev = {
+    LOREKIT_TELEMETRY: process.env.LOREKIT_TELEMETRY,
+    DO_NOT_TRACK: process.env.DO_NOT_TRACK,
+    OTEL_EXPORTER_OTLP_ENDPOINT: process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+    LOREKIT_HOME: process.env.LOREKIT_HOME,
+  };
+  const originalFetch = globalThis.fetch;
+  const calls = [];
+  globalThis.fetch = async (url, opts) => {
+    calls.push({ url, body: JSON.parse(opts.body) });
+    return { ok: true, status: 200, async text() { return '{}'; } };
+  };
+  delete process.env.LOREKIT_TELEMETRY;
+  delete process.env.DO_NOT_TRACK;
+  process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'https://otel.example.com';
+  process.env.LOREKIT_HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'lorekit-meter-'));
+  try {
+    return await body(calls);
+  } finally {
+    globalThis.fetch = originalFetch;
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+/** The single metrics datapoint's attributes, as a plain key→value map. */
+function metricAttrs(call) {
+  const dp = call.body.resourceMetrics[0].scopeMetrics[0].metrics[0].sum.dataPoints[0];
+  return Object.fromEntries(
+    dp.attributes.map((a) => [a.key, a.value.stringValue ?? a.value.boolValue ?? a.value.intValue]),
+  );
+}
+
+test('meterCommand exports on the enabled HOOK path, and the hook meter attrs reach the counter', async () => {
+  // The hook branch counts AFTER run and threads the result's `meter` object
+  // into countInvocation as extra dimensions. Assert both that the enabled path
+  // fires a metrics POST and that hookMeterAttrs' output (lorekit.hook.outcome
+  // + lorekit.hook.event) actually lands on the datapoint — the path this PR
+  // added and that only the disabled cases covered.
+  await withEnabledExport(async (calls) => {
+    const code = await meterCommand('hook', '1.0.0', () => ({
+      exitCode: 0,
+      meter: { 'lorekit.hook.outcome': 'ok', 'lorekit.hook.event': 'SessionStart' },
+    }));
+    assert.equal(code, 0);
+    const metrics = calls.find((c) => c.url.endsWith('/v1/metrics'));
+    assert.ok(metrics, 'the enabled hook path must POST a metric');
+    const attrs = metricAttrs(metrics);
+    assert.equal(attrs['lorekit.cli.command'], 'hook');
+    assert.equal(attrs['lorekit.hook.outcome'], 'ok');
+    assert.equal(attrs['lorekit.hook.event'], 'SessionStart');
+  });
+});
+
+test('meterCommand exports on the enabled MCP path and passes the exit code through', async () => {
+  // The mcp branch counts BEFORE run (long-lived server) and awaits the pending
+  // count in `finally`. Assert the enabled path fires the metrics POST and the
+  // exit code is still returned unchanged.
+  await withEnabledExport(async (calls) => {
+    const code = await meterCommand('mcp', '1.0.0', () => ({ exitCode: 2, foo: 'bar' }));
+    assert.equal(code, 2);
+    const metrics = calls.find((c) => c.url.endsWith('/v1/metrics'));
+    assert.ok(metrics, 'the enabled mcp path must POST a metric');
+    assert.equal(metricAttrs(metrics)['lorekit.cli.command'], 'mcp');
+  });
+});

--- a/packages/mcp-core/src/tools/search.ts
+++ b/packages/mcp-core/src/tools/search.ts
@@ -1,7 +1,8 @@
 import { SpanStatusCode } from '@opentelemetry/api';
 import { z } from 'zod';
 import { type SupabaseClient } from '@supabase/supabase-js';
-import { expandScopeForSearch, scopeType } from '../scope/scope.js';
+import { expandScopeForSearch } from '../scope/scope.js';
+import { scopeTypeAttribute } from '../scope/scope-type-attribute.js';
 import { getTracer, getToolDurationHistogram } from '../telemetry/telemetry.js';
 
 export const SearchInputSchema = z.object({
@@ -33,9 +34,15 @@ export async function search(
   // genuinely `mixed`. This used to be hard-coded `mixed`, which made a
   // single-scope search's latency indistinguishable from an all-scope one and
   // meant the series could never be sliced by real scope type.
-  const histScopeType = input.scopes && input.scopes.length === 1
-    ? scopeType(input.scopes[0])
-    : 'mixed';
+  //
+  // `scopeTypeAttribute` (NOT the raw `scopeType`) does the bucketing: `scopes`
+  // is `z.array(z.string())`, so it is NOT `ScopeSchema`-validated the way
+  // `list.ts`/`write.ts`'s `scope` is. `scopeType` would `split('::')[0]` an
+  // arbitrary caller string straight into this bounded metric label; the
+  // attribute helper maps a single scope to its type (`invalid` for an
+  // ungrammatical one), several to `mixed`, and none to null — coalesced to
+  // `mixed` here to keep the "search over the whole store" semantics above.
+  const histScopeType = scopeTypeAttribute(undefined, input.scopes) ?? 'mixed';
 
   return tracer.startActiveSpan('lorekit.memory.search', { kind: 0 }, async (span) => {
     span.setAttribute('lorekit.tool.name', 'memory.search');

--- a/packages/mcp-core/src/tools/search.ts
+++ b/packages/mcp-core/src/tools/search.ts
@@ -1,7 +1,7 @@
 import { SpanStatusCode } from '@opentelemetry/api';
 import { z } from 'zod';
 import { type SupabaseClient } from '@supabase/supabase-js';
-import { expandScopeForSearch } from '../scope/scope.js';
+import { expandScopeForSearch, scopeType } from '../scope/scope.js';
 import { getTracer, getToolDurationHistogram } from '../telemetry/telemetry.js';
 
 export const SearchInputSchema = z.object({
@@ -27,6 +27,15 @@ export async function search(
   const tracer = getTracer();
   const hist = getToolDurationHistogram();
   const startTime = Date.now();
+
+  // The duration metric's scope-type label. A search over exactly one scope is
+  // that scope's type; a search over several (or none — the whole store) is
+  // genuinely `mixed`. This used to be hard-coded `mixed`, which made a
+  // single-scope search's latency indistinguishable from an all-scope one and
+  // meant the series could never be sliced by real scope type.
+  const histScopeType = input.scopes && input.scopes.length === 1
+    ? scopeType(input.scopes[0])
+    : 'mixed';
 
   return tracer.startActiveSpan('lorekit.memory.search', { kind: 0 }, async (span) => {
     span.setAttribute('lorekit.tool.name', 'memory.search');
@@ -98,7 +107,7 @@ export async function search(
       span.end();
       hist.record((Date.now() - startTime) / 1000, {
         'lorekit.tool.name': 'memory.search',
-        'lorekit.scope.type': 'mixed',
+        'lorekit.scope.type': histScopeType,
       });
     }
   });

--- a/supabase/functions/mcp/mcp-handler.ts
+++ b/supabase/functions/mcp/mcp-handler.ts
@@ -343,16 +343,22 @@ export async function handleMcp(req: Request, auth: AuthContext, span: Span, ada
 
       // UserInputError (bad scope, missing required arg), OrgPermissionError
       // (insufficient role), UnknownOrgError (org slug does not resolve),
-      // TtlError (invalid ttl_days/ttl_minutes/ttl_seconds), and CreatedAtError
-      // (invalid/future created_at override) are all client-caused — the
-      // server handled them correctly. Use clientError() so spans are NOT
+      // TtlError (invalid ttl_days/ttl_minutes/ttl_seconds), CreatedAtError
+      // (invalid/future created_at override), and LimitError (the account is at
+      // its memory cap — an in-band -32040 rejection) are all client-caused —
+      // the server handled them correctly. Use clientError() so spans are NOT
       // marked ERROR (OTel: server spans are ERROR only for 5xx / server-side
-      // faults, not 4xx client errors).
+      // faults, not 4xx client errors). A cap hit is expected and recorded
+      // separately as usage outcome `cap_exceeded`; flagging the span ERROR too
+      // would inflate the `lorekit.mcp` error rate an operator alerts on.
+      // Rate-limit LimitErrors never reach here — they are handled before the
+      // tool runs (see `index.ts`).
       const isClientError = err instanceof UserInputError
         || err instanceof OrgPermissionError
         || err instanceof UnknownOrgError
         || err instanceof TtlError
-        || err instanceof CreatedAtError;
+        || err instanceof CreatedAtError
+        || err instanceof LimitError;
       if (isClientError) {
         toolSpan.clientError(msg).end();
         span.clientError(msg);

--- a/supabase/functions/mcp/mcp-handler.ts
+++ b/supabase/functions/mcp/mcp-handler.ts
@@ -345,8 +345,9 @@ export async function handleMcp(req: Request, auth: AuthContext, span: Span, ada
       // (insufficient role), UnknownOrgError (org slug does not resolve),
       // TtlError (invalid ttl_days/ttl_minutes/ttl_seconds), CreatedAtError
       // (invalid/future created_at override), and LimitError (the account is at
-      // its memory cap — an in-band -32040 rejection) are all client-caused —
-      // the server handled them correctly. Use clientError() so spans are NOT
+      // its memory cap — returned in-band as an isError result, see below) are
+      // all client-caused — the server handled them correctly. Use clientError()
+      // so spans are NOT
       // marked ERROR (OTel: server spans are ERROR only for 5xx / server-side
       // faults, not 4xx client errors). A cap hit is expected and recorded
       // separately as usage outcome `cap_exceeded`; flagging the span ERROR too

--- a/supabase/functions/mcp/webhook.ts
+++ b/supabase/functions/mcp/webhook.ts
@@ -408,7 +408,12 @@ async function processWebhook(req: Request, span: Span): Promise<Response> {
       'lorekit.webhook.hmac_fail_reason': 'secret_not_configured',
       'lorekit.webhook.is_app_event': isAppEvent,
     });
-    span.error('HmacError: secret_not_configured');
+    // A 401: the delivery is unauthenticated because no secret is configured
+    // for this repo. That is a caller/config condition, not a server fault, so
+    // record it WITHOUT flipping the span to ERROR — an unconfigured or forged
+    // delivery is expected in the wild and must not inflate the webhook error
+    // rate. The `hmac_fail_reason` attribute keeps it queryable.
+    span.clientError('HmacError: secret_not_configured');
     return new Response('Unauthorized', { status: 401 });
   }
 
@@ -432,7 +437,11 @@ async function processWebhook(req: Request, span: Span): Promise<Response> {
 
   if (!hmac.ok) {
     span.setAttributes({ 'lorekit.webhook.hmac_fail_reason': hmac.failReason ?? 'unknown' });
-    span.error(`HmacError: ${hmac.failReason ?? 'signature mismatch'}`);
+    // A 401 signature mismatch is a caller condition (a forged or misconfigured
+    // delivery), not a server fault. Record it WITHOUT flipping the span to
+    // ERROR so routine bad signatures do not inflate the webhook error rate;
+    // `hmac_fail_reason` keeps the failure queryable.
+    span.clientError(`HmacError: ${hmac.failReason ?? 'signature mismatch'}`);
     return new Response('Unauthorized', { status: 401 });
   }
 


### PR DESCRIPTION
From a full observability audit of the repo. Three focused telemetry-correctness fixes so regressions are actually visible, plus the doc update.

## What changed

- **Stop flagging expected rejections as server faults.** Memory-cap hits (MCP tool catch) and webhook 401s (HMAC mismatch / secret-not-configured) were setting span status `Error`, inflating the error rate an operator alerts on. Both are 4xx-class client conditions — record them via `clientError()` so they stay queryable (by attribute / usage outcome) without polluting the server error signal.
- **Derive a real `scope.type` for the search duration metric.** `memory.search` hard-coded the histogram's `lorekit.scope.type` label to `mixed`, so a single-scope search's latency was indistinguishable from an all-scope one and the series could never be sliced by scope. One scope → that scope's type; several or none → `mixed`.
- **Give the hook engine a health heartbeat.** The hook fires on every agent turn and always exits 0, so a broken or degrading hook (unusable store, swallowed lookup error) was invisible. Two bounded dimensions now ride the existing invocation counter: `lorekit.hook.event` and `lorekit.hook.outcome` (`ok` | `store_unavailable` | `degraded` | `crash`). The short-lived `hook` is counted after run so the counter can report what the fire did; `mcp` (long-lived) keeps its before-run count.

## Verification

- `deno check` clean on the mcp edge function.
- `mcp-core` typecheck + `search.spec.ts` green.
- CLI `telemetry-identity.test.mjs` 20/20.

## Docs

`docs/otel.md` updated with the two new hook counter dimensions and the count-timing split. No user-facing tool/CLI-flag/config changed — these are internal telemetry, so `llms.txt` and the public docs do not apply.