### PR TITLE
ci: pin Supabase CLI to 2.115.0 across all workflows (fix Integration smoke)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,7 +632,13 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v3
         with:
-          version: latest
+          # Pinned, not `latest`: CLI v2.116.0 changed the local stack's default
+          # privileges so `anon` gains EXECUTE on SECURITY DEFINER functions that
+          # migration 00041 only revokes from PUBLIC, tripping the
+          # `lorekit_org_members_list must not be granted to anon` assertion in
+          # migrations.test.sql. v2.115.0 is the last release with the prior
+          # behaviour. Revisit once the CLI's grant change is understood.
+          version: 2.115.0
 
       # Give the LOCAL edge runtime an OTLP endpoint so its smoke spans actually
       # export to Dash0 (tagged `deployment.environment.name=test`), instead of

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,7 +168,13 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v3
         with:
-          version: latest
+          # Pinned, not `latest`, for consistency with ci.yml (#578): CLI
+          # v2.116.0 changed the local stack's default privileges, tripping a
+          # security assertion under `supabase start`. This job talks to
+          # hosted Supabase, not the local stack, so that specific assertion
+          # doesn't apply here — pinned anyway to avoid unplanned CLI drift
+          # across all workflows until the v2.116.0 grant change is understood.
+          version: 2.115.0
 
       - name: Verify preview environment secrets are set
         run: |
@@ -605,7 +611,13 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v3
         with:
-          version: latest
+          # Pinned, not `latest`, for consistency with ci.yml (#578): CLI
+          # v2.116.0 changed the local stack's default privileges, tripping a
+          # security assertion under `supabase start`. This job talks to
+          # hosted Supabase, not the local stack, so that specific assertion
+          # doesn't apply here — pinned anyway to avoid unplanned CLI drift
+          # across all workflows until the v2.116.0 grant change is understood.
+          version: 2.115.0
 
       - name: Verify production environment secrets are set
         run: |
@@ -1006,7 +1018,13 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v3
         with:
-          version: latest
+          # Pinned, not `latest`, for consistency with ci.yml (#578): CLI
+          # v2.116.0 changed the local stack's default privileges, tripping a
+          # security assertion under `supabase start`. This job talks to
+          # hosted Supabase, not the local stack, so that specific assertion
+          # doesn't apply here — pinned anyway to avoid unplanned CLI drift
+          # across all workflows until the v2.116.0 grant change is understood.
+          version: 2.115.0
 
       - name: Redeploy previous edge functions
         run: supabase functions deploy --no-verify-jwt --project-ref "$PROJECT_REF"

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -128,7 +128,13 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@46f7f98c7f948ad727d22c1e67fab04c223a0520 # v3.0.0
         with:
-          version: latest
+          # Pinned, not `latest`, for consistency with ci.yml (#578): CLI
+          # v2.116.0 changed the local stack's default privileges, tripping a
+          # security assertion under `supabase start`. This job talks to
+          # hosted Supabase, not the local stack, so that specific assertion
+          # doesn't apply here — pinned anyway to avoid unplanned CLI drift
+          # across all workflows until the v2.116.0 grant change is understood.
+          version: 2.115.0
 
       - name: Verify required secrets
         run: |

--- a/.github/workflows/rebuild-preview.yml
+++ b/.github/workflows/rebuild-preview.yml
@@ -103,7 +103,13 @@ jobs:
       - name: Install Supabase CLI
         uses: supabase/setup-cli@v3
         with:
-          version: latest
+          # Pinned, not `latest`, for consistency with ci.yml (#578): CLI
+          # v2.116.0 changed the local stack's default privileges, tripping a
+          # security assertion under `supabase start`. This job talks to
+          # hosted Supabase, not the local stack, so that specific assertion
+          # doesn't apply here — pinned anyway to avoid unplanned CLI drift
+          # across all workflows until the v2.116.0 grant change is understood.
+          version: 2.115.0
 
       - name: Verify preview environment secrets are set
         run: |


### PR DESCRIPTION
## What

Pin every `supabase/setup-cli` step to `2.115.0` instead of `latest`:

- `ci.yml` — the Integration smoke job (the actual fix)
- `deploy.yml` — preview deploy, production deploy, rollback
- `preview.yml`
- `rebuild-preview.yml`

## Why

`Integration smoke (local Supabase)` went red on `main` and on every backend PR, at:

```
migrations.test.sql: lorekit_org_members_list must not be granted to anon
```

Root cause is a CLI drift, not a code change. `supabase/setup-cli@v3` with `version: latest` moved from **v2.115.0** to **v2.116.0** (released 2026-08-26). The newer CLI changes the local stack's default privileges so `anon` gains EXECUTE on SECURITY DEFINER functions that migration 00041 only `revoke ... from public` — the explicit anon grant is no longer stripped, so the security assertion trips.

Proof it is environmental, not a diff:
- The assertion, and migrations 00024/00041 that set the grants, are byte-identical to what passed on 2026-08-25.
- A full bare-Postgres repro (PG16 + pgvector, all migrations) passes the assertion locally — the failure only appears under the drifted CLI's `supabase start`.
- It reproduces identically on `origin/main` and on unrelated feature branches.

It was masked until now: when the `check` job failed, Integration smoke was skipped (a skipped required check passes branch protection). Fixing `check` on the backend PRs unmasked the latent failure.

## Scope

Only `ci.yml`'s Integration smoke job runs the local Supabase stack, so it is the only place the anon-grant assertion actually reproduces — the other four steps deploy against **hosted** Supabase (`db push` / `functions deploy` via `PROJECT_REF`) and are unaffected by that assertion. They are pinned anyway so no workflow silently drifts onto a new CLI while the v2.116.0 default-privilege change is un-investigated; each carries a comment saying exactly that. After this change no workflow resolves `version: latest`.

## Follow-up (separate)

Investigate whether v2.116.0's default-privilege change reveals a real gap (does 00041 need to `revoke ... from anon` explicitly, not just `from public`?) or is purely a CLI test-harness artifact. Tracked as a lesson in LoreKit. Un-pinning is a single-value change in five places once that is settled.