### PR TITLE
chore(review): point Agent0 fix buttons at the development environment

### DIFF
--- a/.github/review.yaml
+++ b/.github/review.yaml
@@ -1,1 +1,2 @@
 agent0_fix_links: true
+agent0_environment: development


### PR DESCRIPTION
Sets `agent0_environment: development` in `.github/review.yaml` so the Fix-with-Agent0 buttons in this repo's pr-reviewer output link to `app.dash0-dev.com` instead of `app.dash0.com`.

Depends on the `agent0_environment` support added in mthines/agent-skills#143 (the reviewer reads this key and passes `--env development` to the deep-link builder). Until #143 merges, this key is a harmless no-op.