### PR TITLE
blog: Agent memory doesn't need embeddings — it needs a schema

### DIFF
--- a/packages/web/public/blog/memory-record.svg
+++ b/packages/web/public/blog/memory-record.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 680 460" role="img" aria-label="A single memory record as a labeled card in two zones. Top zone, what you write: scope and key form the identity, value is the lesson, tags and ttl_days are optional. Bottom zone, what the store keeps: seen_count is the recurrence and salience signal, created and updated give recency, expires_at is auto-expiry, archived_at is a soft delete, and source_agent, trigger and origin fields are provenance and audit.">
+  <style>
+    text{font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;fill:#e7ebf2}
+    .lbl{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;fill:#8892a4;letter-spacing:.02em}
+    .k{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace}
+  </style>
+  <rect x="0" y="0" width="680" height="460" fill="#0d0e11"/>
+
+  <rect x="80" y="22" width="520" height="416" rx="14" fill="#13151a" stroke="#2a2d38"/>
+  <text x="100" y="50" class="k" font-size="13" font-weight="700" fill="#e7ebf2">one memory record</text>
+  <line x1="100" y1="60" x2="580" y2="60" stroke="#2a2d38"/>
+
+  <!-- ZONE A -->
+  <text x="100" y="82" class="lbl" font-size="10.5" fill="#f5a623">WHAT YOU WRITE</text>
+
+  <text x="112" y="108" class="k" font-size="12.5" fill="#f5a623">scope</text>
+  <text x="560" y="108" text-anchor="end" class="lbl" font-size="11">where it belongs (an address)</text>
+  <text x="112" y="136" class="k" font-size="12.5" fill="#f5a623">key</text>
+  <text x="560" y="136" text-anchor="end" class="lbl" font-size="11">stable id → upsert, not append</text>
+  <rect x="150" y="94" width="150" height="50" rx="8" fill="none" stroke="#f5a623" stroke-opacity="0.35" stroke-dasharray="4 3"/>
+  <text x="225" y="159" text-anchor="middle" class="k" font-size="9" fill="#f5a623">scope + key = identity</text>
+
+  <text x="112" y="190" class="k" font-size="12.5" fill="#e7ebf2">value</text>
+  <text x="560" y="190" text-anchor="end" class="lbl" font-size="11">the lesson — advisory, not a rule</text>
+
+  <text x="112" y="218" class="k" font-size="12.5" fill="#aeb6c2">tags</text>
+  <text x="330" y="218" class="lbl" font-size="9.5" fill="#556072">optional</text>
+  <text x="560" y="218" text-anchor="end" class="lbl" font-size="11">labels · a second axis, not scope</text>
+  <text x="112" y="244" class="k" font-size="12.5" fill="#aeb6c2">ttl_days</text>
+  <text x="330" y="244" class="lbl" font-size="9.5" fill="#556072">optional</text>
+  <text x="560" y="244" text-anchor="end" class="lbl" font-size="11">auto-expiry</text>
+
+  <!-- divider -->
+  <line x1="100" y1="266" x2="580" y2="266" stroke="#2a2d38"/>
+  <text x="100" y="288" class="lbl" font-size="10.5">WHAT THE STORE KEEPS</text>
+
+  <text x="112" y="314" class="k" font-size="12.5" fill="#7ce6bf">seen_count</text>
+  <rect x="205" y="302" width="86" height="17" rx="8" fill="#34d399" fill-opacity="0.16" stroke="#34d399" stroke-opacity="0.4"/>
+  <text x="248" y="314" text-anchor="middle" class="k" font-size="9" fill="#7ce6bf">salience</text>
+  <text x="560" y="314" text-anchor="end" class="lbl" font-size="11">recurrence — re-learned five times &gt; once</text>
+
+  <text x="112" y="342" class="k" font-size="12.5" fill="#c5ccd6">created · updated</text>
+  <text x="560" y="342" text-anchor="end" class="lbl" font-size="11">recency (14-day half-life)</text>
+
+  <text x="112" y="370" class="k" font-size="12.5" fill="#c5ccd6">expires_at</text>
+  <text x="560" y="370" text-anchor="end" class="lbl" font-size="11">the resolved TTL instant</text>
+
+  <text x="112" y="398" class="k" font-size="12.5" fill="#c5ccd6">archived_at</text>
+  <text x="560" y="398" text-anchor="end" class="lbl" font-size="11">soft delete — hidden, not destroyed</text>
+
+  <text x="112" y="426" class="k" font-size="12.5" fill="#c5ccd6">source_agent · trigger · origin_*</text>
+  <text x="560" y="426" text-anchor="end" class="lbl" font-size="11">provenance / audit trail</text>
+</svg>

--- a/packages/web/public/blog/scope-hierarchy.svg
+++ b/packages/web/public/blog/scope-hierarchy.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 440" role="img" aria-label="Four scope levels drawn as centered bands narrowing toward the top: branch at the top, then repo, then project, then global widest at the bottom. A downward arrow on the left is labeled read most-specific first. Each band shows its canonical address grammar — branch::owner/repo::branch, repo::owner/repo, project::name, global. A note at the bottom says on the same key, the narrowest scope wins.">
+  <style>
+    text{font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;fill:#e7ebf2}
+    .lbl{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;fill:#8892a4;letter-spacing:.02em}
+    .k{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace}
+  </style>
+  <defs>
+    <marker id="arh" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#8892a4"/></marker>
+  </defs>
+  <rect x="0" y="0" width="640" height="440" fill="#0d0e11"/>
+
+  <!-- read-order arrow -->
+  <text x="40" y="60" class="lbl" font-size="10.5" transform="rotate(90 40 60)">READ MOST-SPECIFIC FIRST</text>
+  <line x1="58" y1="86" x2="58" y2="316" stroke="#8892a4" stroke-width="1.5" marker-end="url(#arh)"/>
+
+  <!-- branch -->
+  <rect x="230" y="70" width="220" height="56" rx="10" fill="#7c8cf8" fill-opacity="0.14" stroke="#7c8cf8" stroke-opacity="0.6"/>
+  <text x="340" y="92" text-anchor="middle" font-size="13" font-weight="700" fill="#aeb9ff">branch</text>
+  <text x="340" y="112" text-anchor="middle" class="k" font-size="9.5" fill="#8892a4">branch::{owner}/{repo}::{branch}</text>
+
+  <!-- repo -->
+  <rect x="195" y="140" width="290" height="56" rx="10" fill="#f5a623" fill-opacity="0.13" stroke="#f5a623" stroke-opacity="0.6"/>
+  <text x="340" y="162" text-anchor="middle" font-size="13" font-weight="700" fill="#f5a623">repo</text>
+  <text x="340" y="182" text-anchor="middle" class="k" font-size="9.5" fill="#8892a4">repo::{owner}/{repo}</text>
+
+  <!-- project -->
+  <rect x="160" y="210" width="360" height="56" rx="10" fill="#34d399" fill-opacity="0.12" stroke="#34d399" stroke-opacity="0.55"/>
+  <text x="340" y="232" text-anchor="middle" font-size="13" font-weight="700" fill="#7ce6bf">project</text>
+  <text x="340" y="252" text-anchor="middle" class="k" font-size="9.5" fill="#8892a4">project::{name}</text>
+
+  <!-- global -->
+  <rect x="120" y="280" width="440" height="56" rx="10" fill="#8892a4" fill-opacity="0.12" stroke="#8892a4" stroke-opacity="0.5"/>
+  <text x="340" y="302" text-anchor="middle" font-size="13" font-weight="700" fill="#c5ccd6">global</text>
+  <text x="340" y="322" text-anchor="middle" class="k" font-size="9.5" fill="#8892a4">global</text>
+
+  <line x1="120" y1="366" x2="560" y2="366" stroke="#2a2d38"/>
+  <text x="340" y="392" text-anchor="middle" class="lbl" font-size="11.5">On the same key, the narrowest scope wins —</text>
+  <text x="340" y="410" text-anchor="middle" class="lbl" font-size="11.5">a branch note shadows the repo one, which shadows global.</text>
+  <text x="340" y="430" text-anchor="middle" class="k" font-size="10" fill="#f5a623">`::` is the only separator — it can't collide with `/` or `:`</text>
+</svg>

--- a/packages/web/public/blog/structure-vs-similarity.svg
+++ b/packages/web/public/blog/structure-vs-similarity.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 380" role="img" aria-label="Two ways to find a memory, side by side. Left, structure: a task starts, resolved by scope precedence, then ranked by recency, recurrence, relevance and outcome, giving the lessons that fit — tagged deterministic, inspectable, free, offline. Right, similarity: the lesson text is embedded into a vector, stored in a vector index, queried by nearest-neighbor, giving the nearest chunks — tagged semantic, opaque, metered, needs a service. A caption says the two are complementary: structure first, embeddings as an optional layer on top.">
+  <style>
+    text{font-family:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;fill:#e7ebf2}
+    .lbl{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;fill:#8892a4;letter-spacing:.02em}
+    .k{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace}
+  </style>
+  <defs>
+    <marker id="ars" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#8892a4"/></marker>
+  </defs>
+  <rect x="0" y="0" width="720" height="380" fill="#0d0e11"/>
+
+  <!-- LEFT — structure -->
+  <text x="80" y="34" class="lbl" font-size="12" fill="#f5a623">STRUCTURE · how LoreKit reads</text>
+  <rect x="80" y="46" width="240" height="30" rx="8" fill="#1a1d24" stroke="#2a2d38"/>
+  <text x="200" y="65" text-anchor="middle" font-size="11.5">a task starts — no query yet</text>
+  <line x1="200" y1="76" x2="200" y2="92" stroke="#8892a4" stroke-width="1.4" marker-end="url(#ars)"/>
+  <rect x="80" y="94" width="240" height="34" rx="8" fill="#1a1d24" stroke="#f5a623" stroke-opacity="0.4"/>
+  <text x="200" y="115" text-anchor="middle" font-size="11.5">scope precedence — narrowest wins</text>
+  <line x1="200" y1="128" x2="200" y2="144" stroke="#8892a4" stroke-width="1.4" marker-end="url(#ars)"/>
+  <rect x="80" y="146" width="240" height="42" rx="8" fill="#1a1d24" stroke="#f5a623" stroke-opacity="0.4"/>
+  <text x="200" y="165" text-anchor="middle" font-size="11">rank by the columns:</text>
+  <text x="200" y="180" text-anchor="middle" class="k" font-size="9.5" fill="#8892a4">recency · recurrence · relevance · outcome</text>
+  <line x1="200" y1="188" x2="200" y2="204" stroke="#8892a4" stroke-width="1.4" marker-end="url(#ars)"/>
+  <rect x="80" y="206" width="240" height="34" rx="8" fill="#2a2010" stroke="#f5a623"/>
+  <text x="200" y="227" text-anchor="middle" font-size="11.5" font-weight="600" fill="#f5a623">the lessons that fit the budget</text>
+  <text x="200" y="270" text-anchor="middle" class="k" font-size="10.5" fill="#7ce6bf">deterministic · inspectable · free · offline</text>
+
+  <line x1="360" y1="40" x2="360" y2="300" stroke="#2a2d38" stroke-dasharray="3 4"/>
+
+  <!-- RIGHT — similarity -->
+  <text x="400" y="34" class="lbl" font-size="12" fill="#7c8cf8">SIMILARITY · the vector way</text>
+  <rect x="400" y="46" width="240" height="28" rx="8" fill="#1a1d24" stroke="#2a2d38"/>
+  <text x="520" y="64" text-anchor="middle" font-size="11.5">the lesson text</text>
+  <line x1="520" y1="74" x2="520" y2="88" stroke="#8892a4" stroke-width="1.4" marker-end="url(#ars)"/>
+  <rect x="400" y="90" width="240" height="28" rx="8" fill="#1a1d24" stroke="#7c8cf8" stroke-opacity="0.4"/>
+  <text x="520" y="108" text-anchor="middle" font-size="11.5">embed → vector</text>
+  <line x1="520" y1="118" x2="520" y2="132" stroke="#8892a4" stroke-width="1.4" marker-end="url(#ars)"/>
+  <rect x="400" y="134" width="240" height="28" rx="8" fill="#1a1d24" stroke="#7c8cf8" stroke-opacity="0.4"/>
+  <text x="520" y="152" text-anchor="middle" font-size="11.5">vector index</text>
+  <line x1="520" y1="162" x2="520" y2="176" stroke="#8892a4" stroke-width="1.4" marker-end="url(#ars)"/>
+  <rect x="400" y="178" width="240" height="28" rx="8" fill="#1a1d24" stroke="#7c8cf8" stroke-opacity="0.4"/>
+  <text x="520" y="196" text-anchor="middle" font-size="11.5">nearest-neighbor query</text>
+  <line x1="520" y1="206" x2="520" y2="220" stroke="#8892a4" stroke-width="1.4" marker-end="url(#ars)"/>
+  <rect x="400" y="222" width="240" height="30" rx="8" fill="#13151a" stroke="#7c8cf8"/>
+  <text x="520" y="242" text-anchor="middle" font-size="11.5" font-weight="600" fill="#aeb9ff">the nearest chunks</text>
+  <text x="520" y="270" text-anchor="middle" class="k" font-size="10.5" fill="#8892a4">semantic · opaque · metered · needs a service</text>
+
+  <line x1="40" y1="300" x2="680" y2="300" stroke="#2a2d38"/>
+  <text x="360" y="326" text-anchor="middle" class="lbl" font-size="11.5" fill="#c5ccd6">Complementary, not opposed — structure first,</text>
+  <text x="360" y="344" text-anchor="middle" class="lbl" font-size="11.5" fill="#c5ccd6">and embeddings as a layer on top only if paraphrase recall earns its cost.</text>
+</svg>

--- a/packages/web/src/content/blog/agent-memory-data-model.mdx
+++ b/packages/web/src/content/blog/agent-memory-data-model.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Agent memory doesn't need embeddings — it needs a schema"
 description: "Everyone reached for vector databases. But most of what a coding agent needs to remember is small, specific, and recurring — a scoped note, not a semantic blob. Here's the deterministic, no-AI data model LoreKit runs on, the rationale for every column, and an invitation to converge on a shared shape."
-date: "2026-09-05"
+date: "2026-08-29"
 author: "Mads Thines"
 readingMinutes: 9
 tags: ["agent-memory", "data-model", "deterministic", "no-embeddings", "lorekit"]

--- a/packages/web/src/content/blog/agent-memory-data-model.mdx
+++ b/packages/web/src/content/blog/agent-memory-data-model.mdx
@@ -105,21 +105,13 @@ That's retrieval from *structure* — scope precedence, a stable key, an honest 
   <figcaption>Two ways to find a memory. Structure is deterministic, inspectable, and free; similarity is semantic but opaque and metered. For recurring, specific gotchas, structure wins — and nothing stops you layering embeddings on top later.</figcaption>
 </figure>
 
-## Where I'll be honest about the limits
-
-A schema post that only lists wins isn't honest, so:
-
-- **Lexical, not semantic.** Relevance is recurrence, recency, and word-overlap with your branch name — no embeddings on the read path. A genuine paraphrase can miss. That's the real cost of determinism, and it's the thing embeddings would fix if you added them as a layer.
-- **"Relevant" means your branch, not your task.** At session start there's no task yet, so the relevance signal is a coarse hint from the branch name. A well-named branch helps; `wip` does nothing.
-- **Single-writer, whole-record model.** This is a store of small facts, not a CRDT. It's the right model for lore and the wrong one for live co-editing.
-
-None of these need a vector database to fix. They're honest edges of a deliberately small model.
-
 ## An invitation, not a decree
 
 Here's the part I'm actually unsure about, and want dialogue on.
 
 Every agent tool is quietly reinventing this shape — some file of remembered facts, addressed somehow, with some idea of freshness and recurrence. We're all solving the same small problem in mutually incompatible ways, so lore is trapped in whatever tool wrote it.
+
+I spend my days working with OpenTelemetry, so I've watched this exact movie before. Telemetry used to be locked inside whatever agent emitted it, until a shared shape — spans, attributes, one wire format — let any tool read any other tool's data. Nobody had to win; they just had to agree on the shape. That's where the instinct here comes from: not one winning memory product, but one shape everyone can write to.
 
 The part worth agreeing on, I think, isn't the storage engine or the ranking algorithm — those should vary freely. It's the **two things that make lore portable**: a **record shape** (`scope`, `key`, `value`, plus `tags`, `ttl`, provenance) and a **scope grammar** (`global` / `project::…` / `repo::…` / `branch::…`) that addresses a lesson the same way regardless of which agent wrote it. Get those shared, and a lesson your CI agent learns is one your editor agent can read — across tools, over MCP, without an import step.
 

--- a/packages/web/src/content/blog/agent-memory-data-model.mdx
+++ b/packages/web/src/content/blog/agent-memory-data-model.mdx
@@ -111,7 +111,7 @@ Here's the part I'm actually unsure about, and want dialogue on.
 
 Every agent tool is quietly reinventing this shape — some file of remembered facts, addressed somehow, with some idea of freshness and recurrence. We're all solving the same small problem in mutually incompatible ways, so lore is trapped in whatever tool wrote it.
 
-I spend my days working with OpenTelemetry, so I've watched this exact movie before. Telemetry used to be locked inside whatever agent emitted it, until a shared shape — spans, attributes, one wire format — let any tool read any other tool's data. Nobody had to win; they just had to agree on the shape. That's where the instinct here comes from: not one winning memory product, but one shape everyone can write to.
+I work with OpenTelemetry every day at [Dash0](https://www.dash0.com), so I've watched this exact movie before. Telemetry used to be locked inside whatever agent emitted it, until a shared shape — spans, attributes, one wire format — let any tool read any other tool's data. Nobody had to win; they just had to agree on the shape. That's where the instinct here comes from: not one winning memory product, but one shape everyone can write to.
 
 The part worth agreeing on, I think, isn't the storage engine or the ranking algorithm — those should vary freely. It's the **two things that make lore portable**: a **record shape** (`scope`, `key`, `value`, plus `tags`, `ttl`, provenance) and a **scope grammar** (`global` / `project::…` / `repo::…` / `branch::…`) that addresses a lesson the same way regardless of which agent wrote it. Get those shared, and a lesson your CI agent learns is one your editor agent can read — across tools, over MCP, without an import step.
 

--- a/packages/web/src/content/blog/agent-memory-data-model.mdx
+++ b/packages/web/src/content/blog/agent-memory-data-model.mdx
@@ -1,0 +1,142 @@
+---
+title: "Agent memory doesn't need embeddings — it needs a schema"
+description: "Everyone reached for vector databases. But most of what a coding agent needs to remember is small, specific, and recurring — a scoped note, not a semantic blob. Here's the deterministic, no-AI data model LoreKit runs on, the rationale for every column, and an invitation to converge on a shared shape."
+date: "2026-09-05"
+author: "Mads Thines"
+readingMinutes: 9
+tags: ["agent-memory", "data-model", "deterministic", "no-embeddings", "lorekit"]
+order: 4
+keywords: ["agent memory", "data model", "schema", "deterministic", "no embeddings", "scopes", "labels", "lorekit", "memory standard", "MCP memory", "scope grammar"]
+---
+
+## The reach for a vector database
+
+When agent memory got popular, almost everyone reached for the same thing: embed the text, store the vectors, query by similarity. Obvious move — it's how retrieval works everywhere else.
+
+For a coding agent, it's mostly the wrong tool. The things an agent needs to remember aren't fuzzy documents you find by vibe. They're small, specific, and *recurring*: the integration tests need a database up first; this API returns `[]`, not a 404; use the shared client, not a raw query. A scoped note, not a semantic blob. And for a scoped note, similarity search is a heavy, non-deterministic, opaque way to do what a `WHERE` clause does exactly.
+
+So LoreKit went the boring way: a deterministic data model, no embeddings, no model call on the read path. This post is the rationale for every column in that model — and, at the end, an honest question: is a shape like this worth agreeing on?
+
+## What "good" means for this kind of memory
+
+Before the columns, the constraints they're chosen against. Agent memory for coding should be:
+
+- **Deterministic.** The same store and the same task produce the same read, every time. You can reason about it, test it, and reproduce a bug.
+- **Inspectable.** It's plain records you can `cat`, `grep`, `diff`, and commit. When the agent recalls something wrong, you can see exactly which row and why.
+- **Cheap.** No embedding bill, no vector index to build or re-build, nothing to keep warm.
+- **Portable.** It runs offline against files on disk, or against a hosted store, with the same shape. No service is required to get value.
+- **Boring.** A junior engineer can predict what it will and won't surface. Predictability is a feature.
+
+Embedding-based memory buys you real things — genuine semantic recall, paraphrase tolerance — at the cost of every item on that list. It's non-deterministic, opaque, metered, and drifts as you re-embed. For a pile of recurring, specific gotchas, that's a bad trade. So the design question is: *what's the smallest set of columns that gets you most of the value, deterministically?*
+
+## The record you write
+
+A write is three required fields and a few optional ones:
+
+```json
+memory.write {
+  scope: "repo::acme/checkout",
+  key:   "tests-need-local-postgres",
+  value: "Integration tests need Postgres up first: docker compose up -d db.",
+  tags:  ["ci", "gotcha"],
+  ttl_days: 30                 // optional — auto-expire
+}
+```
+
+That's the whole contract an agent has to honor. Everything else the store derives or keeps for you. Let me take the load-bearing fields one at a time — the question each answers, and what breaks without it.
+
+### `scope` — *where does this knowledge belong?*
+
+Scope is the idea the whole model hangs on. A lesson is true somewhere specific: on this branch, in this repo, across a project, or everywhere. LoreKit encodes that as a canonical, collision-free address:
+
+```text
+global
+project::{name}
+repo::{owner}/{repo}
+branch::{owner}/{repo}::{branch}
+```
+
+The `::` double-colon is the only separator — deliberately, so a `/` in a repo path and a `:` in a branch name never get confused for structure. Scopes are read **most-specific-first**: a branch lesson beats a repo lesson beats a global one on the same key. That precedence is what lets a spike's findings stay on its branch while a hard-won global rule follows you everywhere.
+
+Without scope you have one flat pile, and it gets *worse* as it grows — every project's quirks bleed into every read. Scope is how the same store serves a fresh repo and a shared, org-wide corpus without tuning.
+
+<figure>
+  <img src="/blog/scope-hierarchy.svg" alt="Four nested scope levels drawn as bands from widest to narrowest: global at the base, then project, then repo, then branch at the top. An arrow labeled 'read most-specific first' points from branch down through the stack, and a note shows that a branch lesson shadows a repo lesson with the same key. The canonical address grammar is shown beside each level: global, project::name, repo::owner/repo, branch::owner/repo::branch." width="640" height="440" />
+  <figcaption>Scope is an address, not a folder. Four levels, read narrowest-first, so the most specific lesson on a key wins — and a `::` grammar that can't collide with the `/` in a repo path or the `:` in a branch name.</figcaption>
+</figure>
+
+### `key` — *what is this lesson's stable identity?*
+
+The key is what makes memory a store and not a log. Write the same key twice and the second write *updates* the first — same lesson, one row. That's what keeps a store from filling with a thousand near-identical captures of "the DB wasn't running." A good key is a slug for the lesson (`tests-need-local-postgres`), stable across the times you re-learn it.
+
+Without a stable key you get append-only noise, and the signal you actually want — *this keeps happening* — is buried instead of counted.
+
+### `value` — *the lesson itself*
+
+Plain text, and deliberately advisory. The read block that surfaces these literally labels them *"considerations, not rules."* A lesson is a note your agent left for its future self; it can be ignored when it's wrong. That's the difference between lore and a linter — and why lore complements your `CLAUDE.md` rules rather than competing with them.
+
+### `tags` — *a second axis that isn't scope*
+
+Scope says *where*; tags say *what kind*. They're orthogonal on purpose. A `loop::reviewer-lessons` tag buckets one automated writer's output; `wip` marks a throwaway; `source::pr-webhook` records that a lesson was harvested from a PR review. You can filter or cap by tag without touching the scope hierarchy. Collapsing the two axes into one — folders that mean both "where" and "what" — is exactly the tangle scopes-plus-tags avoids.
+
+## The columns the store keeps
+
+Beyond what you write, the store maintains a few system columns. You don't set them; they're what make the *read* smart without a model in the loop.
+
+- **`seen_count` (recurrence).** Every re-write of a key increments it. A lesson you've re-learned five times is worth more than a one-off, and this is the column that knows. It's the single most useful signal a deterministic store has — salience without semantics.
+- **`created` / `updated` (recency).** Timestamps, decayed on a two-week half-life at read time. Recent lessons lean up; ancient ones fade without being deleted.
+- **`expires_at` (TTL).** Some facts are true for a week — "skip the flaky test until Friday's fix." Set `ttl_days` on the write and the row goes invisible on its own. No cleanup task, no stale note steering you in November.
+- **`archived_at` (soft delete).** Retiring a lesson hides it from reads without destroying the history.
+- **Provenance (`source_agent`, `trigger`, `origin_repo` / `origin_branch` / `origin_commit` / `origin_pr`).** Where the lesson came from — which agent, what prompted it, the exact commit or PR. This is the audit trail: when a lesson is wrong, you can trace it to its origin instead of guessing.
+
+<figure>
+  <img src="/blog/memory-record.svg" alt="A single memory record drawn as a labeled card, split into two zones. The top zone, 'what you write', holds scope, key, value, and optional tags and ttl_days. The bottom zone, 'what the store keeps', holds seen_count, created and updated, expires_at, archived_at, and provenance fields source_agent, trigger, origin_repo, origin_branch, origin_commit, origin_pr. Callouts mark seen_count as the salience signal and scope-plus-key as the identity." width="680" height="460" />
+  <figcaption>The whole record. Three fields you write, a handful the store keeps — every one there to answer a specific question at read time, none of it a vector.</figcaption>
+</figure>
+
+## The read is structure, not similarity
+
+Here's the surprise: with those columns, you don't need embeddings to rank well. At the start of a task there's no query yet, so the read scores the candidates on signals the columns already carry — recurrence (`seen_count`), recency (`updated`), a cheap relevance pull from the branch name, and outcome (whether applying a lesson has helped, derived from its tags, with a neutral prior so a new lesson isn't buried). Equal weights by default, all deterministic, all inspectable.
+
+That's retrieval from *structure* — scope precedence, a stable key, an honest recurrence count — rather than from vector similarity. Same store, same task, same result, every time, for a fraction of a cent.
+
+<figure>
+  <img src="/blog/structure-vs-similarity.svg" alt="Two columns compared. Left, 'structure', shows a query resolved by scope precedence plus a rank over the columns recency, recurrence, relevance, and outcome, tagged deterministic, inspectable, free, offline. Right, 'similarity', shows text embedded into a vector, stored in a vector index, and queried by nearest-neighbor, tagged semantic, opaque, metered, needs a service. A caption notes the two are complementary: structure first, embeddings as an optional layer on top." width="720" height="380" />
+  <figcaption>Two ways to find a memory. Structure is deterministic, inspectable, and free; similarity is semantic but opaque and metered. For recurring, specific gotchas, structure wins — and nothing stops you layering embeddings on top later.</figcaption>
+</figure>
+
+## Where I'll be honest about the limits
+
+A schema post that only lists wins isn't honest, so:
+
+- **Lexical, not semantic.** Relevance is recurrence, recency, and word-overlap with your branch name — no embeddings on the read path. A genuine paraphrase can miss. That's the real cost of determinism, and it's the thing embeddings would fix if you added them as a layer.
+- **"Relevant" means your branch, not your task.** At session start there's no task yet, so the relevance signal is a coarse hint from the branch name. A well-named branch helps; `wip` does nothing.
+- **Single-writer, whole-record model.** This is a store of small facts, not a CRDT. It's the right model for lore and the wrong one for live co-editing.
+
+None of these need a vector database to fix. They're honest edges of a deliberately small model.
+
+## An invitation, not a decree
+
+Here's the part I'm actually unsure about, and want dialogue on.
+
+Every agent tool is quietly reinventing this shape — some file of remembered facts, addressed somehow, with some idea of freshness and recurrence. We're all solving the same small problem in mutually incompatible ways, so lore is trapped in whatever tool wrote it.
+
+The part worth agreeing on, I think, isn't the storage engine or the ranking algorithm — those should vary freely. It's the **two things that make lore portable**: a **record shape** (`scope`, `key`, `value`, plus `tags`, `ttl`, provenance) and a **scope grammar** (`global` / `project::…` / `repo::…` / `branch::…`) that addresses a lesson the same way regardless of which agent wrote it. Get those shared, and a lesson your CI agent learns is one your editor agent can read — across tools, over MCP, without an import step.
+
+I'm not declaring a standard. I'm proposing a shape that has earned its keep in one real system, putting it out in the open, and asking the obvious questions:
+
+- Is a deterministic, no-embeddings model enough for your use, or does it break somewhere I haven't hit?
+- Is the four-level scope grammar the right set of levels — too many, too few, wrong names?
+- What's missing from the record? What's there that shouldn't be?
+
+The schema and the scope validator are open in the repo. Tell me where it's wrong — that's the point of writing it down.
+
+## Start local, poke holes
+
+If you want to see the model in your own repo before you argue with it, that's one command and a folder you own:
+
+```bash
+npx @lorekit/cli install
+```
+
+It writes the records as plain files you can read. Then break it, and tell me how.

--- a/packages/web/src/content/blog/agent-memory-working-set.mdx
+++ b/packages/web/src/content/blog/agent-memory-working-set.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Your agent's memory should scale from 6 lessons to 60,000"
 description: "The obvious answer to agent memory — inject the lessons — breaks the moment your store gets interesting. LoreKit spends a fixed slice of your context window on the highest-signal, de-duplicated lessons, so the read costs the same at 6 lessons or 60,000 — and always tells you what it left out. Here's how it scales, and the honest limits."
-date: "2026-08-22"
+date: "2026-09-29"
 author: "Mads Thines"
 readingMinutes: 8
 tags: ["agent-memory", "context-window", "retrieval", "ranking", "lorekit"]

--- a/packages/web/src/content/blog/give-your-agent-a-memory.mdx
+++ b/packages/web/src/content/blog/give-your-agent-a-memory.mdx
@@ -173,7 +173,7 @@ Honest boundary while you're deciding: there's no semantic search here, and noth
 
 The obvious worry about a store that only grows: it gets worse the more it learns. A folder with six lessons injects six lines. A year-old team store with sixty thousand can't inject sixty thousand.
 
-It doesn't. The read spends a fixed slice of your context window — not a fixed number of lessons — on the highest-signal, de-duplicated ones, and tells you exactly what it left out. Same code, both ends of the range. That's the next post: [Your agent's memory should scale from 6 lessons to 60,000](/blog/agent-memory-working-set).
+It doesn't. The read spends a fixed slice of your context window — not a fixed number of lessons — on the highest-signal, de-duplicated ones, and tells you exactly what it left out. Same code, both ends of the range. The deterministic model that makes that work — scopes, a stable key, no embeddings — is its own post: [Agent memory doesn't need embeddings — it needs a schema](/blog/agent-memory-data-model).
 
 ## Start local today
 

--- a/packages/web/src/lib/blog/sections.ts
+++ b/packages/web/src/lib/blog/sections.ts
@@ -38,6 +38,12 @@ export const BLOG_SECTIONS: readonly BlogSection[] = [
     summary:
       "Self-healing and self-improving agents sound like an ML problem. They're not. It's a plain read-fail-write loop over shared memory — no fine-tuning, no new model call. Here's how LoreKit does it, guardrails and all.",
   },
+  {
+    id: 'agent-memory-data-model',
+    label: "Agent memory doesn't need embeddings — it needs a schema",
+    summary:
+      "Everyone reached for vector databases. But most of what a coding agent needs to remember is small, specific, and recurring — a scoped note, not a semantic blob. Here's the deterministic, no-AI data model LoreKit runs on, the rationale for every column, and an invitation to converge on a shared shape.",
+  },
 ];
 
 /** URL slugs / MDX filename stems, in listing order (newest first). */


### PR DESCRIPTION
## What

A new blog post: **"Agent memory doesn't need embeddings — it needs a schema."** Releases **today** (dated 2026-08-29).

The design-rationale case for LoreKit's deterministic, no-embeddings data model, ending on an **invitation** to converge on a shared shape — not a standard decree.

- **Rationale, field by field.** The written record (`scope`, `key`, `value`, + optional `tags`, `ttl_days`) and the store-kept columns (`seen_count`, `created`/`updated`, `expires_at`, `archived_at`, provenance) — each framed as *the question it answers* and *what breaks without it*. `outcome` is described as a **derived** ranking signal, not a stored column.
- **The scope grammar as the portable bit** — `global` / `project::{name}` / `repo::{owner}/{repo}` / `branch::{owner}/{repo}::{branch}`, `::`-only, most-specific-first.
- **Structure vs. similarity retrieval**, and an open "tell me where it's wrong" close. The invitation grounds the "converge on a shared shape" instinct in **OpenTelemetry** (linked to Dash0) — a shared shape let any tool read any other's telemetry, and that's the model for a portable lore shape.
- **Three figures:** `scope-hierarchy`, `memory-record`, `structure-vs-similarity` (dark-theme SVG).

## Content-calendar changes bundled in
- **`agent-memory-data-model`** → date `2026-08-29` (release today).
- **`agent-memory-working-set`** (the "scale from 6 to 60,000" post) → rescheduled to `2026-09-29` (a month out). It becomes a future draft: hidden and 404 in prod until then, still previewable on Vercel preview.
- **`give-your-agent-a-memory`** → the "next post" link is repointed from the (now delayed) scaling post to this data-model post, which explains the deterministic model behind the bounded read.

## Files
- `packages/web/src/content/blog/agent-memory-data-model.mdx`
- `packages/web/src/content/blog/agent-memory-working-set.mdx` (date only)
- `packages/web/src/content/blog/give-your-agent-a-memory.mdx` (link only)
- `packages/web/public/blog/{scope-hierarchy,memory-record,structure-vs-similarity}.svg`
- `packages/web/src/lib/blog/sections.ts` — registry entry (`order: 4`)

## Notes
- Prose run through the humanizer. Blog specs (`sections.spec` + `mdx-render.spec`, 11 tests) and `xmllint` green.
- No `llms.txt` impact (blog is self-contained); no config/contract changes.
- Static generation means the date doesn't flip a post live on its own — this merge is the build that publishes the data-model post and drops the scaling post from prod.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8s1w6a6bdvwq1tYE4ViQN)_