### PR TITLE
ci(web-preview): fail fast on a blocked Vercel deploy and comment the reason

### DIFF
--- a/.github/actions/vercel-preview-deploy/action.yml
+++ b/.github/actions/vercel-preview-deploy/action.yml
@@ -82,6 +82,18 @@ inputs:
       'false' the `url` output is empty. Defaults to 'true' (build + deploy).
     required: false
     default: 'true'
+  deploy-timeout:
+    description: >-
+      Max wall-clock time for `vercel deploy` before it is treated as a hung /
+      blocked deployment and failed. A GNU `timeout` duration ('15m', '900s').
+
+      `vercel deploy` polls until the deployment is READY or ERROR; a BLOCKED
+      one — most often because the commit author's email can't be matched to a
+      GitHub account with project access — never resolves, so without a bound the
+      CLI hangs until the 6-hour job default. This turns that hang into a fast,
+      reported failure. Ignored when deploy is 'false'.
+    required: false
+    default: '15m'
   alias-label:
     description: >-
       When set (e.g. 'pr-42'), assign a STABLE alias to this deployment —
@@ -209,20 +221,48 @@ runs:
         VERCEL_TOKEN: ${{ inputs.vercel-token }}
         VERCEL_ORG_ID: ${{ inputs.vercel-org-id }}
         VERCEL_PROJECT_ID: ${{ inputs.vercel-project-id }}
+        DEPLOY_TIMEOUT: ${{ inputs.deploy-timeout }}
       run: |
-        set -euo pipefail
-        # Vercel prints the deployment URL to stdout and progress to stderr;
-        # keep them separate (no 2>&1) and grep the URL so a trailing stderr
-        # line can never be mistaken for the deployment URL.
-        out="$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")"
+        # NOT `set -e`: we capture `vercel`'s exit code and report the reason
+        # ourselves rather than aborting on it. `timeout` bounds a BLOCKED
+        # deployment (which `vercel deploy` would otherwise poll on forever, up to
+        # the 6-hour job default) so a hang becomes a fast, reported failure —
+        # `--kill-after` force-kills if the CLI ignores the initial SIGTERM.
+        set -uo pipefail
+        # Vercel prints the deployment URL to stdout and progress + any block
+        # reason to stderr; keep them SEPARATE (no 2>&1) so a stderr line can
+        # never be mistaken for the URL, and capture stderr to a file so the
+        # failure reason below can quote it.
+        err_file="$(mktemp)"
+        out="$(timeout --kill-after=30s "$DEPLOY_TIMEOUT" vercel deploy --prebuilt --token="$VERCEL_TOKEN" 2>"$err_file")"
+        code=$?
+        err="$(cat "$err_file")"; rm -f "$err_file"
         echo "$out"
-        # `|| true` so grep's no-match exit (1) doesn't abort under pipefail/set -e
-        # before the guard below runs — an empty URL is handled by that guard,
-        # which prints a clear ::error:: and exits 1, so nothing is swallowed.
+        [ -n "$err" ] && printf '%s\n' "$err" >&2
+
+        # Persist a concise reason to the shared workspace so the CALLER can post
+        # it in a PR comment on failure (a composite action cannot comment, and a
+        # step output does not reliably survive a non-zero exit). Then exit 1.
+        reason_file="${GITHUB_WORKSPACE}/vercel-deploy-error.txt"
+        fail() {
+          printf '%s\n' "$1" > "$reason_file"
+          echo "::error::$1"
+          exit 1
+        }
+
+        if [ "$code" -eq 124 ]; then
+          fail "Vercel deploy timed out after ${DEPLOY_TIMEOUT}. A deployment that never becomes Ready is almost always BLOCKED by Vercel — most commonly because the commit author's email can't be matched to a GitHub account with access to the project. Check the commit author and the project's Git deployment-protection settings."
+        fi
+        if [ "$code" -ne 0 ]; then
+          # Prefer Vercel's own stated cause; fall back to the tail of its output.
+          detail="$(printf '%s\n' "$err" "$out" | grep -iE 'block|could not be matched|not authorized|error' | tail -3 || true)"
+          [ -z "$detail" ] && detail="$(printf '%s\n' "$out" "$err" | grep -vE '^[[:space:]]*$' | tail -3 || true)"
+          fail "Vercel deploy failed (exit ${code}).${detail:+$'\n'$detail}"
+        fi
+
         URL="$(printf '%s\n' "$out" | grep -Eo 'https://[^[:space:]]+' | tail -1 || true)"
         if [ -z "$URL" ]; then
-          echo "::error::Could not parse Vercel preview deployment URL"
-          exit 1
+          fail "Could not parse the Vercel deployment URL from the CLI output — the deployment may not have completed."
         fi
         echo "url=$URL" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,10 @@ jobs:
   #    Non-blocking by design: it is deliberately NOT in the `summary` gate's
   #    `needs`, so a transient Vercel failure can never block a merge (the old
   #    Vercel preview check wasn't a merge gate either). It self-skips green on a
-  #    fork PR where the Vercel secrets are unavailable.
+  #    fork PR where the Vercel secrets are unavailable. A deploy Vercel BLOCKS
+  #    (e.g. the commit author's email isn't matched to a GitHub account) now
+  #    fails FAST — bounded by a `vercel deploy` timeout instead of hanging to the
+  #    job default — and posts the reason as a sticky PR comment.
   web-preview:
     name: Web — Vercel preview (changed)
     needs: [changes]

--- a/.github/workflows/web-preview-deploy.yml
+++ b/.github/workflows/web-preview-deploy.yml
@@ -5,8 +5,11 @@
 # (the composite action). The composite owns the pull → build → deploy → alias
 # sequence; THIS workflow owns everything around it that only makes sense for a
 # PR preview: the fork-secret guard, the incremental "is a redeploy needed?"
-# decision, checking out the PR head, and the sticky status comment. A composite
-# action cannot express that — it has no `jobs:` — so it lives here.
+# decision, checking out the PR head, and the sticky status comment — posted on
+# a successful deploy AND on a failed one (e.g. a deployment Vercel BLOCKED
+# because the commit author's email isn't matched to a GitHub account), so a
+# block is visible on the PR instead of a silent hang. A composite action cannot
+# express that — it has no `jobs:` — so it lives here.
 #
 # Callers:
 #   - ci.yml               → on every PR push, force: false (quota-friendly)
@@ -90,6 +93,11 @@ jobs:
   deploy:
     name: Deploy Vercel preview
     runs-on: ubuntu-latest
+    # Backstop above the composite's own `vercel deploy` timeout (15m) plus
+    # install + build, so even a hang OUTSIDE the deploy step can't run to the
+    # 6-hour job default. The deploy-command timeout fires first, so the failure
+    # comment step below still gets to run.
+    timeout-minutes: 30
     # Serialize every preview for this PR — CI's automatic deploy and a manual
     # `/web-preview` must not race, or two `vercel alias set` calls can leave the
     # stable pr-<n> alias pointing at the older of the two deployments.
@@ -292,12 +300,69 @@ jobs:
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
 
-      # One line in the run summary either way, so an agent or human reading the
-      # job knows what it decided without opening the step logs.
+      # The deploy was decided AND attempted, but the composite action failed —
+      # e.g. Vercel BLOCKED the deployment (commit author's email not matched to
+      # a GitHub account) and `vercel deploy` hit the timeout. Without this, the
+      # only signal was a red (non-blocking) job most people never open. Post the
+      # captured reason to the PR so the failure is visible where the work is.
+      #
+      # Reuses the same sticky marker as the success comment so a previously-green
+      # preview flips to "❌ Failed" in place rather than stacking — but writes NO
+      # `sha=` in the marker, on purpose: the "Decide" step keys its incremental
+      # skip off that sha, so omitting it makes the next web push RE-ATTEMPT the
+      # deploy instead of treating this failed commit as already deployed.
+      - name: Comment on preview failure
+        if: failure() && steps.preview.outcome == 'failure'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_SHA: ${{ inputs.head-sha }}
+          PR_NUMBER: ${{ inputs.pr-number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const sha = process.env.PR_SHA.slice(0, 7);
+            const findMarker = '<!-- lorekit-web-preview';
+            const markerLine = '<!-- lorekit-web-preview -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            let reason = '';
+            try {
+              reason = fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/vercel-deploy-error.txt`, 'utf8').trim();
+            } catch { /* no reason file — fall back to a generic message */ }
+            const detail = reason || 'The Vercel deployment did not complete. See the workflow logs for the CLI output.';
+            const updated = new Date().toISOString().replace('T', ' ').slice(0, 16);
+            const body = [
+              markerLine,
+              'The dashboard preview for this PR — redeployed on each push that changes the web app.',
+              '',
+              '| Name | Status | Preview | Deployment (this commit) | Updated (UTC) |',
+              '| :--- | :----- | :------ | :----------------------- | :------------ |',
+              `| **lorekit** | ❌ Failed | — | \`${sha}\` | ${updated} |`,
+              '',
+              '> [!WARNING]',
+              '> **The preview deploy for this commit failed — no preview is available.**',
+              '>',
+              ...detail.split('\n').map((l) => `> ${l}`),
+              '',
+              `<sub>A blocked deployment is most often the commit author's email not matching a GitHub account with project access. Fix the cause, then push again or comment \`/web-preview\` to retry. · [Workflow logs](${runUrl})</sub>`,
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });
+            const existing = comments.find((c) => c.body?.includes(findMarker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      # One line in the run summary for every outcome — deployed, failed, or
+      # skipped — so an agent or human reading the job knows what happened without
+      # opening the step logs.
       - name: Summarize the outcome
         if: always()
         env:
-          DEPLOYED: ${{ steps.gate.outputs.deploy }}
+          DECIDED: ${{ steps.gate.outputs.deploy }}
+          OUTCOME: ${{ steps.preview.outcome }}
           REASON: ${{ steps.gate.outputs.reason }}
           URL: ${{ steps.preview.outputs.url }}
           ALIAS: ${{ steps.preview.outputs.alias-url }}
@@ -307,10 +372,18 @@ jobs:
           {
             echo "### Web preview"
             echo ""
-            if [ "$DEPLOYED" = "true" ]; then
+            if [ "$DECIDED" = "true" ] && [ "$OUTCOME" = "success" ]; then
               echo "Deployed \`${PR_SHA:0:7}\`."
               [ -n "$ALIAS" ] && echo "- Preview (stable): $ALIAS"
               [ -n "$URL" ] && echo "- Deployment (this commit): $URL"
+            elif [ "$DECIDED" = "true" ]; then
+              echo "❌ Deploy FAILED for \`${PR_SHA:0:7}\` — a status comment was posted on the PR."
+              if [ -f "${GITHUB_WORKSPACE}/vercel-deploy-error.txt" ]; then
+                echo ""
+                echo '```text'
+                cat "${GITHUB_WORKSPACE}/vercel-deploy-error.txt"
+                echo '```'
+              fi
             else
               echo "No deployment this run — ${REASON:-no reason recorded}."
             fi


### PR DESCRIPTION
## What

The `web-preview` job could hang for hours instead of reporting a failure. When Vercel **blocks** a deployment — most often because the commit author's email can't be matched to a GitHub account with project access (e.g. `noreply@anthropic.com` on automated commits) — the deployment never becomes Ready, so `vercel deploy --prebuilt` polls on it until the **6-hour job default**. Meanwhile the sticky-comment step only ran on success, so the PR showed **nothing**.

This makes a blocked deploy fail fast and surface the reason on the PR.

## Changes

- **`.github/actions/vercel-preview-deploy/action.yml`** — bound `vercel deploy` with `timeout --kill-after` (new optional `deploy-timeout` input, default `15m`) so a blocked/hung deploy fails in minutes, not hours. Capture the CLI's stderr and persist a concise failure reason to a shared-workspace file (`vercel-deploy-error.txt`) the caller can read — a composite action can't post a comment, and a step output doesn't reliably survive a non-zero exit. stdout/stderr stay separate so a stderr line is never mistaken for the deployment URL.
- **`.github/workflows/web-preview-deploy.yml`** — add a 30-minute job `timeout-minutes` backstop, and a **failure-comment** step that posts the captured reason to the PR. It reuses the same sticky marker as the success comment (so a green preview flips to "❌ Failed" in place rather than stacking) but writes **no** `sha=` in the marker, so the next web push re-attempts the deploy instead of treating the failed commit as already deployed. The summary step now distinguishes deployed / failed / skipped.
- **`.github/workflows/ci.yml`** — comment update describing the new fail-fast + comment behavior.

## Behavior

- **Non-blocking is unchanged** — `web-preview` is still not in the `summary` gate's `needs`, so it can't block a merge. It now surfaces a block **loudly** (red non-blocking check + PR comment) instead of hanging silently.
- Benefits every deploying caller of the composite action (`ci.yml` → reusable, `/web-preview`, `preview.yml`); the build-only caller (`deploy.yml`, `deploy: 'false'`) is unaffected since it never runs the deploy step.

## Testing

- YAML validated for all three files.
- The composite deploy step's bash was exercised against stubbed `vercel`/`timeout` for the three paths — **success** (parses URL, exits 0), **blocked** (non-zero exit; the real "commit email … could not be matched to a GitHub account" message is captured into the reason file), and **timeout** (exit 124 → timeout reason) — each producing the expected exit code and reason file.

## Docs

No user-facing docs impact — this is CI/workflow internals only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8s1w6a6bdvwq1tYE4ViQN)_