### PR TITLE
feat(web): surface signups whose confirmation email never sent

### DIFF
--- a/docs/otel.md
+++ b/docs/otel.md
@@ -711,6 +711,35 @@ error **message** is deliberately never reported: it is prose, it is localised,
 and it can embed the address that was typed — unbounded and PII-bearing, the two
 things a grouping key must not be.
 
+**One exception: `email_send_failed`.** A broken mailer (bad SMTP credentials, a
+DNS record the sending domain needs but doesn't have, an unreachable relay)
+never gets a `code` from GoTrue, and `name` is the same generic `AuthApiError`
+every other server-side auth fault carries — so without a special case, the one
+failure class an operator most needs to alert on independently was indistinguishable
+from any other API error. `isEmailSendFailure` (`lib/auth-email-failure.ts`)
+recognises it from the message's stable `"Error sending … email"` prefix — the
+one part of the message that is neither prose nor PII — shared with
+`friendlyAuthError`'s user-facing copy so the two can never classify the same
+error differently.
+
+**Signup can also succeed at the API layer and still never notify anyone.**
+When the project requires confirmation, `email_password_signup` reaches a third
+branch that emits neither `auth.attempt`'s failure nor its success (see below)
+— by design, since Supabase returns the identical response for a brand-new
+signup and a resubmission to an already-registered address, and reporting
+success there would leak that distinction. That symmetry is also exactly what
+made a delivered-nowhere signup invisible: the API call itself succeeded, so
+`reportAuthFailure` never ran, and nothing else was watching. `reportAuthPending`
+(`auth.pending`, `LoginButton.tsx`) closes that gap without breaking the
+symmetry — it fires identically for both cases, proving only that a signup
+reached this state. Paired against `auth.success` for
+`auth.method = email_confirmation` (`WelcomeContent.tsx`, emitted when the link
+is actually opened), a sustained gap — many pending, few completions, over a
+window wider than a normal inbox-checking delay — is the regression signal for
+a mailer that is silently failing every delivery: the signal this funnel had no
+way to surface before, and the one a misconfigured DNS record on the sending
+domain trips first.
+
 The funnel is `auth.attempt` minus `auth.success`, grouped by `auth.method` — for
 every method that emits both. Three do not, in different directions, so read
 those rows differently:
@@ -721,22 +750,28 @@ those rows differently:
   is the only call site), so its subtraction is *negative* — the matching intent
   was recorded on the signup page one document earlier, as
   `email_password_signup`.
-- `email_password_signup` emits both — but only on the two branches that
-  terminate in this document (`data.session` → success, `signUpError` →
-  failure). When the project requires confirmation, the attempt ends on the
-  "check your inbox" screen having emitted *neither*, for the reason below, so
-  its subtraction counts every confirmation-pending signup as drop-off. Those
-  are the ones that reappear as `email_confirmation` successes on `/welcome`,
-  which is why the two rows have to be read as a pair.
+- `email_password_signup` emits an attempt on every submission and, on the two
+  branches that terminate in this document, `data.session` → success or
+  `signUpError` → failure — so its plain subtraction still overstates
+  drop-off by every confirmation-pending signup, which is neither. When the
+  project requires confirmation, the attempt instead ends on the "check your
+  inbox" screen emitting `auth.pending` (see below), so read this row as
+  `attempt − success − pending` for the true abandonment/error count, and
+  `pending` on its own — compared against `email_confirmation` successes on
+  `/welcome` — as the signal for a mailer that accepted the signup and never
+  delivered it.
 
 Two paths deliberately emit no `auth.success`:
 
 - **GitHub OAuth** — success is a redirect to a new document, so the page that
   would report it is already gone. Arrival at the destination is the evidence.
 - **The "confirm your email" screen** — no session exists yet, and Supabase
-  routes an already-registered address down the same branch. Counting it would
-  overstate signups *and* leak the distinction the screen exists to hide. That
-  path completes as `email_confirmation` on `/welcome`.
+  routes an already-registered address down the same branch. Counting it as a
+  success would overstate signups *and* leak the distinction the screen exists
+  to hide, so it emits the neutral `auth.pending` instead (identically for
+  both cases, preserving that symmetry) — see `reportAuthPending` in
+  `lib/auth-telemetry.ts`. That path completes as `email_confirmation` on
+  `/welcome`.
 
 > **These used to be signal attributes, and must never go back to being any.**
 > The surfaces previously called `addSignalAttribute('auth.method', …)`, which

--- a/packages/web/src/components/auth/LoginButton.tsx
+++ b/packages/web/src/components/auth/LoginButton.tsx
@@ -10,6 +10,7 @@ import {
   reportAuthAttempt,
   reportAuthFailure,
   reportAuthOptionSelected,
+  reportAuthPending,
   reportAuthSuccess,
   type AuthMethod,
 } from '@/lib/auth-telemetry';
@@ -275,9 +276,13 @@ export function LoginButton({ compact = false }: LoginButtonProps) {
     // this same screen is shown either way — it must not reveal which.
     //
     // Deliberately NOT reported as a success: no session exists yet, and the
-    // branch is also what an already-registered address takes. Counting it
-    // would both overstate signups and leak the distinction the screen exists
-    // to hide. `email_confirmation` on /welcome is where that path completes.
+    // branch is also what an already-registered address takes. Counting it as
+    // a success would both overstate signups and leak the distinction the
+    // screen exists to hide. `email_confirmation` on /welcome is where that
+    // path completes — but this is still the only place a signup that fully
+    // succeeded here (and needs an email neither of us can confirm was ever
+    // delivered) can be counted at all. See `reportAuthPending`.
+    reportAuthPending(method);
     setStep('confirm');
   }
 

--- a/packages/web/src/lib/auth-email-failure.spec.ts
+++ b/packages/web/src/lib/auth-email-failure.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { isEmailSendFailure } from './auth-email-failure';
+
+describe('isEmailSendFailure', () => {
+  it('matches the stable GoTrue mailer-failure prefix', () => {
+    expect(isEmailSendFailure('Error sending confirmation email')).toBe(true);
+    expect(isEmailSendFailure('Error sending magic link email')).toBe(true);
+    expect(isEmailSendFailure('Error sending recovery email')).toBe(true);
+  });
+
+  // The failure that motivated this: a DNS resolution error connecting to the
+  // mail relay never mentions "smtp" in its text, so matching that substring
+  // alone would have missed it.
+  it('matches a DNS-resolution failure that never mentions smtp', () => {
+    expect(
+      isEmailSendFailure('Error sending confirmation email: dial tcp: lookup mail.example.com: no such host'),
+    ).toBe(true);
+  });
+
+  it('still matches the legacy smtp/delivery substrings', () => {
+    expect(isEmailSendFailure('Error sending confirmation mail: smtp failure')).toBe(true);
+    expect(isEmailSendFailure('Mail delivery failed')).toBe(true);
+  });
+
+  it('does not match unrelated auth errors', () => {
+    expect(isEmailSendFailure('Invalid login credentials')).toBe(false);
+    expect(isEmailSendFailure('Email rate limit exceeded')).toBe(false);
+  });
+
+  it('is total for nullish input', () => {
+    expect(isEmailSendFailure(null)).toBe(false);
+    expect(isEmailSendFailure(undefined)).toBe(false);
+    expect(isEmailSendFailure('')).toBe(false);
+  });
+});

--- a/packages/web/src/lib/auth-email-failure.ts
+++ b/packages/web/src/lib/auth-email-failure.ts
@@ -1,0 +1,25 @@
+/**
+ * Whether a Supabase auth error is GoTrue failing to SEND the auth email —
+ * a broken mailer (bad SMTP credentials, a DNS record the sending domain
+ * needs but doesn't have, the relay unreachable) — as opposed to any other
+ * kind of `AuthApiError`.
+ *
+ * GoTrue never gives this failure a stable `code`; every mail failure comes
+ * back as a generic `AuthApiError`, and the only thing that names it is the
+ * message, always prefixed "Error sending <kind> email" (confirmation, magic
+ * link, recovery, invite) followed by whatever the underlying transport
+ * reported. That prefix is the one thing this function can rely on staying
+ * stable across mail providers and failure shapes — matching on "smtp" alone
+ * misses a DNS-resolution failure to the mail relay (`dial tcp: lookup … no
+ * such host` never mentions SMTP), which is exactly the failure this exists
+ * to catch.
+ *
+ * Shared by `auth-errors.ts` (user-facing copy) and `auth-telemetry.ts` (the
+ * bounded `auth.error_code`) so the two can never classify the same error
+ * differently.
+ */
+export function isEmailSendFailure(message: string | null | undefined): boolean {
+  if (!message) return false;
+  const msg = message.toLowerCase();
+  return (msg.includes('error sending') && msg.includes('email')) || msg.includes('smtp') || msg.includes('delivery');
+}

--- a/packages/web/src/lib/auth-errors.spec.ts
+++ b/packages/web/src/lib/auth-errors.spec.ts
@@ -104,6 +104,16 @@ describe('friendlyAuthError', () => {
     );
   });
 
+  // The failure that motivated this: a DNS-misconfigured sending domain fails
+  // the mail relay's lookup, and that error text never mentions "smtp".
+  it('maps a DNS-resolution mailer failure that never mentions smtp', () => {
+    expect(
+      friendlyAuthError({
+        message: 'Error sending confirmation email: dial tcp: lookup mail.example.com: no such host',
+      }),
+    ).toContain("couldn't deliver");
+  });
+
   it('falls back to the capitalised raw message', () => {
     expect(friendlyAuthError({ message: 'something odd happened' })).toBe(
       'Something odd happened',

--- a/packages/web/src/lib/auth-errors.ts
+++ b/packages/web/src/lib/auth-errors.ts
@@ -13,6 +13,7 @@
  */
 
 import { MIN_PASSWORD_LENGTH } from './password-policy';
+import { isEmailSendFailure } from './auth-email-failure';
 
 /**
  * Structural subset of `@supabase/supabase-js`'s `AuthError` this module
@@ -111,8 +112,9 @@ export function friendlyAuthError(error: AuthErrorLike): string {
     return 'Sign-up is currently disabled. Please contact the administrator.';
   }
 
-  // -- Email provider rejected delivery (bounced, no such domain, ...) ------
-  if (msg.includes('smtp') || msg.includes('delivery')) {
+  // -- Email provider rejected delivery, or the mailer itself is broken -----
+  // (bounced, no such domain, unreachable SMTP relay, DNS lookup failure, ...)
+  if (isEmailSendFailure(msg)) {
     return "We couldn't deliver an email to that address. Please check the address and try again.";
   }
 

--- a/packages/web/src/lib/auth-telemetry.spec.ts
+++ b/packages/web/src/lib/auth-telemetry.spec.ts
@@ -1,6 +1,33 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-import { authErrorCode, authIntent, type AuthMethod } from './auth-telemetry';
+// Mirrors `lib/analytics/track.spec.ts`'s stand-in: records the wire shape
+// `emit()` hands `sendEvent` rather than asserting against the real SDK, which
+// never runs in a unit test.
+vi.mock('@dash0/sdk-web', () => {
+  const calls: Array<{ name: string; attributes: Record<string, string> }> = [];
+  return {
+    sendEvent: (name: string, options: { attributes: Record<string, string> }) => {
+      calls.push({ name, attributes: options.attributes });
+    },
+    __calls: calls,
+  };
+});
+
+import {
+  authErrorCode,
+  authIntent,
+  AUTH_PENDING_EVENT,
+  reportAuthPending,
+  type AuthMethod,
+} from './auth-telemetry';
+
+const { __calls: calls } = (await import('@dash0/sdk-web')) as unknown as {
+  __calls: Array<{ name: string; attributes: Record<string, string> }>;
+};
+
+beforeEach(() => {
+  calls.length = 0;
+});
 
 describe('authErrorCode', () => {
   it('prefers the stable Supabase error code', () => {
@@ -22,6 +49,22 @@ describe('authErrorCode', () => {
   it('reports unknown for null and undefined', () => {
     expect(authErrorCode(null)).toBe('unknown');
     expect(authErrorCode(undefined)).toBe('unknown');
+  });
+
+  // GoTrue gives a broken mailer no stable `code` — only a message. Without
+  // this, a DNS-misconfigured sending domain and every other server-side auth
+  // fault reported the same generic `name`, with no way to alert on the
+  // mailer specifically.
+  it('classifies a broken mailer as email_send_failed even with no stable code', () => {
+    expect(
+      authErrorCode({ name: 'AuthApiError', message: 'Error sending confirmation email' }),
+    ).toBe('email_send_failed');
+    expect(
+      authErrorCode({
+        name: 'AuthApiError',
+        message: 'Error sending confirmation email: dial tcp: lookup mail.example.com: no such host',
+      }),
+    ).toBe('email_send_failed');
   });
 });
 
@@ -65,5 +108,21 @@ describe('authIntent', () => {
     for (const method of methods) {
       expect(authIntent(method)).toBeTruthy();
     }
+  });
+});
+
+describe('reportAuthPending', () => {
+  // This is the one event on the "check your inbox" branch — see the
+  // docblock at its definition for why neither success nor failure fires
+  // there, and why that used to mean nothing did.
+  it('emits auth.pending with the method and its intent', () => {
+    reportAuthPending('email_password_signup');
+
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.name).toBe(AUTH_PENDING_EVENT);
+    expect(calls[0]!.attributes).toEqual({
+      'auth.method': 'email_password_signup',
+      'auth.intent': 'signup',
+    });
   });
 });

--- a/packages/web/src/lib/auth-telemetry.ts
+++ b/packages/web/src/lib/auth-telemetry.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { sendEvent } from '@dash0/sdk-web';
+import { isEmailSendFailure } from './auth-email-failure';
 
 /**
  * Discrete telemetry for the authentication funnel.
@@ -102,6 +103,7 @@ export const AUTH_ATTEMPT_EVENT = 'auth.attempt';
 export const AUTH_SUCCESS_EVENT = 'auth.success';
 export const AUTH_FAILURE_EVENT = 'auth.failure';
 export const AUTH_OPTION_SELECTED_EVENT = 'auth.option_selected';
+export const AUTH_PENDING_EVENT = 'auth.pending';
 
 /** The SDK's own event options, derived from `sendEvent` so the two cannot drift. */
 type AuthEventOptions = NonNullable<Parameters<typeof sendEvent>[1]>;
@@ -131,6 +133,7 @@ function emit(name: string, options: AuthEventOptions): void {
 interface AuthErrorLike {
   code?: string | undefined;
   name?: string | undefined;
+  message?: string | undefined;
 }
 
 /**
@@ -139,15 +142,26 @@ interface AuthErrorLike {
  * Supabase populates `code` for the errors that have a stable contract
  * (`invalid_credentials`, `email_not_confirmed`, …) and leaves it undefined for
  * transport-level ones, where `name` is the next most stable thing. The MESSAGE
- * is deliberately never used: it is prose, it is localised, and it can embed the
- * address that was typed — unbounded and PII-bearing, the two things a grouping
- * key must not be.
+ * itself is deliberately never reported verbatim: it is prose, it is localised,
+ * and it can embed the address that was typed — unbounded and PII-bearing, the
+ * two things a grouping key must not be.
+ *
+ * One exception: a broken mailer (bad SMTP credentials, a missing DNS record on
+ * the sending domain, an unreachable relay) never gets a `code` from GoTrue, and
+ * `name` is just the same generic `AuthApiError` every other server-side auth
+ * failure carries — so without this check that entire failure class collapsed
+ * into a bucket indistinguishable from any other API error, with no way to alert
+ * on it specifically. `isEmailSendFailure` (`auth-email-failure.ts`) recognises
+ * it from the message's stable "Error sending … email" prefix — the one part of
+ * the message that is neither prose nor PII — and reports the bounded
+ * `email_send_failed` instead.
  *
  * Total function: any shape of input yields a usable string, because telemetry
  * must never be the reason an auth handler throws.
  */
 export function authErrorCode(error: AuthErrorLike | null | undefined): string {
   if (!error) return 'unknown';
+  if (isEmailSendFailure(error.message)) return 'email_send_failed';
   return error.code ?? error.name ?? 'unknown';
 }
 
@@ -217,6 +231,43 @@ export function reportAuthFailure(method: AuthMethod, error: AuthErrorLike | nul
 export function reportAuthOptionSelected(method: AuthMethod): void {
   emit(AUTH_OPTION_SELECTED_EVENT, {
     title: `Auth option selected: ${method}`,
+    attributes: { 'auth.method': method, 'auth.intent': authIntent(method) },
+  });
+}
+
+/**
+ * Record that a signup reached the "check your inbox" screen with neither an
+ * error nor a session — `email_password_signup`'s third branch
+ * (`LoginButton.tsx`), taken when the project requires confirmation.
+ *
+ * ## Why this exists
+ *
+ * That branch is a genuine blind spot, and by design: Supabase returns the
+ * exact same response — no error, no session — whether this is a brand-new
+ * signup awaiting confirmation or a resubmission to an already-registered
+ * address, so reporting `auth.success` there would overstate signups *and*
+ * leak the distinction the screen exists to hide (see the comment at the call
+ * site). The result is that this event, `reportAuthFailure` and
+ * `reportAuthSuccess` are jointly exhaustive over the outcomes this document
+ * can observe — but none of the three previously fired here, so a signup that
+ * fully succeeded at the API layer and was then never delivered (a
+ * misconfigured DNS record on the sending domain, an unreachable SMTP relay,
+ * a silently-dropped async send) looked, in the browser's own telemetry,
+ * identical to one that never happened at all.
+ *
+ * This event does not — cannot — prove the email was delivered; Supabase
+ * never tells the browser that. What it proves is the one fact the browser
+ * *can* attest to: the signup reached this state. Paired with the
+ * `auth.success` events for `auth.method = email_confirmation`
+ * (`WelcomeContent.tsx`, emitted when the link is actually opened), a
+ * sustained gap between the two — many pending, few completions, over a
+ * window wider than a normal inbox-checking delay — is the regression signal
+ * for exactly the failure mode this event exists to catch, and the only one
+ * this funnel can offer for it.
+ */
+export function reportAuthPending(method: AuthMethod): void {
+  emit(AUTH_PENDING_EVENT, {
+    title: `Auth pending: ${method}`,
     attributes: { 'auth.method': method, 'auth.intent': authIntent(method) },
   });
 }


### PR DESCRIPTION
## Why

A signup that succeeds at the API layer but never gets its confirmation email delivered (broken SMTP credentials, a missing DNS record on the sending domain, an unreachable relay) previously produced zero telemetry — that branch deliberately reports neither success nor failure, to avoid leaking whether the address is already registered.

## What changed

- Add `auth.pending` (`reportAuthPending`), emitted on that silent branch so the population is at least countable — paired against `email_confirmation` successes, a sustained gap is the regression signal for a silently-failing mailer
- Classify GoTrue's unstable `"Error sending ... email"` mailer errors into a bounded `auth.error_code = email_send_failed` via a shared `isEmailSendFailure` helper, instead of the generic `AuthApiError` bucket
- Update `docs/otel.md`'s auth-funnel section to match

## How to verify

- `pnpm nx test web -- --run src/lib/auth-telemetry.spec.ts src/lib/auth-errors.spec.ts src/lib/auth-email-failure.spec.ts`


---
_Generated by [Claude Code](https://claude.ai/code/session_01EPhRgh7wnYVDp3DNgVEKjZ)_