### PR TITLE
feat(cli): add digest-contract-doc obligations-map entry

### DIFF
--- a/packages/cli/src/shared/obligations-map.mjs
+++ b/packages/cli/src/shared/obligations-map.mjs
@@ -180,6 +180,18 @@ export const SURFACE_PARTNER_MAP = [
     note: 'The flag table and per-command help in bin/lorekit.mjs is the origin of every flag claim; docs/cli.md, the package README (prose AND its flag table) and CLAUDE.md each restate it. Found by running this command against its own changed-set while changing the meaning of --strict: nothing fired, because the map covered every generated surface and no hand-written one. A path proxy, not a content predicate — bin/lorekit.mjs changes for reasons unrelated to flags — so advisory by construction, like error-code-doc.',
   },
   {
+    id: 'digest-contract-doc',
+    state: 'advisory',
+    owner: '@mthines',
+    added: '2026-09-01',
+    reviewBy: '2026-12-01',
+    match: 'packages/cli/src/core/lessons.mjs',
+    obliges: ['packages/cli/skill/lorekit-setup/rules/ci-state-records.md'],
+    cluster: 'copies-a-claim',
+    guard: null,
+    note: 'lessons.mjs owns the SessionStart digest contract (fetchLessons\' isGeneralLesson kind filter); ci-state-records.md documents that contract for authors of non-lesson records. This is the second instance of the same class in two consecutive changes — the first was cli-flag-doc (bin/lorekit.mjs → the docs copying its flag claims) — which is the recurrence the whole compile pipeline exists to notice. Advisory, no guard: lessons.mjs changes for many reasons unrelated to the digest contract, so this is a path proxy, not a content predicate.',
+  },
+  {
     id: 'perf-index',
     state: 'advisory',
     owner: '@mthines',

--- a/packages/cli/test/obligations.test.mjs
+++ b/packages/cli/test/obligations.test.mjs
@@ -420,7 +420,15 @@ describe('recurrence clusters', () => {
     const members = clusterMembers('sibling-set', SURFACE_PARTNER_MAP);
     assert.deepEqual(members, ['docs-section', 'plugin-skill', 'perf-index']);
     const copies = clusterMembers('copies-a-claim', SURFACE_PARTNER_MAP);
-    assert.equal(new Set(copies).size, copies.length, 'generated rows must not duplicate an id');
+    assert.deepEqual(copies, [
+      'edge-mirror',
+      'edge-mirror-core',
+      'tool-catalog',
+      'llms-generated',
+      'cli-flag-doc',
+      'digest-contract-doc',
+      'error-code-doc',
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary

PR 1 of 3 (see task context — the other two land as separate PRs, opened after this one is reviewed).

`91334fd` changed the SessionStart digest contract: `isGeneralLesson` in `packages/cli/src/core/lessons.mjs` now hard-excludes any entry whose `kind` isn't `null`/`lesson`. `skill/lorekit-setup/rules/ci-state-records.md` documents that contract for authors of non-lesson records (state records, bus/signal kinds). No `obligations-map.mjs` entry pointed from the implementation to the doc, so nothing flagged the doc when the contract changed.

This is the second instance of the same recurrence class (`copies-a-claim`) in two consecutive changes — the first was `cli-flag-doc` (`bin/lorekit.mjs` → the docs copying its flag claims). That recurrence is the signal the whole compile pipeline exists to notice, so the entry's `note` says so.

- Adds `id: 'digest-contract-doc'`, `match: packages/cli/src/core/lessons.mjs`, `obliges: [skill/lorekit-setup/rules/ci-state-records.md]` (the only rule file that currently documents SessionStart injection behavior — confirmed by grep, not guessed)
- `cluster: 'copies-a-claim'`, `guard: null`, `state: 'advisory'` (a path proxy — `lessons.mjs` changes for many reasons unrelated to the digest contract) — the guard/state coupling is enforced by `obligations.test.mjs`
- Full lifecycle metadata (`owner`, `added`, `reviewBy`) matching every other entry
- Also pins `copies-a-claim` cluster membership in `obligations.test.mjs` with an exact `deepEqual`, mirroring the `sibling-set` assertion — absorbed from review feedback, since the prior uniqueness-only check left the new entry invisible to the suite (deleting it still passed 44/44 before the fix)

No production behavior change — a data-only addition to the Surface-Partner Map plus a test-strength fix.

## Test plan

- [x] `node --test packages/cli/test/obligations.test.mjs` — 44/44 pass
- [x] `node --test packages/cli/test/*.test.mjs` — 1192/1202 pass, same 10 pre-existing loopback-HTTP-shaped failures as `git stash`, no new failures
- [x] `echo "packages/cli/src/core/lessons.mjs" | node packages/cli/bin/lorekit.mjs obligations` — fires the new entry, cites `ci-state-records.md`
- [x] Deleting the entry now fails the suite (43/44) — confirms the new `deepEqual` actually pins it, where it previously passed vacuously (44/44)
- [x] Self-check: `git diff --name-only origin/main... | node packages/cli/bin/lorekit.mjs obligations` (weak evidence per the task notes, since `obligations-map.mjs` itself matches no entry — the functional check above is the real verification)
