### PR TITLE
Extract web-preview comment renderer to a testable module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
           # dependency-free like its siblings, so the string is duplicated and
           # held in place by scripts/ci/web-preview-filter.test.mjs — which fails
           # when any of the three drifts.
-          if printf '%s\n' "$CHANGED" | grep -qE '^(packages/web/|packages/schemas/|package\.json$|nx\.json$|\.github/actions/vercel-preview-deploy/|\.github/workflows/(web-preview|web-preview-deploy)\.yml$)'; then
+          if printf '%s\n' "$CHANGED" | grep -qE '^(packages/web/|packages/schemas/|package\.json$|nx\.json$|scripts/ci/web-preview-comment\.mjs$|\.github/actions/vercel-preview-deploy/|\.github/workflows/(web-preview|web-preview-deploy)\.yml$)'; then
             echo "web_preview=true" >> "$GITHUB_OUTPUT"
           else
             echo "web_preview=false" >> "$GITHUB_OUTPUT"
@@ -134,7 +134,11 @@ jobs:
           # three agree, so it must run when ANY of them moves.
           # `scripts/ci/web-preview-filter` (no extension) matches both the module
           # and its `.test.mjs`, same trick as the migration guards above.
-          if printf '%s\n' "$CHANGED" | grep -qE '^(scripts/ci/web-preview-filter|\.github/workflows/(ci|web-preview-deploy)\.yml$)'; then
+          # `scripts/ci/web-preview-comment` rides along: it is the OTHER
+          # preview-machinery module unit-tested by this job, and its test reads
+          # web-preview-deploy.yml (already on this filter) to prove the workflow
+          # still renders the comment through it.
+          if printf '%s\n' "$CHANGED" | grep -qE '^(scripts/ci/web-preview-(filter|comment)|\.github/workflows/(ci|web-preview-deploy)\.yml$)'; then
             echo "preview_filter=true" >> "$GITHUB_OUTPUT"
           else
             echo "preview_filter=false" >> "$GITHUB_OUTPUT"
@@ -528,6 +532,14 @@ jobs:
 
       - name: Unit-test the web-preview path filter
         run: node --test scripts/ci/web-preview-filter.test.mjs
+
+      # The sticky comment's BODY, for the same reason: it is a Vercel-shaped
+      # contract with tooling outside this repo (a `| Project | Deployment |
+      # Actions | Updated |` table whose Actions cell carries `[Preview](…)`),
+      # plus this repo's own `sha=` marker that the incremental redeploy check
+      # reads back. Both are held by assertion rather than by discipline.
+      - name: Unit-test the web-preview comment body
+        run: node --test scripts/ci/web-preview-comment.test.mjs
 
   # ── Edge typecheck — `deno check` over every Edge Function, ratcheted ────────
   #    Until this job existed, `supabase/functions/**` was typechecked by

--- a/.github/workflows/web-preview-deploy.yml
+++ b/.github/workflows/web-preview-deploy.yml
@@ -65,7 +65,7 @@ on:
           checkout, that job runs before any toolchain setup).
         required: false
         type: string
-        default: '^(packages/web/|packages/schemas/|package\.json$|nx\.json$|\.github/actions/vercel-preview-deploy/|\.github/workflows/(web-preview|web-preview-deploy)\.yml$)'
+        default: '^(packages/web/|packages/schemas/|package\.json$|nx\.json$|scripts/ci/web-preview-comment\.mjs$|\.github/actions/vercel-preview-deploy/|\.github/workflows/(web-preview|web-preview-deploy)\.yml$)'
     secrets:
       # Not `required: true`: on a fork PR these resolve to empty strings, and
       # the guard below turns that into an announced skip rather than a red X.
@@ -251,9 +251,17 @@ jobs:
           # Stable per-PR alias, re-pointed each run (like Vercel's branch URL).
           alias-label: pr-${{ inputs.pr-number }}
 
-      # Post (or update) a single sticky comment — a Vercel-style status table
+      # Post (or update) a single sticky comment — a VERCEL-SHAPED status table
       # with the stable "latest" preview link plus the immutable per-commit link.
       # Idempotent: it edits its own marker comment on re-run, never stacks.
+      #
+      # The body is built by scripts/ci/web-preview-comment.mjs, not inline here,
+      # because the shape is a contract with tooling OUTSIDE this repo: anything
+      # that scrapes a PR for its preview URL was written against Vercel's
+      # comment — its four-column header (Project / Deployment / Actions /
+      # Updated) and the `[Preview](…)` link in the Actions cell — so the columns
+      # cannot drift on a whim. That module is unit-tested by its own test file,
+      # which also asserts this workflow still renders through it.
       - name: Comment preview URL on the PR
         if: steps.gate.outputs.deploy == 'true' && steps.preview.outcome == 'success'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -265,29 +273,23 @@ jobs:
           FORCED: ${{ inputs.force }}
         with:
           script: |
-            const fullSha = process.env.PR_SHA;
-            // Stable find-key; the stored line also carries the full SHA so the
-            // "Decide" step above can diff the next commit against this deploy.
-            const findMarker = '<!-- lorekit-web-preview';
-            const markerLine = `<!-- lorekit-web-preview sha=${fullSha} -->`;
+            const { pathToFileURL } = require('node:url');
+            const { WEB_PREVIEW_MARKER, renderReadyComment } = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/scripts/ci/web-preview-comment.mjs`).href
+            );
             const commitUrl = process.env.PREVIEW_URL;               // immutable, this commit
             const aliasUrl = process.env.ALIAS_URL || '';            // stable, latest (may be empty)
-            const previewUrl = aliasUrl || commitUrl;                // fall back if aliasing was unavailable
-            const forced = process.env.FORCED === 'true';
-            const sha = fullSha.slice(0, 7);
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            // github-script runs in a real Node runner, so Date is available here.
-            const updated = new Date().toISOString().replace('T', ' ').slice(0, 16);
-            const body = [
-              markerLine,
-              'The dashboard preview for this PR — redeployed on each push that changes the web app.',
-              '',
-              '| Name | Status | Preview | Deployment (this commit) | Updated (UTC) |',
-              '| :--- | :----- | :------ | :----------------------- | :------------ |',
-              `| **lorekit** | ✅ Ready | [Visit Preview](${previewUrl}) | [\`${sha}\`](${commitUrl}) | ${updated} |`,
-              '',
-              `<sub>**Preview** always points at the PR's latest commit; **Deployment** is this exact commit${aliasUrl ? '' : ' (stable alias unavailable this run — see workflow logs)'}. · Comment \`/web-preview\` to force a redeploy. · ${forced ? 'Deployed on demand. · ' : ''}[Workflow logs](${runUrl})</sub>`,
-            ].join('\n');
+            const body = renderReadyComment({
+              sha: process.env.PR_SHA,
+              previewUrl: aliasUrl || commitUrl,                     // fall back if aliasing was unavailable
+              commitUrl,
+              aliasAvailable: Boolean(aliasUrl),
+              forced: process.env.FORCED === 'true',
+              runUrl: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+            // Stable find-key; the rendered marker also carries the full SHA so
+            // the "Decide" step above can diff the next commit against this deploy.
+            const findMarker = WEB_PREVIEW_MARKER;
             const { owner, repo } = context.repo;
             const issue_number = Number(process.env.PR_NUMBER);
             const comments = await github.paginate(github.rest.issues.listComments, {
@@ -307,7 +309,7 @@ jobs:
       # captured reason to the PR so the failure is visible where the work is.
       #
       # Reuses the same sticky marker as the success comment so a previously-green
-      # preview flips to "❌ Failed" in place rather than stacking — but writes NO
+      # preview flips to "Error" in place rather than stacking — but writes NO
       # `sha=` in the marker, on purpose: the "Decide" step keys its incremental
       # skip off that sha, so omitting it makes the next web push RE-ATTEMPT the
       # deploy instead of treating this failed commit as already deployed.
@@ -320,31 +322,20 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const sha = process.env.PR_SHA.slice(0, 7);
-            const findMarker = '<!-- lorekit-web-preview';
-            const markerLine = '<!-- lorekit-web-preview -->';
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const { pathToFileURL } = require('node:url');
+            const { WEB_PREVIEW_MARKER, renderErrorComment } = await import(
+              pathToFileURL(`${process.env.GITHUB_WORKSPACE}/scripts/ci/web-preview-comment.mjs`).href
+            );
             let reason = '';
             try {
               reason = fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/vercel-deploy-error.txt`, 'utf8').trim();
-            } catch { /* no reason file — fall back to a generic message */ }
-            const detail = reason || 'The Vercel deployment did not complete. See the workflow logs for the CLI output.';
-            const updated = new Date().toISOString().replace('T', ' ').slice(0, 16);
-            const body = [
-              markerLine,
-              'The dashboard preview for this PR — redeployed on each push that changes the web app.',
-              '',
-              '| Name | Status | Preview | Deployment (this commit) | Updated (UTC) |',
-              '| :--- | :----- | :------ | :----------------------- | :------------ |',
-              `| **lorekit** | ❌ Failed | — | \`${sha}\` | ${updated} |`,
-              '',
-              '> [!WARNING]',
-              '> **The preview deploy for this commit failed — no preview is available.**',
-              '>',
-              ...detail.split('\n').map((l) => `> ${l}`),
-              '',
-              `<sub>A blocked deployment is most often the commit author's email not matching a GitHub account with project access. Fix the cause, then push again or comment \`/web-preview\` to retry. · [Workflow logs](${runUrl})</sub>`,
-            ].join('\n');
+            } catch { /* no reason file — the renderer falls back to a generic message */ }
+            const body = renderErrorComment({
+              sha: process.env.PR_SHA,
+              detail: reason,
+              runUrl: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+            const findMarker = WEB_PREVIEW_MARKER;
             const { owner, repo } = context.repo;
             const issue_number = Number(process.env.PR_NUMBER);
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number });

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,7 +34,11 @@ and local operations.
 > this, mirror the flag (or disable Git deployments in the Vercel dashboard) or
 > you will double-deploy.
 >
-> The sticky comment is a Vercel-style status table exposing **both** URLs, like
+> The sticky comment reproduces **Vercel's own comment structure** — the same
+> `| Project | Deployment | Actions | Updated |` table, a `[Ready](…)` status
+> cell, a `[Preview](…)` link in the Actions cell, and a `<relative-time>`
+> timestamp — because that shape is what external tooling scrapes to find a PR's
+> preview URL. It exposes **both** URLs, like
 > the Git integration did: a **stable** `Preview` link (a `lorekit-pr-<n>-<scope>`
 > alias the job re-points to the newest deployment via `vercel alias set` — which
 > re-points, not deploys, so it costs no quota) and the **immutable** per-commit
@@ -117,6 +121,37 @@ the same comment — only the decision to deploy differs. The build itself is th
 `.github/actions/vercel-preview-deploy` composite action, shared with
 `deploy.yml` and `preview.yml`.
 
+#### The sticky comment is Vercel-shaped on purpose
+
+The comment body is rendered by
+[`scripts/ci/web-preview-comment.mjs`](../scripts/ci/web-preview-comment.mjs) and
+deliberately mirrors the comment Vercel's Git integration used to post, because
+its structure is a **contract with tooling outside this repo**: anything that
+scrapes a PR for "where is the preview?" was written against Vercel's table.
+Reproduced from it, and each line load-bearing for some parser:
+
+- the four column headers in Vercel's order, with its alignment row —
+  `| Project | Deployment | Actions | Updated |`;
+- a `![Ready](…ready.svg) [Ready](<deployment>)` **Deployment** cell, linking the
+  immutable per-commit build;
+- a `[Preview](<url>)` link as the **Actions** cell — the anchor most scrapers
+  key on, and the reason the columns cannot simply be renamed;
+- a `<relative-time datetime="…">` **Updated** cell, which GitHub renders live.
+
+A failed deploy reuses the same table with an `Error` status and no preview link.
+Two things are *not* copied: Vercel's leading `[vc]: #<hash>:<base64>` metadata
+line (a signed payload describing real Vercel projects — forging one would make
+the comment lie to anything that decodes it), and the marker, which stays this
+repo's own `<!-- lorekit-web-preview sha=<40 hex> -->`. That marker is its own
+contract: the incremental check below reads the SHA back out of it, and a FAILED
+deploy writes the marker *without* a `sha=` so the next web push re-attempts
+rather than treating the failed commit as deployed.
+
+`scripts/ci/web-preview-comment.test.mjs` pins all of it — including the
+`[Preview](…)` extraction a scraper performs — and asserts the workflow still
+renders through the module instead of inlining a table again. It runs in the
+`preview-filter` CI job.
+
 **Two gates decide whether a push spends a deployment** (the Vercel Hobby plan
 allows 100/day):
 
@@ -135,8 +170,11 @@ The filter answers one question: *can this file change what the deployed
 dashboard looks like, or how it gets deployed?* It covers `packages/web/`,
 `packages/schemas/` (a `workspace:*` dependency the dashboard compiles in), the
 **root** `package.json` (pnpm overrides reach into the dashboard's dependency
-graph), `nx.json`, the `vercel-preview-deploy` composite action, and
-`web-preview.yml` / `web-preview-deploy.yml`.
+graph), `nx.json`, the `vercel-preview-deploy` composite action,
+`web-preview.yml` / `web-preview-deploy.yml`, and
+`scripts/ci/web-preview-comment.mjs` (the sticky comment's renderer — the only
+way to see its real output is to deploy; its `.test.mjs` is *not* on the filter,
+since a test-only edit changes no output).
 
 Two paths are deliberately **off** it, because both were spending deployments on
 a dashboard nobody had changed:
@@ -163,7 +201,9 @@ written as an extended regex so the one string works under both `grep -E`
 checkout and so cannot import the module). Neither consumer can import it, so
 both carry a copy and `scripts/ci/web-preview-filter.test.mjs` holds them to it:
 the `preview-filter` CI job fails on drift in either copy, and cross-checks that
-`grep -E` and `RegExp` agree on every case.
+`grep -E` and `RegExp` agree on every case. That job also unit-tests the sticky
+comment's body (above) — the other piece of preview machinery `nx affected` never
+sees, since `scripts/**` is outside the task graph.
 
 To ask why a specific PR did or didn't get a preview:
 

--- a/scripts/ci/web-preview-comment.mjs
+++ b/scripts/ci/web-preview-comment.mjs
@@ -1,0 +1,190 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Canonical renderer for the sticky "web preview" PR comment.
+//
+// The body is deliberately shaped like VERCEL's own preview comment, because
+// tooling reads it. Anything that scrapes a PR for "where is the preview?" was
+// written against Vercel's table — it looks for the `| Project | Deployment |
+// Actions | Updated |` header and pulls the URL out of the `[Preview](…)` link
+// in the Actions column. Our previous table said `| Name | Status | Preview |
+// Deployment (this commit) | Updated (UTC) |` with a `[Visit Preview](…)` cell,
+// which is the same information in a shape none of that logic matches — so the
+// preview existed and nothing could find it.
+//
+// What is REPRODUCED from Vercel's format (each line is load-bearing for a
+// parser, not decoration):
+//   - the four column headers, in order, with Vercel's own alignment row;
+//   - a `![Ready](…ready.svg) [Ready](<deployment>)` Deployment cell;
+//   - a `[Preview](<url>)` link as the Actions cell — the anchor most scrapers
+//     key on, and the reason the columns could not simply be renamed;
+//   - a `<relative-time datetime="…">` Updated cell (GitHub renders it live).
+//
+// What is deliberately NOT reproduced: Vercel's leading `[vc]: #<hash>:<base64>`
+// metadata line. That is a signed payload describing real Vercel projects and
+// deployment ids; forging one would make our comment lie to anything that
+// decodes it (Vercel's own bot included). Our HTML marker below is the identity
+// this workflow keys on, and it is kept exactly as it was — the "Decide" step in
+// web-preview-deploy.yml reads `sha=<40 hex>` out of it to decide whether a
+// redeploy is needed, so the marker's shape is a contract, not a comment.
+//
+// Consumed by .github/workflows/web-preview-deploy.yml (both the success and the
+// failure comment) via a dynamic import from the checkout, and unit-tested by
+// web-preview-comment.test.mjs — the format is machine-readable, so it is held
+// by assertions rather than by discipline.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Stable find-key for the sticky comment — matches with and without a `sha=`. */
+export const WEB_PREVIEW_MARKER = '<!-- lorekit-web-preview';
+
+/** Vercel's status icons, hotlinked exactly as its own comment does. */
+const STATUS_ICON = {
+  ready: 'https://vercel.com/static/status/ready.svg',
+  error: 'https://vercel.com/static/status/error.svg',
+};
+
+/** The project name in the Project column. */
+const PROJECT = 'lorekit';
+
+const TABLE_HEADER = [
+  '| Project | Deployment | Actions | Updated |',
+  '| :--- | :----- | :------ | :------ |',
+];
+
+const MONTHS = [
+  'Jan',
+  'Feb',
+  'Mar',
+  'Apr',
+  'May',
+  'Jun',
+  'Jul',
+  'Aug',
+  'Sep',
+  'Oct',
+  'Nov',
+  'Dec',
+];
+
+/**
+ * The literal text inside `<relative-time>`, in Vercel's phrasing
+ * (`Sep 1, 2026 7:17pm UTC`). GitHub replaces it with a live relative string
+ * when it renders the element, so this is the fallback anyone sees in a raw
+ * body, an email notification, or an API read.
+ *
+ * @param {Date} at
+ * @returns {string}
+ */
+export function formatUpdatedLabel(at) {
+  const hours24 = at.getUTCHours();
+  const meridiem = hours24 < 12 ? 'am' : 'pm';
+  const hours = hours24 % 12 === 0 ? 12 : hours24 % 12;
+  const minutes = String(at.getUTCMinutes()).padStart(2, '0');
+  return `${MONTHS[at.getUTCMonth()]} ${at.getUTCDate()}, ${at.getUTCFullYear()} ${hours}:${minutes}${meridiem} UTC`;
+}
+
+/**
+ * The Updated cell — a GitHub `<relative-time>` element, as Vercel emits.
+ *
+ * @param {Date} at
+ * @returns {string}
+ */
+function updatedCell(at) {
+  return `<relative-time datetime="${at.toISOString()}">${formatUpdatedLabel(at)}</relative-time>`;
+}
+
+/**
+ * The marker line. A successful deploy records the full head SHA in it; a FAILED
+ * one deliberately does not, so the next web push re-attempts the deploy instead
+ * of treating the failed commit as already deployed.
+ *
+ * @param {string | null} sha - full 40-char SHA, or null to omit it.
+ * @returns {string}
+ */
+function markerLine(sha) {
+  return sha ? `${WEB_PREVIEW_MARKER} sha=${sha} -->` : `${WEB_PREVIEW_MARKER} -->`;
+}
+
+const INTRO = 'The dashboard preview for this PR — redeployed on each push that changes the web app.';
+
+function assertFullSha(sha) {
+  if (!/^[0-9a-f]{40}$/.test(String(sha ?? ''))) {
+    throw new Error(`web-preview comment: expected a full 40-char SHA, got '${sha}'`);
+  }
+}
+
+/**
+ * The comment for a SUCCESSFUL preview deploy.
+ *
+ * @param {object} input
+ * @param {string} input.sha            Full 40-char SHA of the deployed head.
+ * @param {string} input.previewUrl     Stable "latest commit" URL (the `pr-<n>` alias),
+ *                                      or the immutable one when aliasing was unavailable.
+ * @param {string} input.commitUrl      Immutable per-deployment URL for THIS commit.
+ * @param {boolean} input.aliasAvailable Whether the stable alias was set this run.
+ * @param {boolean} input.forced        Whether this run came from `/web-preview`.
+ * @param {string} input.runUrl         Workflow-run URL.
+ * @param {Date} [input.at]             Timestamp for the Updated cell (defaults to now).
+ * @returns {string} The full comment body.
+ */
+export function renderReadyComment({
+  sha,
+  previewUrl,
+  commitUrl,
+  aliasAvailable,
+  forced,
+  runUrl,
+  at = new Date(),
+}) {
+  assertFullSha(sha);
+  if (!previewUrl || !commitUrl) {
+    throw new Error('web-preview comment: previewUrl and commitUrl are both required');
+  }
+  const short = sha.slice(0, 7);
+  const aliasNote = aliasAvailable
+    ? ''
+    : ' (the stable alias was unavailable this run, so **Preview** points at this exact build too — see the workflow logs)';
+  return [
+    markerLine(sha),
+    INTRO,
+    '',
+    ...TABLE_HEADER,
+    `| **${PROJECT}** | ![Ready](${STATUS_ICON.ready}) [Ready](${commitUrl}) | [Preview](${previewUrl}) | ${updatedCell(at)} |`,
+    '',
+    `<sub>**Preview** always points at this PR's latest commit; **Deployment** is the immutable build of [\`${short}\`](${commitUrl})${aliasNote}. · Comment \`/web-preview\` to force a redeploy.${forced ? ' · Deployed on demand.' : ''} · [Workflow logs](${runUrl})</sub>`,
+  ].join('\n');
+}
+
+/**
+ * The comment for a FAILED preview deploy — same table, `Error` status, no
+ * preview link, plus the captured reason so a block (most often the commit
+ * author's email not matching a GitHub account with project access) is visible
+ * on the PR instead of only in a job nobody opens.
+ *
+ * @param {object} input
+ * @param {string} input.sha       Full 40-char SHA of the head that failed.
+ * @param {string} input.detail    Captured failure reason (may be multi-line).
+ * @param {string} input.runUrl    Workflow-run URL.
+ * @param {Date} [input.at]        Timestamp for the Updated cell (defaults to now).
+ * @returns {string} The full comment body.
+ */
+export function renderErrorComment({ sha, detail, runUrl, at = new Date() }) {
+  assertFullSha(sha);
+  const short = sha.slice(0, 7);
+  const reason =
+    (detail ?? '').trim() ||
+    'The Vercel deployment did not complete. See the workflow logs for the CLI output.';
+  return [
+    // No `sha=` on purpose — see markerLine().
+    markerLine(null),
+    INTRO,
+    '',
+    ...TABLE_HEADER,
+    `| **${PROJECT}** | ![Error](${STATUS_ICON.error}) Error | — | ${updatedCell(at)} |`,
+    '',
+    '> [!WARNING]',
+    `> **The preview deploy for \`${short}\` failed — no preview is available.**`,
+    '>',
+    ...reason.split('\n').map((line) => `> ${line}`),
+    '',
+    `<sub>A blocked deployment is most often the commit author's email not matching a GitHub account with project access. Fix the cause, then push again or comment \`/web-preview\` to retry. · [Workflow logs](${runUrl})</sub>`,
+  ].join('\n');
+}

--- a/scripts/ci/web-preview-comment.test.mjs
+++ b/scripts/ci/web-preview-comment.test.mjs
@@ -1,0 +1,189 @@
+// Unit tests for the sticky web-preview comment body.
+//
+// The body is READ BY MACHINES — both by this repo's own "Decide whether a
+// redeploy is needed" step (which pulls the deployed SHA out of the marker) and
+// by external tooling that scrapes a PR for its preview URL, which was written
+// against Vercel's comment shape. So the assertions below are not about
+// prettiness: each one pins a structure some parser keys on.
+//
+// The Vercel-shaped anchors are re-derived here the way a scraper would find
+// them (a header match, a `[Preview](…)` regex) rather than compared to a
+// snapshot, so a cosmetic edit stays free while a shape change goes red.
+//
+// Run: node --test scripts/ci/web-preview-comment.test.mjs
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import {
+  WEB_PREVIEW_MARKER,
+  formatUpdatedLabel,
+  renderReadyComment,
+  renderErrorComment,
+} from './web-preview-comment.mjs';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../..');
+
+const SHA = '4f307759b0f7c85ab9f13172ee59de4747aa8c0a';
+const PREVIEW_URL = 'https://lorekit-pr-629-mads-thines-projects.vercel.app';
+const COMMIT_URL = 'https://lorekit-65k6q0gu9-mads-thines-projects.vercel.app';
+const RUN_URL = 'https://github.com/mthines/lorekit/actions/runs/33548435410';
+const AT = new Date('2026-09-01T19:17:00.000Z');
+
+const ready = (over = {}) =>
+  renderReadyComment({
+    sha: SHA,
+    previewUrl: PREVIEW_URL,
+    commitUrl: COMMIT_URL,
+    aliasAvailable: true,
+    forced: false,
+    runUrl: RUN_URL,
+    at: AT,
+    ...over,
+  });
+
+const errored = (over = {}) =>
+  renderErrorComment({ sha: SHA, detail: 'Deployment blocked.', runUrl: RUN_URL, at: AT, ...over });
+
+// ── The Vercel-shaped table ──────────────────────────────────────────────────
+// Verbatim from a real Vercel comment. If Vercel ever changes these, THIS is
+// the line to change — everything else about the format follows from it.
+const VERCEL_HEADER = '| Project | Deployment | Actions | Updated |';
+const VERCEL_ALIGNMENT = '| :--- | :----- | :------ | :------ |';
+
+test('the table header and alignment row are Vercel\'s, verbatim', () => {
+  for (const body of [ready(), errored()]) {
+    const lines = body.split('\n');
+    const header = lines.indexOf(VERCEL_HEADER);
+    assert.notEqual(header, -1, 'the Vercel column header is missing');
+    assert.equal(lines[header + 1], VERCEL_ALIGNMENT);
+    // Exactly one project row follows the alignment row.
+    assert.match(lines[header + 2], /^\| \*\*lorekit\*\* \|/);
+  }
+});
+
+test('the preview URL is reachable through Vercel\'s `[Preview](…)` anchor', () => {
+  // The extraction an external scraper performs, spelled out.
+  const found = ready().match(/\[Preview\]\((https?:\/\/[^)\s]+)\)/);
+  assert.ok(found, 'no `[Preview](…)` link — this is the anchor preview-URL scrapers key on');
+  assert.equal(found[1], PREVIEW_URL);
+});
+
+test('the Deployment cell carries Vercel\'s status icon and a `[Ready](…)` link', () => {
+  const body = ready();
+  assert.ok(body.includes('![Ready](https://vercel.com/static/status/ready.svg)'));
+  // `(?<!!)` so the status IMAGE — `![Ready](…svg)` — is not mistaken for the link.
+  const found = body.match(/(?<!!)\[Ready\]\((https?:\/\/[^)\s]+)\)/);
+  assert.ok(found, 'no `[Ready](…)` link in the Deployment column');
+  // Deployment is the IMMUTABLE per-commit build, never the moving alias.
+  assert.equal(found[1], COMMIT_URL);
+});
+
+test('the Updated cell is a `<relative-time>` element with a parseable datetime', () => {
+  for (const body of [ready(), errored()]) {
+    const found = body.match(/<relative-time datetime="([^"]+)">([^<]+)<\/relative-time>/);
+    assert.ok(found, 'no `<relative-time>` element in the Updated column');
+    assert.equal(found[1], AT.toISOString());
+    assert.equal(new Date(found[1]).getTime(), AT.getTime());
+    assert.equal(found[2], 'Sep 1, 2026 7:17pm UTC');
+  }
+});
+
+test('the old, unmatchable column shape is gone', () => {
+  for (const body of [ready(), errored()]) {
+    assert.ok(!body.includes('| Name | Status |'), 'the pre-Vercel header is back');
+    assert.ok(!body.includes('Visit Preview'), '`Visit Preview` is not an anchor scrapers match');
+  }
+});
+
+test('Vercel\'s signed `[vc]:` metadata line is never forged', () => {
+  for (const body of [ready(), errored()]) {
+    assert.ok(!body.includes('[vc]:'), 'we must not emit a fake Vercel metadata payload');
+  }
+});
+
+// ── The marker: this repo's own contract with the "Decide" step ───────────────
+
+test('a successful comment records the full SHA the Decide step reads back', () => {
+  const body = ready();
+  assert.ok(body.startsWith(`${WEB_PREVIEW_MARKER} sha=${SHA} -->`));
+  // The exact regex in web-preview-deploy.yml's Decide step.
+  assert.equal(body.match(/lorekit-web-preview sha=([0-9a-f]{40})/)?.[1], SHA);
+});
+
+test('a FAILED comment omits `sha=` so the next push re-attempts the deploy', () => {
+  const body = errored();
+  assert.ok(body.startsWith(`${WEB_PREVIEW_MARKER} -->`));
+  assert.equal(body.match(/lorekit-web-preview sha=([0-9a-f]{40})/), null);
+  // Still found by the same sticky-comment key, so it edits in place.
+  assert.ok(body.includes(WEB_PREVIEW_MARKER));
+});
+
+// ── Content that must survive the reshape ────────────────────────────────────
+
+test('the commit, the redeploy hint and the run link stay in the footnote', () => {
+  const body = ready();
+  assert.ok(body.includes(`[\`${SHA.slice(0, 7)}\`](${COMMIT_URL})`));
+  assert.ok(body.includes('`/web-preview`'));
+  assert.ok(body.includes(`[Workflow logs](${RUN_URL})`));
+});
+
+test('a missing stable alias is announced, not silently identical', () => {
+  assert.ok(!ready().includes('stable alias was unavailable'));
+  assert.ok(
+    ready({ aliasAvailable: false, previewUrl: COMMIT_URL }).includes('stable alias was unavailable'),
+  );
+});
+
+test('an on-demand deploy says so', () => {
+  assert.ok(!ready().includes('Deployed on demand'));
+  assert.ok(ready({ forced: true }).includes('Deployed on demand'));
+});
+
+test('the failure reason is blockquoted line by line, with a fallback', () => {
+  const body = errored({ detail: 'Line one\nLine two' });
+  assert.ok(body.includes('> Line one'));
+  assert.ok(body.includes('> Line two'));
+  assert.ok(body.includes('> [!WARNING]'));
+  assert.ok(errored({ detail: '   ' }).includes('did not complete'));
+});
+
+test('an Error row offers no preview link', () => {
+  assert.equal(errored().match(/\[Preview\]\(/), null);
+  assert.ok(errored().includes('![Error](https://vercel.com/static/status/error.svg)'));
+});
+
+// ── Guards ───────────────────────────────────────────────────────────────────
+
+test('a short or malformed SHA is refused rather than rendered', () => {
+  assert.throws(() => ready({ sha: '4f30775' }), /full 40-char SHA/);
+  assert.throws(() => errored({ sha: '' }), /full 40-char SHA/);
+  assert.throws(() => ready({ previewUrl: '' }), /required/);
+});
+
+test('formatUpdatedLabel spells midnight and noon the way Vercel does', () => {
+  assert.equal(formatUpdatedLabel(new Date('2026-01-05T00:04:00Z')), 'Jan 5, 2026 12:04am UTC');
+  assert.equal(formatUpdatedLabel(new Date('2026-12-31T12:00:00Z')), 'Dec 31, 2026 12:00pm UTC');
+  assert.equal(formatUpdatedLabel(new Date('2026-09-02T10:41:25Z')), 'Sep 2, 2026 10:41am UTC');
+});
+
+// ── The workflow consumes THIS module, rather than carrying a copy ───────────
+// The whole reason the renderer moved out of the YAML is that the format is now
+// a contract with outside tooling; an inline table in the workflow would drift
+// away from these assertions silently.
+test('web-preview-deploy.yml renders through this module', () => {
+  const yaml = readFileSync(join(repoRoot, '.github/workflows/web-preview-deploy.yml'), 'utf8');
+  assert.ok(
+    yaml.includes('scripts/ci/web-preview-comment.mjs'),
+    'the workflow no longer imports the canonical renderer',
+  );
+  assert.ok(yaml.includes('renderReadyComment'), 'the success comment does not use the renderer');
+  assert.ok(yaml.includes('renderErrorComment'), 'the failure comment does not use the renderer');
+  assert.ok(
+    !yaml.includes('| Project | Deployment | Actions | Updated |'),
+    'the table is inlined in the workflow again — it must live in one place',
+  );
+});

--- a/scripts/ci/web-preview-filter.mjs
+++ b/scripts/ci/web-preview-filter.mjs
@@ -42,6 +42,11 @@
  * - the composite action + the two `web-preview*` workflows — the preview
  *   machinery itself, so a change to how previews are built gets verified by
  *   actually building one.
+ * - `scripts/ci/web-preview-comment.mjs` — the sticky comment's renderer, for
+ *   the same reason: its output is a contract with outside tooling that scrapes
+ *   the PR for the preview URL, and the only way to see the real rendered
+ *   comment is to deploy. Its `.test.mjs` is deliberately NOT matched (the
+ *   `\.mjs$` anchor excludes it) — a test-only edit changes no output.
  *
  * Deliberately ABSENT:
  * - `.github/workflows/ci.yml` — every other gate in that file includes itself
@@ -57,7 +62,7 @@
  *   another package) cannot change what the dashboard renders.
  */
 export const WEB_PREVIEW_PATH_FILTER =
-  '^(packages/web/|packages/schemas/|package\\.json$|nx\\.json$|\\.github/actions/vercel-preview-deploy/|\\.github/workflows/(web-preview|web-preview-deploy)\\.yml$)';
+  '^(packages/web/|packages/schemas/|package\\.json$|nx\\.json$|scripts/ci/web-preview-comment\\.mjs$|\\.github/actions/vercel-preview-deploy/|\\.github/workflows/(web-preview|web-preview-deploy)\\.yml$)';
 
 /** Does this repo-relative path require a new preview deployment? */
 export function matchesWebPreviewPath(filename) {

--- a/scripts/ci/web-preview-filter.test.mjs
+++ b/scripts/ci/web-preview-filter.test.mjs
@@ -41,6 +41,10 @@ const CASES = [
   ['.github/actions/vercel-preview-deploy/action.yml', true],
   ['.github/workflows/web-preview.yml', true],
   ['.github/workflows/web-preview-deploy.yml', true],
+  // The sticky comment's renderer — its output is what outside tooling scrapes,
+  // and only a real deploy renders it. Its test file is not machinery.
+  ['scripts/ci/web-preview-comment.mjs', true],
+  ['scripts/ci/web-preview-comment.test.mjs', false],
 
   // ── Deliberately excluded: quota, not correctness ──────────────────────────
   // ci.yml is the regression this filter exists to fix — see the "unrelated CI


### PR DESCRIPTION
The sticky PR comment that displays preview URLs is now rendered by a dedicated, unit-tested module instead of being inlined in the GitHub Actions workflow. This ensures the comment structure — which is a contract with external tooling that scrapes PRs for preview URLs — stays consistent and verifiable.

## Summary

Extracted the web-preview comment rendering logic from `.github/workflows/web-preview-deploy.yml` into `scripts/ci/web-preview-comment.mjs`, with comprehensive unit tests in `scripts/ci/web-preview-comment.test.mjs`. The comment deliberately mirrors Vercel's own preview comment structure because external tooling was written to parse that format.

## Key changes

- **New module `scripts/ci/web-preview-comment.mjs`**: Exports `renderReadyComment()` and `renderErrorComment()` functions that generate the sticky comment body. The module includes detailed comments explaining why the table structure matches Vercel's format exactly — the four-column header (`Project | Deployment | Actions | Updated`), the `[Preview](…)` link in the Actions cell, and the `<relative-time>` element are all load-bearing for external scrapers.

- **New test file `scripts/ci/web-preview-comment.test.mjs`**: 16 unit tests that verify:
  - The Vercel-shaped table header is present and unchanged
  - The `[Preview](…)` link is extractable the way external scrapers do it
  - The `[Ready](…)` link points to the immutable per-commit deployment
  - The `<relative-time>` element has a parseable ISO datetime
  - The marker line records the full SHA on success, omits it on failure
  - All content (commit link, redeploy hint, workflow logs) survives the reshape
  - Error details are blockquoted with a fallback message
  - Input validation rejects malformed SHAs
  - The workflow still imports and uses this module (not inlined)

- **Updated `web-preview-deploy.yml`**: Both the success and failure comment steps now dynamically import and call the renderer functions instead of building the comment inline. The marker find-key is now exported from the module (`WEB_PREVIEW_MARKER`).

- **Updated filter and CI config**: Added `scripts/ci/web-preview-comment.mjs` to the web-preview change filter in both `ci.yml` and `web-preview-filter.test.mjs`, since the comment's output is part of the deployed preview machinery. The `.test.mjs` file is deliberately excluded from the filter (via the `\.mjs$` anchor) because test-only edits don't change output.

- **Updated documentation**: `docs/deployment.md` now explains why the comment is Vercel-shaped, what parts are reproduced and why, and how the marker is a contract with the "Decide" step.

## Implementation details

- The comment format is **machine-readable**: the marker line `<!-- lorekit-web-preview sha=<40 hex> -->` is parsed by the "Decide" step to detect whether a redeploy is needed. Failed deploys omit the `sha=` so the next push re-attempts instead of treating the failed commit as deployed.

- The `formatUpdatedLabel()` function spells midnight and noon the way Vercel does (12:04am, 12:00pm), and the `<relative-time>` element includes both an ISO datetime attribute (for parsing) and a human-readable fallback (for emails/API reads).

- The module is imported via `pathToFileURL()` in the workflow because `github-script` runs in a Node.js context where dynamic imports need file URLs.

- All three copies of the change filter regex (grep in `ci.yml`, RegExp in `web-preview-filter.mjs`, test cases in `web-preview-filter.test.mjs`) are held in sync by the test file, which now also includes the new path.

https://claude.ai/code/session_01M4KFDkxuzXK9k541xRoc9G