### PR TITLE
Enforce the two relevance-read contracts where they are declared

### DIFF
--- a/packages/mcp-core/src/webhook/comment-relevance.spec.ts
+++ b/packages/mcp-core/src/webhook/comment-relevance.spec.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
+  COMPARE_FILES_CEILING,
   DECLINE_PATTERN,
   LINE_TOUCH_RADIUS,
   SAFE_MARKER_VALUE,
+  filesFromCompareBody,
   patchTouchesLine,
   buildRelevanceKey,
   buildRelevanceRecord,
@@ -234,6 +236,50 @@ describe('patchTouchesLine', () => {
   it('LINE_TOUCH_RADIUS is the documented default', () => {
     expect(LINE_TOUCH_RADIUS).toBe(10);
     expect(patchTouchesLine(patch, 11)).toBe(patchTouchesLine(patch, 11, LINE_TOUCH_RADIUS));
+  });
+});
+
+describe('filesFromCompareBody', () => {
+  const entry = (filename: string): ComparedFile => ({ filename, patch: '@@ -1 +1 @@' });
+
+  it('passes a real files array through', () => {
+    expect(filesFromCompareBody({ files: [entry('src/a.ts')] })).toEqual([entry('src/a.ts')]);
+  });
+
+  it('treats a files array GitHub actually sent as empty as a completed walk', () => {
+    // Two commits with identical trees really do list no files, and "the walk
+    // completed and found nothing" is evidence — distinct from every case below.
+    expect(filesFromCompareBody({ files: [] })).toEqual([]);
+  });
+
+  // Each of these is a body that cannot answer "did anything land on this
+  // file". Reading any of them as `[]` would hand touchEvidenceFromFiles a
+  // completed walk, which yields `touched: false` and files a suppression for a
+  // file nothing looked at.
+  it('is undecidable when the files key is absent or not an array', () => {
+    expect(filesFromCompareBody({})).toBeNull();
+    expect(filesFromCompareBody({ files: null })).toBeNull();
+    expect(filesFromCompareBody({ files: 'src/a.ts' })).toBeNull();
+    expect(filesFromCompareBody({ files: { 0: entry('src/a.ts') } })).toBeNull();
+  });
+
+  it('is undecidable for a body that is not an object at all', () => {
+    expect(filesFromCompareBody(null)).toBeNull();
+    expect(filesFromCompareBody(undefined)).toBeNull();
+    expect(filesFromCompareBody('not json')).toBeNull();
+    expect(filesFromCompareBody([])).toBeNull();
+  });
+
+  it('is undecidable at the truncation ceiling, where an absent file proves nothing', () => {
+    const atCeiling = Array.from({ length: COMPARE_FILES_CEILING }, (_, i) => entry(`f${i}.ts`));
+    expect(filesFromCompareBody({ files: atCeiling })).toBeNull();
+    expect(filesFromCompareBody({ files: atCeiling.slice(0, -1) })).toHaveLength(
+      COMPARE_FILES_CEILING - 1,
+    );
+  });
+
+  it('COMPARE_FILES_CEILING is the documented compare limit', () => {
+    expect(COMPARE_FILES_CEILING).toBe(300);
   });
 });
 

--- a/packages/mcp-core/src/webhook/comment-relevance.ts
+++ b/packages/mcp-core/src/webhook/comment-relevance.ts
@@ -249,6 +249,38 @@ export interface ComparedFile {
 }
 
 /**
+ * `compare` truncates its `files` array at 300 entries and gives no flag saying
+ * so, so a diff sitting exactly at the ceiling is unreadable rather than a diff
+ * that happens not to contain the file.
+ */
+export const COMPARE_FILES_CEILING = 300;
+
+/**
+ * A `compare` response body → the file list `touchEvidenceFromFiles` consumes,
+ * or `null` when the body cannot answer the question.
+ *
+ * This exists because the shell's own stated contract — `null` on any condition
+ * that makes the answer unknowable — was being broken by its own default.
+ * Reading an absent or non-array `files` key as `[]` turns "GitHub did not tell
+ * us" into the one value the decision below reads as a COMPLETED walk that did
+ * not contain the file: `touched: false`, and a suppression filed for a file
+ * nothing ever looked at.  That is the same inversion the ceiling guard exists
+ * to prevent, arriving through a `??` rather than through truncation — so both
+ * now sit on one side of one seam instead of one being guarded and the other
+ * left to a default nobody read.
+ *
+ * A `files: []` that GitHub actually sent is NOT that case and passes through.
+ * A compare of two commits with identical trees really does list no files, and
+ * "the walk completed and found nothing" is evidence.
+ */
+export function filesFromCompareBody(body: unknown): ComparedFile[] | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const files = (body as { files?: unknown }).files;
+  if (!Array.isArray(files)) return null;
+  return files.length >= COMPARE_FILES_CEILING ? null : (files as ComparedFile[]);
+}
+
+/**
  * A completed `compare` plus one thread's anchor → touch evidence, or `null`
  * when the pair cannot decide.
  *

--- a/packages/mcp-core/src/webhook/github-review-parse.spec.ts
+++ b/packages/mcp-core/src/webhook/github-review-parse.spec.ts
@@ -142,22 +142,65 @@ describe('parseThreadNode', () => {
   });
 
   describe('thumbs-down logins', () => {
-    it('collects every reacting login', () => {
-      const parsed = parseThreadNode(
-        node({ reactions: { nodes: [{ user: { login: 'alice' } }, { user: { login: 'bob' } }] } }),
-      );
+    /** One 👎 reaction node, in the shape the query returns. */
+    const down = (login: string) => ({ content: 'THUMBS_DOWN', user: { login } });
+
+    it('collects every 👎 login', () => {
+      const parsed = parseThreadNode(node({ reactions: { nodes: [down('alice'), down('bob')] } }));
       expect(parsed?.thumbsDownLogins).toEqual(['alice', 'bob']);
     });
 
     it('drops a reaction from a deleted user rather than yielding undefined', () => {
       const parsed = parseThreadNode(
-        node({ reactions: { nodes: [{ user: null }, {}, { user: { login: 'alice' } }] } }),
+        node({
+          reactions: {
+            nodes: [{ content: 'THUMBS_DOWN', user: null }, { content: 'THUMBS_DOWN' }, down('alice')],
+          },
+        }),
       );
       expect(parsed?.thumbsDownLogins).toEqual(['alice']);
     });
 
     it('is empty when the reactions connection is absent', () => {
       expect(parseThreadNode(node({ reactions: undefined }))?.thumbsDownLogins).toEqual([]);
+    });
+
+    // The query narrows to `content: THUMBS_DOWN`, so in a correct response
+    // every node already is one. These two cases exist because this list feeds
+    // SUPPRESSION: if that argument is ever dropped from the query, a 👍 on a
+    // good finding must not start recording that the finding was unwanted. The
+    // filter is what makes the `thumbsDownLogins` doc comment enforceable in the
+    // module that declares it, instead of in an unspec'd query string.
+    it('drops any reaction that is not a 👎', () => {
+      const parsed = parseThreadNode(
+        node({
+          reactions: {
+            nodes: [
+              { content: 'THUMBS_UP', user: { login: 'approver' } },
+              { content: 'HEART', user: { login: 'fan' } },
+              down('objector'),
+            ],
+          },
+        }),
+      );
+      expect(parsed?.thumbsDownLogins).toEqual(['objector']);
+    });
+
+    it('fails closed on a reaction whose content is absent or unrecognised', () => {
+      // Dropping a reaction this module cannot attest is 👎 costs one signal.
+      // Keeping it records that a finding was unwanted on evidence nobody has.
+      const parsed = parseThreadNode(
+        node({
+          reactions: {
+            nodes: [
+              { user: { login: 'unknown-intent' } },
+              { content: null, user: { login: 'null-content' } },
+              { content: 'thumbs_down', user: { login: 'wrong-case' } },
+            ],
+          },
+        }),
+      );
+      expect(parsed?.thumbsDownLogins).toEqual([]);
     });
   });
 

--- a/packages/mcp-core/src/webhook/github-review-parse.ts
+++ b/packages/mcp-core/src/webhook/github-review-parse.ts
@@ -55,8 +55,25 @@ interface RawComment {
   author?: { login?: unknown; __typename?: unknown } | null;
   commit?: RawCommit | null;
   originalCommit?: RawCommit | null;
-  reactions?: { nodes?: readonly ({ user?: { login?: unknown } | null } | null)[] | null } | null;
+  reactions?: {
+    nodes?:
+      | readonly ({ content?: unknown; user?: { login?: unknown } | null } | null)[]
+      | null;
+  } | null;
 }
+
+/**
+ * The one reaction that means "this finding was wrong".
+ *
+ * The GraphQL query already narrows to `content: THUMBS_DOWN`, so in a correct
+ * response every node is one — and that is exactly why this module re-checks it.
+ * `thumbsDownLogins` feeds SUPPRESSION, so the cost of the query losing its
+ * filter is that an author's 👍 on a good finding starts recording that the
+ * finding was unwanted. That contract was declared here, in a spec'd module, and
+ * enforced only by an argument in a query string in an unspec'd fetch shell,
+ * where no test could hold it.
+ */
+const THUMBS_DOWN = 'THUMBS_DOWN';
 
 interface RawThreadNode {
   isResolved?: unknown;
@@ -117,7 +134,11 @@ export function parseThreadNode(node: unknown): ReviewThreadFacts | null {
       .slice(1)
       .map((c) => (typeof c.body === 'string' ? c.body : ''))
       .filter(Boolean),
+    // Fails CLOSED on an unrecognised or absent `content`: dropping a reaction
+    // this module cannot attest is 👎 costs one suppression signal, while
+    // keeping it records that a finding was unwanted on evidence nobody has.
     thumbsDownLogins: (root.reactions?.nodes ?? [])
+      .filter((r) => r?.content === THUMBS_DOWN)
       .map((r) => r?.user?.login)
       .filter((login): login is string => typeof login === 'string'),
   };

--- a/supabase/functions/mcp/comment-relevance.ts
+++ b/supabase/functions/mcp/comment-relevance.ts
@@ -251,6 +251,38 @@ export interface ComparedFile {
 }
 
 /**
+ * `compare` truncates its `files` array at 300 entries and gives no flag saying
+ * so, so a diff sitting exactly at the ceiling is unreadable rather than a diff
+ * that happens not to contain the file.
+ */
+export const COMPARE_FILES_CEILING = 300;
+
+/**
+ * A `compare` response body → the file list `touchEvidenceFromFiles` consumes,
+ * or `null` when the body cannot answer the question.
+ *
+ * This exists because the shell's own stated contract — `null` on any condition
+ * that makes the answer unknowable — was being broken by its own default.
+ * Reading an absent or non-array `files` key as `[]` turns "GitHub did not tell
+ * us" into the one value the decision below reads as a COMPLETED walk that did
+ * not contain the file: `touched: false`, and a suppression filed for a file
+ * nothing ever looked at.  That is the same inversion the ceiling guard exists
+ * to prevent, arriving through a `??` rather than through truncation — so both
+ * now sit on one side of one seam instead of one being guarded and the other
+ * left to a default nobody read.
+ *
+ * A `files: []` that GitHub actually sent is NOT that case and passes through.
+ * A compare of two commits with identical trees really does list no files, and
+ * "the walk completed and found nothing" is evidence.
+ */
+export function filesFromCompareBody(body: unknown): ComparedFile[] | null {
+  if (typeof body !== 'object' || body === null) return null;
+  const files = (body as { files?: unknown }).files;
+  if (!Array.isArray(files)) return null;
+  return files.length >= COMPARE_FILES_CEILING ? null : (files as ComparedFile[]);
+}
+
+/**
  * A completed `compare` plus one thread's anchor → touch evidence, or `null`
  * when the pair cannot decide.
  *

--- a/supabase/functions/mcp/github-review-parse.ts
+++ b/supabase/functions/mcp/github-review-parse.ts
@@ -58,8 +58,25 @@ interface RawComment {
   author?: { login?: unknown; __typename?: unknown } | null;
   commit?: RawCommit | null;
   originalCommit?: RawCommit | null;
-  reactions?: { nodes?: readonly ({ user?: { login?: unknown } | null } | null)[] | null } | null;
+  reactions?: {
+    nodes?:
+      | readonly ({ content?: unknown; user?: { login?: unknown } | null } | null)[]
+      | null;
+  } | null;
 }
+
+/**
+ * The one reaction that means "this finding was wrong".
+ *
+ * The GraphQL query already narrows to `content: THUMBS_DOWN`, so in a correct
+ * response every node is one — and that is exactly why this module re-checks it.
+ * `thumbsDownLogins` feeds SUPPRESSION, so the cost of the query losing its
+ * filter is that an author's 👍 on a good finding starts recording that the
+ * finding was unwanted. That contract was declared here, in a spec'd module, and
+ * enforced only by an argument in a query string in an unspec'd fetch shell,
+ * where no test could hold it.
+ */
+const THUMBS_DOWN = 'THUMBS_DOWN';
 
 interface RawThreadNode {
   isResolved?: unknown;
@@ -120,7 +137,11 @@ export function parseThreadNode(node: unknown): ReviewThreadFacts | null {
       .slice(1)
       .map((c) => (typeof c.body === 'string' ? c.body : ''))
       .filter(Boolean),
+    // Fails CLOSED on an unrecognised or absent `content`: dropping a reaction
+    // this module cannot attest is 👎 costs one suppression signal, while
+    // keeping it records that a finding was unwanted on evidence nobody has.
     thumbsDownLogins: (root.reactions?.nodes ?? [])
+      .filter((r) => r?.content === THUMBS_DOWN)
       .map((r) => r?.user?.login)
       .filter((login): login is string => typeof login === 'string'),
   };

--- a/supabase/functions/mcp/github-review-read.ts
+++ b/supabase/functions/mcp/github-review-read.ts
@@ -30,7 +30,9 @@
  */
 
 import {
+  filesFromCompareBody,
   touchEvidenceFromFiles,
+  type ComparedFile,
   type TouchEvidence,
 } from './comment-relevance.ts';
 import { parseThreadNode, type ReviewThreadFacts } from './github-review-parse.ts';
@@ -53,13 +55,6 @@ const THREAD_COMMENT_PAGE_SIZE = 50;
  * beyond it get `null` touch evidence, i.e. undecidable, i.e. no record.
  */
 const MAX_TOUCH_COMPARES = 12;
-
-/**
- * `compare` truncates its `files` array at 300 entries with no flag saying so,
- * so a diff at exactly the ceiling is treated as unreadable rather than as a
- * diff that happens not to contain the file.
- */
-const COMPARE_FILES_CEILING = 300;
 
 export interface ReviewThreadRead {
   /**
@@ -97,8 +92,12 @@ const REVIEW_THREADS_QUERY = `
                 author{ login __typename }
                 commit{ oid }
                 originalCommit{ oid }
+                # content is selected even though the argument already narrows
+                # to 👎: parseThreadNode re-checks it, so losing this filter
+                # drops the reactions instead of silently reading a 👍 as a 👎
+                # on a suppression input.
                 reactions(content: THUMBS_DOWN, first: 20){
-                  nodes{ user{ login } }
+                  nodes{ content user{ login } }
                 }
               }
             }
@@ -183,7 +182,7 @@ export async function fetchReviewThreads(args: {
  * against one commit, so the common case is one HTTP call for the whole sweep.
  */
 export class TouchProbe {
-  private readonly cache = new Map<string, Json | null>();
+  private readonly cache = new Map<string, ComparedFile[] | null>();
   private compares = 0;
 
   constructor(
@@ -218,25 +217,26 @@ export class TouchProbe {
     return touchEvidenceFromFiles(files, thread.rootPath, thread.rootLine);
   }
 
-  /** `null` on any condition that makes the answer unknowable. */
-  private async filesSince(baseSha: string): Promise<Json[] | null> {
-    if (this.cache.has(baseSha)) return this.cache.get(baseSha) as Json[] | null;
+  /**
+   * `null` on any condition that makes the answer unknowable.
+   *
+   * Which conditions those are is `filesFromCompareBody`'s call, not this
+   * method's: it owns both the truncation ceiling and the absent-key case, and
+   * it is spec'd. All this method decides is whether an HTTP response arrived
+   * at all.
+   */
+  private async filesSince(baseSha: string): Promise<ComparedFile[] | null> {
+    if (this.cache.has(baseSha)) return this.cache.get(baseSha) ?? null;
     if (this.compares >= MAX_TOUCH_COMPARES) return null;
 
     this.compares++;
-    let result: Json[] | null = null;
+    let result: ComparedFile[] | null = null;
     try {
       const res = await fetch(
         `${GITHUB_API}/repos/${this.repo}/compare/${baseSha}...${this.headSha}`,
         { headers: githubHeaders(this.token) },
       );
-      if (res.ok) {
-        const body: Json = await res.json();
-        const files: Json[] = body['files'] ?? [];
-        // At the ceiling the array is silently truncated, so an absent file
-        // proves nothing.
-        result = files.length >= COMPARE_FILES_CEILING ? null : files;
-      }
+      if (res.ok) result = filesFromCompareBody(await res.json());
     } catch {
       result = null;
     }


### PR DESCRIPTION
Two contract seams found reviewing #640, both the same shape: a guarantee stated in a pure, spec'd module and enforced only in the impure fetch shell around it, where no test could hold it. Stacked on #640 because the code they fix exists only on that branch.

## `thumbsDownLogins` did not check that a reaction was a 👎

`ReviewThreadFacts.thumbsDownLogins` is documented as "logins that reacted 👎 to the ROOT comment", but `parseThreadNode` read every reaction node it was handed. The whole guarantee lived in `content: THUMBS_DOWN` inside the GraphQL query string — a file in no mirror pair and no spec. Worse, the spec asserted `collects every reacting login`, so it *pinned* the unfiltered behaviour: dropping that argument would start turning an author's 👍 on a good finding into a record that the finding was unwanted, with all 21 cases still green. `thumbsDownLogins` feeds suppression, so that inversion is expensive.

`content` is now selected and re-checked in the module that declares the contract. It fails **closed** on an absent or unrecognised content — dropping a reaction the module cannot attest is a 👎 costs one suppression signal, whereas keeping it records a rejection on evidence nobody has.

## `filesSince` broke its own documented contract with a default

Its doc comment is `null` on any condition that makes the answer unknowable. Then `body['files'] ?? []` converted "GitHub did not tell us" into the one value `touchEvidenceFromFiles` reads as a **completed** walk that did not contain the file — `touched: false`, and a suppression filed for a file nothing ever looked at.

That is precisely the inversion `COMPARE_FILES_CEILING` was added to prevent, arriving through a `??` instead of through truncation. So both now sit in `filesFromCompareBody` in the pure module: one seam, spec'd, mirrored, drift-guarded. A `files: []` GitHub actually sent still passes through, because two commits with identical trees really do list no files and a completed walk that found nothing is evidence.

The shell keeps the HTTP call, its memo and the compare budget, and decides only whether a response arrived.

## Why both, in one PR

#640's own review noted the structural point: two decisions were lifted into pure modules there, and the same defect class immediately reappeared in the code *feeding* one of them and in the query string that *was* the other's unenforceable contract. Lifting a decision does not protect its inputs. These are those two inputs.

## Verification

Both guards were probed by breaking what they guard, then restored:

- removing the reaction filter fails 2 of the 23 `github-review-parse` cases
- restoring the `?? []` default fails 2 of the new compare-body cases

Gates green: `mcp-core` 1730 passed / 1 skipped (up from 1722 — 8 new cases), `node scripts/ci/deno-check-functions.mjs` with every baseline unchanged at 0, `pnpm nx affected -t typecheck,lint --base=origin/main` at 0 errors, and both mirror pairs byte-identical under `edge-parity.spec.ts`.

Not covered, deliberately: the fetch shell itself stays edge-only and unspec'd, on `github-app-client.ts`'s precedent — it is `fetch` plus a loop, and a spec for it would be a spec for a mock. The two rules in it a test could hold are now both in the pure module.

## Review this first

`filesFromCompareBody`'s fail-closed direction is a judgement call worth a second opinion. An unreadable compare now writes **no** record rather than a `touched: false` one, so a genuinely-ignored comment on a repo that trips the ceiling or a flaky compare goes unrecorded instead of being recorded correctly. I took that trade because a missing record is recoverable on the next sighting and a false suppression trains the reviewer to stay quiet — but it does mean less signal on large diffs.

https://claude.ai/code/session_01J6iWLkrnKDsk8YNsjaKQq4

---
_Generated by [Claude Code](https://claude.ai/code/session_01J6iWLkrnKDsk8YNsjaKQq4)_