### PR TITLE
Set agent0_org so fix buttons open the intended Dash0 organization

### DIFF
--- a/.github/review.yaml
+++ b/.github/review.yaml
@@ -1,2 +1,3 @@
 agent0_fix_links: true
 agent0_environment: development
+agent0_org: e8b3aed4-ae5f-4093-a1af-448a98405346


### PR DESCRIPTION
## Why

`pr-reviewer`'s Fix-with-Agent0 buttons take an optional `org` query param, resolved from `agent0_org` in this file. Without it the link lands the reader in whichever org Agent0 resolves for them — ambiguous for anyone belonging to several.

## What changed

- `.github/review.yaml`: added `agent0_org: e8b3aed4-ae5f-4093-a1af-448a98405346`

## How to verify

Every fix button on the next `pr-reviewer` run carries `&org=e8b3aed4-ae5f-4093-a1af-448a98405346`. The key is validated against `^[A-Za-z0-9][A-Za-z0-9._-]{0,62}$` at both the shell and the link builder; this value was checked against both in `mthines/agent-skills`.

https://claude.ai/code/session_018vqEFrNqNC9BrMze5tc2jC

---
_Generated by [Claude Code](https://claude.ai/code/session_018vqEFrNqNC9BrMze5tc2jC)_