### PR TITLE
feat(evals): make the golden experiment affordable, and make arm B-organic reachable

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -298,6 +298,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
+        with:
+          # This job holds `pull-requests: write` for the label drop and also
+          # spawns the agent under test. Nothing here uses git auth — the label
+          # step goes through GH_TOKEN — so keep the token out of .git/config
+          # rather than leaving it where the run could read it.
+          persist-credentials: false
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -18,9 +18,20 @@
 # THREE TIERS, PRICED BY WHAT THEY SPEND.
 #   offline    free      unit tests + `--dry-run` plans. Auto, path-filtered.
 #   preflight  ~1 call   proves THIS runner is clean. Auto, path-filtered.
-#   live       many      `golden` / `variants`. Manual dispatch or a label.
+#   live       0..many   `probe` (free), `golden` / `variants` (paid). Manual
+#                        dispatch or a label.
 # The split exists so a routine change to the harness is validated for free and
 # only a deliberate act spends money.
+#
+# NARROWING A PAID RUN. Both experiments take a subset: `--arm <id>` picks
+# golden's arms and `--variant <id>` picks the variants ladder's rows, both
+# repeatable, both meaning "every one" when empty. The cheapest real experiment
+# is therefore one arm at `--reps 1` — a single model call. The one thing a
+# subset cannot buy is a lift it did not measure: a selection without arm A has
+# no baseline, so every comparison in it reports `comparable: false` and names
+# the absent arm, rather than printing a 0 that reads as "memory made no
+# difference". That rule is structural (the control is simply not in the
+# summary), not a check anyone has to remember.
 #
 # NOTHING HERE GATES A MERGE. The offline tier is a real check on the harness's
 # own code; the live tiers report numbers. An eval result is evidence about the
@@ -53,6 +64,10 @@ on:
     # `labeled` is here so adding `run-evals` to an open PR starts the paid
     # tier without a push. The other three are the default set, restated
     # because naming any type replaces the default.
+    #
+    # `unlabeled` is deliberately NOT here. The live job removes the label
+    # itself when it finishes, so listening for the removal would have the
+    # workflow re-trigger on its own cleanup.
     types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
@@ -60,11 +75,22 @@ on:
         description: "Which experiment to run"
         type: choice
         default: preflight
-        options: [preflight, golden, variants]
+        # `arm0` is deliberately ABSENT. It is a real subcommand and it is the
+        # cheapest paid one, but its summary.json carries neither `arms[]` nor
+        # `cells{}` nor `costUsd`, so the Report step below would render an
+        # empty report and the Dash0 export would emit no datapoints — a paid
+        # run with no record of what it bought. `golden --arm 0` is the same
+        # single arm at the same cost, through the pipeline that reports and
+        # exports it, so that is the affordance offered here.
+        options: [preflight, probe, golden, variants]
       reps:
         description: "Repetitions per arm/cell (1-10; N=3 is a low-power indicator)"
         type: string
         default: "3"
+      arms:
+        description: "golden only — space-separated arm ids, empty for all (0 A B-organic B-canonical C)"
+        type: string
+        default: ""
       variants:
         description: "variants only — space-separated ids, empty for all"
         type: string
@@ -150,6 +176,11 @@ jobs:
           # `github.event.label.name`: the latter is only populated on the
           # `labeled` event, so a push to an already-labelled PR would drop
           # back to the free tier without anyone removing the label.
+          #
+          # Reading the LIVE set is what makes the label sticky, and the live
+          # job's last step is what makes it one-shot again: it removes the
+          # label when the run ends, pass or fail, so the next push is free
+          # unless someone deliberately asks again.
           LABELLED: ${{ contains(github.event.pull_request.labels.*.name, 'run-evals') }}
           EVENT: ${{ github.event_name }}
         run: |
@@ -260,6 +291,10 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: read
+      # For the label removal at the end of the job, and nothing else. Labels
+      # live on the issues API, so `pull-requests: write` is the grant that
+      # covers `DELETE /issues/{n}/labels/{name}`.
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
@@ -290,33 +325,59 @@ jobs:
           # experiments at the documented default N.
           SUBCOMMAND: ${{ github.event.inputs.subcommand || 'golden' }}
           REPS: ${{ github.event.inputs.reps || '3' }}
+          ARMS: ${{ github.event.inputs.arms || '' }}
           VARIANTS: ${{ github.event.inputs.variants || '' }}
           SKIP_OFF_TARGET: ${{ github.event.inputs.skip_off_target || 'false' }}
         run: |
           set -euo pipefail
           case "$SUBCOMMAND" in
-            preflight|golden|variants) ;;
+            preflight|probe|golden|variants) ;;
             *) echo "::error::unknown subcommand: $SUBCOMMAND"; exit 1 ;;
           esac
           if ! printf '%s' "$REPS" | grep -qE '^([1-9]|10)$'; then
             echo "::error::reps must be 1-10, got: $REPS"
             exit 1
           fi
-          ARGS="$SUBCOMMAND --skip-if-unavailable"
-          # `preflight` REFUSES --reps and --out rather than ignoring them: it
-          # is one call in a fixed arm and writes no run directory, so passing
-          # them would fail the run instead of being harmlessly redundant.
-          if [ "$SUBCOMMAND" != "preflight" ]; then
+          ARGS="$SUBCOMMAND"
+          # `probe` spawns no model, so there is no credential for it to be
+          # missing: `--skip-if-unavailable` would be accepted and ignored, and
+          # promising to skip on an unavailability that cannot arise is worse
+          # than not offering it.
+          if [ "$SUBCOMMAND" != "probe" ]; then
+            ARGS="$ARGS --skip-if-unavailable"
+          fi
+          # `preflight` and `probe` REFUSE --reps and --out rather than
+          # ignoring them: neither writes a run directory, and preflight is one
+          # call in a fixed arm, so passing them would FAIL the run instead of
+          # being harmlessly redundant.
+          if [ "$SUBCOMMAND" = "golden" ] || [ "$SUBCOMMAND" = "variants" ]; then
             ARGS="$ARGS --reps $REPS --out ./.eval-out"
           fi
-          # `--variant` / `--skip-off-target` mean nothing to golden or
-          # preflight, and neither REFUSES them — they would be accepted and
-          # dropped, so a run narrowed to two variants would quietly run the
-          # whole golden experiment instead. Refuse the combination here.
-          if [ "$SUBCOMMAND" != "variants" ] && { [ -n "$VARIANTS" ] || [ "$SKIP_OFF_TARGET" = "true" ]; }; then
-            echo "::error::--variant / --skip-off-target apply to the variants subcommand only, not $SUBCOMMAND"
+          # Which subcommand each narrowing flag belongs to. The harness now
+          # refuses every one of these crossings itself, so this is the second
+          # of two independent checks rather than the only one — but it is the
+          # one that fails in a second, before pnpm install and before the
+          # Claude CLI is fetched, and it names the input rather than the flag.
+          if [ "$SUBCOMMAND" != "golden" ] && [ -n "$ARMS" ]; then
+            echo "::error::arms applies to the golden subcommand only, not $SUBCOMMAND"
             exit 1
           fi
+          if [ "$SUBCOMMAND" != "variants" ] && { [ -n "$VARIANTS" ] || [ "$SKIP_OFF_TARGET" = "true" ]; }; then
+            echo "::error::variants / skip_off_target apply to the variants subcommand only, not $SUBCOMMAND"
+            exit 1
+          fi
+          # Arm ids are the only allow-listed vocabulary here that is not
+          # lowercase-only: `A`, `B-organic` and `B-canonical` all carry
+          # capitals, so the variant pattern would have rejected every arm but
+          # `0`. Matched against the literal set instead of a shape, because
+          # the set is five items and closed.
+          for id in $ARMS; do
+            case "$id" in
+              0|A|B-organic|B-canonical|C) ;;
+              *) echo "::error::not an arm id: $id"; exit 1 ;;
+            esac
+            ARGS="$ARGS --arm $id"
+          done
           for id in $VARIANTS; do
             if ! printf '%s' "$id" | grep -qE '^[a-z0-9-]+$'; then
               echo "::error::not a variant id: $id"
@@ -329,6 +390,16 @@ jobs:
           fi
           echo "args=$ARGS" >> "$GITHUB_OUTPUT"
           echo "subcommand=$SUBCOMMAND" >> "$GITHUB_OUTPUT"
+          # Whether this run leaves a run directory to report on, export and
+          # upload. Derived ONCE here rather than restated as a growing
+          # `!= 'preflight'` chain on each of the three steps below — that
+          # chain is exactly how `probe` would have been added to the choice
+          # list and silently failed three steps that assume a summary.json.
+          if [ "$SUBCOMMAND" = "golden" ] || [ "$SUBCOMMAND" = "variants" ]; then
+            echo "artifacts=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "artifacts=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Run
         working-directory: packages/evals
@@ -352,7 +423,7 @@ jobs:
       # `preflight` writes no run directory by design, so it has nothing to
       # report or upload — its whole result is the exit code and the stdout above.
       - name: Report
-        if: always() && steps.args.outputs.subcommand != 'preflight'
+        if: always() && steps.args.outputs.artifacts == 'true'
         working-directory: packages/evals
         run: |
           node -e '
@@ -440,13 +511,13 @@ jobs:
       # and are uploaded regardless, so an export that fails costs the run
       # nothing — which is why it is allowed to be visible instead of swallowed.
       - name: Export the run to Dash0
-        if: always() && steps.args.outputs.subcommand != 'preflight'
+        if: always() && steps.args.outputs.artifacts == 'true'
         env:
           LOREKIT_TELEMETRY_TOKEN: ${{ secrets.LOREKIT_TELEMETRY_TOKEN }}
         run: node scripts/telemetry/eval-telemetry.mjs packages/evals/.eval-out
 
       - name: Upload artifacts
-        if: always() && steps.args.outputs.subcommand != 'preflight'
+        if: always() && steps.args.outputs.artifacts == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: evals-${{ steps.args.outputs.subcommand }}-${{ github.run_id }}
@@ -466,3 +537,33 @@ jobs:
           include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 14
+
+      # The label is a ONE-SHOT trigger, and this step is what makes that true.
+      #
+      # `live` is decided from the PR's CURRENT label set, not from
+      # `github.event.label.name` — deliberately, so a push to an
+      # already-labelled PR does not silently drop back to the free tier. The
+      # cost of that correctness is that the label is STICKY: every subsequent
+      # `synchronize` re-runs the paid tier until a human removes it. That is
+      # not what anyone means by "run the evals on this PR", and it has already
+      # billed a second unasked-for `golden` run on this branch. Removing the
+      # label here turns "label it" into exactly one paid run, which is what
+      # the affordance always looked like it did.
+      #
+      # `always()`: a FAILED run must drop the label too. Leaving it on after a
+      # failure is the worst case — the next push re-spends on a run already
+      # known to be broken.
+      #
+      # `|| true` on a 404: the label may be gone already (a human removed it,
+      # or a re-run of this job). Absent is the state this step wants.
+      - name: Drop the run-evals label
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh api -X DELETE \
+            "repos/${REPO}/issues/${PR_NUMBER}/labels/run-evals" \
+            --silent 2>/dev/null \
+            || echo "run-evals was not on the PR (already removed) — nothing to do."

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -554,8 +554,12 @@ jobs:
       # failure is the worst case — the next push re-spends on a run already
       # known to be broken.
       #
-      # `|| true` on a 404: the label may be gone already (a human removed it,
-      # or a re-run of this job). Absent is the state this step wants.
+      # The delete is allowed to fail without failing the job — the label may be
+      # gone already (a human removed it, or a re-run of this job), and absent is
+      # the state this step wants. But the reason is SURFACED rather than
+      # asserted: the command never reports a status code here, so claiming
+      # "already removed" was a guess that read as a fact. A failure that is not
+      # a 404 leaves the label on the PR, and the warning says so.
       - name: Drop the run-evals label
         if: always() && github.event_name == 'pull_request'
         env:
@@ -565,5 +569,5 @@ jobs:
         run: |
           gh api -X DELETE \
             "repos/${REPO}/issues/${PR_NUMBER}/labels/run-evals" \
-            --silent 2>/dev/null \
-            || echo "run-evals was not on the PR (already removed) — nothing to do."
+            --silent \
+            || echo "::warning::could not remove the run-evals label; if it is still on the PR the next push will re-spend."

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -277,6 +277,7 @@ node bin/run-eval.mjs golden --dry-run        # the arm plan, no model call
 node bin/run-eval.mjs preflight               # one call; is the environment clean?
 node bin/run-eval.mjs arm0 --reps 1 --out ./.eval-out
 node bin/run-eval.mjs golden --reps 3 --lesson-file ./organic.md
+node bin/run-eval.mjs golden --reps 1 --arm 0  # one arm, one call — the cheapest real run
 node bin/run-eval.mjs variants --reps 3        # which FRAMING, and what it costs
 ```
 
@@ -289,7 +290,9 @@ canonical one**, which would report a curated lesson as the agent's own wording.
 
 A comparison whose either side has zero usable reps is marked
 `comparable: false` and carries **no lift at all** — not `0`, which reads as
-"memory made no difference" when the truth is "nothing was measured".
+"memory made no difference" when the truth is "nothing was measured". A `--arm`
+selection that omits the baseline lands in exactly the same place, with a
+different reason: see [Narrowing a paid run](#narrowing-a-paid-run).
 
 Requires the `claude` CLI on `PATH` and an authenticated Claude Code install.
 Run `preflight` first — it exits non-zero when the session loaded skills,
@@ -313,7 +316,48 @@ a well-equipped machine cost $1.13 to say one word. `preflight` reports its own
 | `--model <id>`          | Model under test. Changing it mid-batch makes the arms incomparable. |
 | `--permission-mode <m>` | Passed to `claude`. See the root caveat below.                       |
 | `--lesson-file <path>`  | `golden`: the organic lesson. Absent ⇒ B-organic is skipped.         |
+| `--arm <id>`            | `golden`: run only these arms (repeatable). Empty ⇒ all.             |
+| `--variant <id>`        | `variants`: run only these rows (repeatable). Empty ⇒ all.           |
+| `--skip-off-target`     | `variants`: on-target task only. Halves the cost, gives up the NET.  |
 | `--skip-if-unavailable` | Exit 0 with a "skipped" report when a live run cannot start. For CI. |
+
+Each narrowing flag belongs to exactly one subcommand and is **refused**, not
+ignored, everywhere else — including crossed over (`golden --variant`,
+`variants --arm`) and aimed at a subcommand that is already a single fixed arm
+(`arm0 --arm B-canonical`, which reads exactly like a request for the seeded
+arm and would otherwise have delivered the empty-store one at full price).
+
+### Narrowing a paid run
+
+`--arm` is the cost dial for `golden`, the way `--variant` is for `variants`.
+Empty means every arm; a list is a narrowing.
+
+```bash
+node bin/run-eval.mjs golden --reps 1 --arm 0                 # 1 call — the cheapest real run
+node bin/run-eval.mjs golden --reps 3 --arm A --arm B-canonical   # 6 calls — the headline contrast
+node bin/run-eval.mjs golden --reps 3 --arm 0 --arm A --arm C     # 9 calls — the arm-C diagnostic
+```
+
+Two rules, both enforced before anything is spent:
+
+- **Arm C needs arm 0.** Arm C's whole construction is re-reading arm 0's
+  transcript, so `--arm C` alone is refused with the flag to add. Left to the
+  arm planner it would be skipped for "arm 0 produced no transcript" — true,
+  and no help at all in working out what to type.
+- **A selection without arm A carries no lift.** Arm A is the baseline, a lift
+  is a difference against it, and a run that did not measure the baseline has
+  no difference to report. Every comparison in such a run is
+  `comparable: false` with a reason naming the absent arm — never a `0`, which
+  reads as "memory made no difference". This is structural: the control is
+  simply not in `summaries`, so there is no check to forget. Arm A is
+  deliberately **not** forced into the selection either — a "just score the
+  seeded arm" run is a legitimate thing to want, and silently doubling the
+  cheapest run's cost to protect a number nobody asked for is the worse trade.
+
+A narrowed run records `armsRequested` on its `summary.json` (`null` when the
+whole experiment ran), and every unselected arm appears in `skippedArms` with
+`not selected` as its reason — so "arm A is missing" and "arm A was never asked
+for" are told apart by reading the artifact, not by remembering the flags.
 
 ### Running in a container (CI, Docker, a cloud sandbox)
 
@@ -347,22 +391,54 @@ plugins into the control arm, and it is non-root, so the default
 `bypassPermissions` is accepted rather than refused — both blockers above are
 absent by construction rather than worked around. Three tiers:
 
-| Tier        | Cost           | Trigger                                                   |
-| ----------- | -------------- | --------------------------------------------------------- |
-| `offline`   | free           | automatic, on a PR touching the harness or what it drives |
-| `preflight` | one model call | same                                                      |
-| `live`      | the experiment | `workflow_dispatch`, or a `run-evals` label on the PR     |
+| Tier        | Cost            | Trigger                                                   |
+| ----------- | --------------- | --------------------------------------------------------- |
+| `offline`   | free            | automatic, on a PR touching the harness or what it drives |
+| `preflight` | one model call  | same                                                      |
+| `live`      | free .. the lot | `workflow_dispatch`, or a `run-evals` label on the PR     |
 
-The dispatch form takes the subcommand, `reps` (capped at 10), a variant
-narrowing and `--skip-off-target`; it writes `summary.json`'s own caveats into
-the run's step summary and uploads `.eval-out` as an artifact. `costUsd` is
+The dispatch form takes the subcommand, `reps` (capped at 10), an **arm**
+narrowing for `golden`, a **variant** narrowing plus `--skip-off-target` for
+`variants`, and it validates every one against a literal allow-list before it
+reaches a command line. Each narrowing is refused on the subcommand it does not
+belong to — twice over, once here and once in the harness, the workflow's copy
+existing only because it fails in a second, before `pnpm install` and before
+the Claude CLI is fetched. The cheapest useful dispatch is
+`golden` / `reps: 1` / `arms: 0` — one model call.
+
+Two subcommands are deliberately absent from the choice list:
+
+- **`probe` is present and free** — it seeds a store, installs the real
+  SessionStart hook and prints what gets injected, spawning no model at all. It
+  writes no run directory, so the report, the Dash0 export and the artifact
+  upload all skip for it, driven by one `artifacts` output the resolver derives
+  rather than a growing `!= 'preflight'` chain on each step.
+- **`arm0` is absent on purpose.** It is a real subcommand and the cheapest
+  paid one, but its `summary.json` carries neither `arms[]` nor `cells{}` nor
+  `costUsd`, so the report would render empty and the Dash0 export would emit
+  no datapoints — a paid run with no record of what it bought.
+  `golden --arm 0` is the same single arm at the same cost, through the
+  pipeline that reports and exports it.
+
+**The `run-evals` label is one-shot.** The `live` gate reads the PR's _current_
+label set rather than `github.event.label.name`, because the latter is only
+populated on the `labeled` event and a push to an already-labelled PR would
+silently drop back to the free tier. The cost of that correctness is a sticky
+label that re-spends on every subsequent push — which has already billed one
+unasked-for `golden` run. The job's last step therefore removes the label
+itself, on success _and_ on failure (leaving it on after a failure is the worst
+case: the next push re-spends on a run already known to be broken). `unlabeled`
+is not in the workflow's trigger types, so that cleanup cannot re-trigger it.
+
+The step summary writes `summary.json`'s own caveats into
+the run, and `.eval-out` is uploaded as an artifact. `costUsd` is
 reported once for the run, because it is the one figure that sums across it.
 `usableReps` and the discarded count are reported **per arm** (`golden`) and
 **per variant** (`variants`), because that is the only place they exist: each
 arm and each cell discards independently, so there is no run-wide N a
 conclusion could honestly cite.
 
-Every live invocation there passes `--skip-if-unavailable`, which turns an
+Every live invocation that spawns a model passes `--skip-if-unavailable`, which turns an
 unstartable run into exit 0 plus a report naming what was missing, instead of a
 failure. That is what makes the workflow safe on a fork PR (secrets do not
 interpolate) and in a repository before the `ANTHROPIC_API_KEY` secret is added:
@@ -370,7 +446,9 @@ a job with no credential must not be red for a reason unrelated to the change.
 Locally, leave the flag off — a silent exit 0 tells you nothing, which is why it
 is opt-in rather than the default. The three preconditions it decides on live in
 `src/harness/runnable.mjs`: the binary, the credential, and `bypassPermissions`
-under root.
+under root. `probe` is not given the flag: it spawns no model, so there is no
+credential for it to be missing, and promising to skip on an unavailability
+that cannot arise is worse than not offering it.
 
 Artifacts land under `<out>/arm0-<runId>/rep-<n>/` as `transcript.jsonl`,
 `result.json` and `meta.json`, with a `summary.json` per run. They are written

--- a/packages/evals/README.md
+++ b/packages/evals/README.md
@@ -406,7 +406,7 @@ existing only because it fails in a second, before `pnpm install` and before
 the Claude CLI is fetched. The cheapest useful dispatch is
 `golden` / `reps: 1` / `arms: 0` — one model call.
 
-Two subcommands are deliberately absent from the choice list:
+Two subcommands warrant a note on the choice list:
 
 - **`probe` is present and free** — it seeds a store, installs the real
   SessionStart hook and prints what gets injected, spawning no model at all. It

--- a/packages/evals/bin/run-eval.mjs
+++ b/packages/evals/bin/run-eval.mjs
@@ -57,11 +57,13 @@ import {
   ARM_0,
   ARM_A,
   ARM_C,
+  GOLDEN_ARMS,
   armById,
   armCPrompt,
   armPlan,
   compareArms,
   describeComparison,
+  resolveArmSelection,
   summarizeArm,
   transcriptDigest,
 } from "../src/harness/golden.mjs";
@@ -87,7 +89,8 @@ Subcommands:
                        between two arms. B-organic is SKIPPED (with a stated
                        reason) unless --lesson-file supplies the lesson the loop
                        would have saved; it is never substituted with the
-                       canonical one.
+                       canonical one. Narrow the spend with --arm; a selection
+                       without arm A carries no lift, by construction.
   variants             Which FRAMING of one fact teaches best, and what does it
                        cost? Crosses the lesson ladder (rule-only … padded)
                        against an ON-TARGET task and an OFF-TARGET one, so a
@@ -124,6 +127,14 @@ Options:
                        runs (CI, Docker, cloud sandboxes) need e.g. acceptEdits.
   --lesson-file <path> golden: the organic lesson, read from a file. Without it
                        (or --lesson) the B-organic arm is skipped, never faked.
+  --arm <id>           golden: run only these arms (repeatable). Known ids:
+                       ${GOLDEN_ARMS.map((a) => a.id).join(", ")}. Empty means
+                       every arm. The cheapest real golden is one arm at
+                       --reps 1. Two rules: arm C needs arm 0 (it re-reads its
+                       transcript) and is refused without it; a selection
+                       WITHOUT arm A reports no lift at all, because a lift is
+                       a difference against the baseline and the baseline did
+                       not run — the comparison says so rather than printing 0.
   --variant <id>       variants: run only these rows (repeatable). Known ids:
                        ${VARIANT_IDS.join(", ")}.
   --skip-off-target    variants: run the on-target task only. Halves the cost
@@ -184,6 +195,10 @@ export function parseArgs(argv) {
     // narrowing, so the difference between "asked for none" and "asked for all"
     // never has to be inferred from a sentinel.
     variants: [],
+    // The same shape, for golden's arms. The two cost dials are deliberately
+    // symmetric: one is `--variant` on the variants ladder, the other `--arm`
+    // on the golden arms, and neither needs its own mental model.
+    arms: [],
     skipOffTarget: false,
     scope: null,
     scopeMode: "branch",
@@ -223,6 +238,9 @@ export function parseArgs(argv) {
         break;
       case "--variant":
         options.variants.push(rest[++i]);
+        break;
+      case "--arm":
+        options.arms.push(rest[++i]);
         break;
       case "--skip-off-target":
         options.skipOffTarget = true;
@@ -285,6 +303,12 @@ export function parseArgs(argv) {
   // real calls and produces an unreadable artifact.
   if (options.variants.some((v) => typeof v !== "string" || v.trim() === "")) {
     throw new Error("--variant requires a non-empty variant id");
+  }
+  // Same trap as `--variant`: a bare `--arm` pushes `undefined`, which would
+  // reach `resolveArmSelection` as an id and be refused there — but with a
+  // message about an unknown arm rather than about the missing value.
+  if (options.arms.some((a) => typeof a !== "string" || a.trim() === "")) {
+    throw new Error("--arm requires a non-empty arm id");
   }
   if (options.lesson && options.lessonFile) {
     throw new Error(
@@ -534,7 +558,23 @@ async function runGolden(options) {
     "golden defines each arm's own store",
     "the organic lesson goes in --lesson-file",
   );
+  // The variants ladder's dials, typed at the arms experiment. Refused rather
+  // than ignored for the reason every other refusal here exists: a caller who
+  // narrowed with `--variant` and got all four arms reads the bill as the
+  // harness misbehaving, and the cost of finding out is a paid run.
+  refuseUnhonourableFlags(
+    options,
+    ["--variant", "--skip-off-target"],
+    "golden runs ARMS, not the variants ladder",
+    "narrow the arms with --arm <id>",
+  );
   requireRunnable(options);
+
+  // Resolved BEFORE the sandbox and before `requireRunnable` has spent
+  // anything: an unknown id or a C-without-0 selection is an argument mistake,
+  // and the whole point of the flag is to spend less.
+  const selectedArms = resolveArmSelection(options.arms);
+  const narrowed = options.arms.length > 0;
 
   const id = runId();
   const outDir = path.resolve(options.out, `golden-${id}`);
@@ -546,9 +586,12 @@ async function runGolden(options) {
   const perArm = new Map();
   let priorDigest = "";
 
-  // Arm 0 first — it is the only source of the prior transcript.
-  const armsToRun = [armById(ARM_0)];
-  for (let rep = 1; rep <= options.reps; rep++) {
+  // Arm 0 first — it is the only source of the prior transcript. Skipping it
+  // when it was not selected is the ENTIRE saving of `--arm`: leaving it
+  // unconditional would charge for it on every subset run, and arm C is
+  // refused up front rather than silently pulling it back in.
+  const armsToRun = selectedArms.includes(ARM_0) ? [armById(ARM_0)] : [];
+  for (let rep = 1; armsToRun.length > 0 && rep <= options.reps; rep++) {
     const sandbox = await createSandbox({ keep: options.keep });
     try {
       const repDir = path.join(outDir, `arm-${ARM_0}`, `rep-${rep}`);
@@ -592,6 +635,11 @@ async function runGolden(options) {
   const { run: plannedArms, skipped } = armPlan({
     organicLesson: Boolean(organicLesson),
     priorTranscript: Boolean(priorDigest),
+    // `null`, not the full id list, when nothing was narrowed: the skip reason
+    // for an unselected arm names the selection, and "not selected — this run
+    // asked for 0, A, B-organic, B-canonical, C" is a sentence no unnarrowed
+    // run should ever be able to produce.
+    selected: narrowed ? selectedArms : null,
   });
 
   for (const arm of plannedArms) {
@@ -637,6 +685,11 @@ async function runGolden(options) {
     runId: id,
     model: options.model,
     repsRequested: options.reps,
+    // `null` means the whole experiment ran. A subset is recorded ON THE
+    // ARTIFACT rather than left to be inferred from which arms happen to be
+    // present, because "arm A is missing" and "arm A was never asked for" are
+    // read very differently by whoever opens this file next.
+    armsRequested: narrowed ? selectedArms : null,
     caveat:
       `N=${options.reps} per arm is a low-power INDICATOR, not proof. ` +
       `Treat every difference as directional; widening N — not reinterpreting ` +
@@ -673,8 +726,8 @@ async function runGolden(options) {
 async function runVariants(options) {
   refuseUnhonourableFlags(
     options,
-    ["--seed", "--scope", "--scope-mode", "--lesson", "--lesson-file"],
-    "variants defines its own store, scope and lesson text",
+    ["--seed", "--scope", "--scope-mode", "--lesson", "--lesson-file", "--arm"],
+    "variants defines its own store, scope and lesson text, and runs no arms",
     "pick rows with --variant <id> instead",
   );
   requireRunnable(options);
@@ -814,6 +867,16 @@ async function runArm0(options) {
     ["--seed", "--lesson"],
     "arm0 always runs against an EMPTY store",
     'or use the "probe" subcommand, which seeds',
+  );
+  // arm0 IS one arm, so a narrowing flag has nothing to narrow. It is refused
+  // rather than ignored because `--arm B-canonical` on this subcommand looks
+  // exactly like a request for the seeded arm and would silently deliver the
+  // empty-store one instead — a paid run answering a different question.
+  refuseUnhonourableFlags(
+    options,
+    ["--arm", "--variant", "--skip-off-target"],
+    "arm0 is a single fixed arm and selects nothing",
+    'narrow the arms with "golden --arm <id>"',
   );
   requireRunnable(options);
 
@@ -999,6 +1062,9 @@ async function runPreflight(options) {
       "--reps",
       "--out",
       "--dry-run",
+      "--arm",
+      "--variant",
+      "--skip-off-target",
     ],
     "preflight is a single call in a fixed empty-store arm, it writes no run directory, and the model call IS the check",
   );
@@ -1056,8 +1122,17 @@ async function runProbe(options) {
   // `--dry-run` most misleadingly of all, since probe is already dry.
   refuseUnhonourableFlags(
     options,
-    ["--reps", "--out", "--timeout", "--command", "--dry-run"],
-    "probe builds one arm, spawns no model, writes no run directory and is already dry",
+    [
+      "--reps",
+      "--out",
+      "--timeout",
+      "--command",
+      "--dry-run",
+      "--arm",
+      "--variant",
+      "--skip-off-target",
+    ],
+    "probe builds one arm, spawns no model, writes no run directory, selects nothing and is already dry",
   );
 
   const sandbox = await createSandbox({ keep: options.keep });

--- a/packages/evals/bin/run-eval.mjs
+++ b/packages/evals/bin/run-eval.mjs
@@ -577,13 +577,13 @@ async function runGolden(options) {
     "golden runs ARMS, not the variants ladder",
     "narrow the arms with --arm <id>",
   );
-  requireRunnable(options);
-
   // Resolved BEFORE the sandbox and before `requireRunnable` has spent
   // anything: an unknown id or a C-without-0 selection is an argument mistake,
   // and the whole point of the flag is to spend less.
   const selectedArms = resolveArmSelection(options.arms);
   const narrowed = options.arms.length > 0;
+
+  requireRunnable(options);
 
   const id = runId();
   const outDir = path.resolve(options.out, `golden-${id}`);

--- a/packages/evals/bin/run-eval.mjs
+++ b/packages/evals/bin/run-eval.mjs
@@ -76,7 +76,7 @@ import { gradeSandbox } from "../src/grading/grade.mjs";
 import { readInjectedLessons } from "../src/sandbox/hook-install.mjs";
 import { classifyRetrieval } from "../src/grading/retrieval.mjs";
 import { createSandbox } from "../src/sandbox/sandbox.mjs";
-import { listAll } from "../src/sandbox/store-setup.mjs";
+import { harvestOrganicLesson, listAll } from "../src/sandbox/store-setup.mjs";
 import { taskById } from "../src/harness/task.mjs";
 
 const USAGE = `Usage: node bin/run-eval.mjs <subcommand> [options]
@@ -579,12 +579,16 @@ async function runGolden(options) {
   const id = runId();
   const outDir = path.resolve(options.out, `golden-${id}`);
   const task = taskById("branch-scope");
-  const organicLesson = await readOrganicLesson(options);
+  const suppliedLesson = await readOrganicLesson(options);
 
   await fsp.mkdir(outDir, { recursive: true });
 
   const perArm = new Map();
   let priorDigest = "";
+  // What arm 0 wrote, harvested from its own store. Only consulted when the
+  // operator supplied nothing — an explicit --lesson/--lesson-file is a
+  // deliberate choice of material and always wins over a harvest.
+  let harvested = null;
 
   // Arm 0 first — it is the only source of the prior transcript. Skipping it
   // when it was not selected is the ENTIRE saving of `--arm`: leaving it
@@ -627,10 +631,27 @@ async function runGolden(options) {
       // one attempt, and averaging or concatenating several would give it
       // strictly more information than the single retry the arms model.
       if (!priorDigest) priorDigest = transcriptDigest(run.transcriptText);
+      // And the FIRST arm-0 lesson as arm B-organic's, on the same rule and
+      // for the same reason. Harvested before `dispose()` — the sandbox store
+      // is the only place this text exists.
+      if (!suppliedLesson && !harvested) {
+        harvested = await harvestOrganicLesson(sandbox);
+      }
     } finally {
       await sandbox.dispose();
     }
   }
+
+  // The operator's own material always wins; the harvest is the fallback that
+  // makes the arm reachable at all. `null` for both means the arm is skipped —
+  // the canonical lesson is never substituted here, at either layer.
+  const organicLesson =
+    suppliedLesson || (harvested && harvested.value) || null;
+  const organicSource = suppliedLesson
+    ? "operator"
+    : harvested
+      ? "arm-0"
+      : null;
 
   const { run: plannedArms, skipped } = armPlan({
     organicLesson: Boolean(organicLesson),
@@ -690,6 +711,24 @@ async function runGolden(options) {
     // present, because "arm A is missing" and "arm A was never asked for" are
     // read very differently by whoever opens this file next.
     armsRequested: narrowed ? selectedArms : null,
+    // WHERE arm B-organic's lesson came from. Recorded because the arm's whole
+    // claim is that the text is the agent's own: "operator" is a human's file
+    // and "arm-0" is this run's own write, and a reader who cannot tell them
+    // apart cannot tell whether the number is about the loop or about a person
+    // writing a good lesson. `null` means the arm did not run.
+    organicLesson: organicSource && {
+      source: organicSource,
+      chars: organicLesson.length,
+      // Present only on a harvest — where in the store it was found, and how
+      // many candidates there were, so seeding from one of several is visible.
+      ...(harvested && organicSource === "arm-0"
+        ? {
+            scope: harvested.scope,
+            key: harvested.key,
+            candidates: harvested.entries,
+          }
+        : {}),
+    },
     caveat:
       `N=${options.reps} per arm is a low-power INDICATOR, not proof. ` +
       `Treat every difference as directional; widening N — not reinterpreting ` +
@@ -737,9 +776,7 @@ async function runVariants(options) {
   // the spend behind it while every other row kept `--reps` — and emit the
   // variant twice in the ranking.
   const requested =
-    options.variants.length > 0
-      ? [...new Set(options.variants)]
-      : VARIANT_IDS;
+    options.variants.length > 0 ? [...new Set(options.variants)] : VARIANT_IDS;
   for (const id of requested) variantById(id); // refuse an unknown id up front
 
   const id = runId();
@@ -815,7 +852,9 @@ async function runVariants(options) {
     scoreVariant({
       variant,
       onTarget: cell(`${variant.id}-${onTargetTask.id}`),
-      offTarget: offTargetRun ? cell(`${variant.id}-${offTargetTask.id}`) : null,
+      offTarget: offTargetRun
+        ? cell(`${variant.id}-${offTargetTask.id}`)
+        : null,
       baselineOnTarget: cell(`baseline-${onTargetTask.id}`),
       baselineOffTarget: offTargetRun
         ? cell(`baseline-${offTargetTask.id}`)

--- a/packages/evals/bin/run-eval.mjs
+++ b/packages/evals/bin/run-eval.mjs
@@ -539,6 +539,15 @@ function totalCostUsd(summaries) {
 // is only ever tested for truthiness (`Boolean(priorDigest)`); the arm loop
 // skips `armCPrompt` under `--dry-run`, so it can never reach a model.
 const DRY_RUN_DIGEST = "(dry-run: arm 0 was planned, not run)";
+// Arm B-organic's counterpart. Shaped like a real harvest so the summary's
+// provenance block stays well-formed instead of spreading `undefined`s, and
+// self-describing for the same reason the digest above is.
+const DRY_RUN_HARVEST = Object.freeze({
+  value: "(dry-run: arm 0's lesson was planned, not harvested)",
+  key: "(dry-run)",
+  scope: "(dry-run)",
+  entries: 0,
+});
 
 /**
  * The golden experiment. Arms 0 / A / B / C, then the comparison.
@@ -615,6 +624,10 @@ async function runGolden(options) {
         // under `--dry-run`, so this value is only ever read through
         // `Boolean(priorDigest)` and never reaches a prompt.
         if (!priorDigest) priorDigest = DRY_RUN_DIGEST;
+        // Same artefact, same fix: without this the plan reports B-organic
+        // skipped for "arm 0 was not run, or ran and wrote nothing to harvest"
+        // — both clauses false under a dry run that planned arm 0.
+        if (!suppliedLesson && !harvested) harvested = DRY_RUN_HARVEST;
         continue;
       }
       const { run, record } = await runRep({

--- a/packages/evals/src/harness/golden.mjs
+++ b/packages/evals/src/harness/golden.mjs
@@ -185,10 +185,11 @@ export function armPlan({
   };
   const reasons = {
     "organic-lesson":
-      "no organic lesson supplied — pass --lesson-file <path> with the lesson " +
-      "the loop would have saved after arm 0. It is never auto-substituted " +
-      "with the canonical one, which would report a curated lesson as the " +
-      "agent's own wording.",
+      "no organic lesson — arm 0 was not run, or ran and wrote nothing to " +
+      "harvest. Supply one explicitly with --lesson-file <path>, or include " +
+      "arm 0 so its own write can be carried over. It is never auto-" +
+      "substituted with the canonical one, which would report a curated " +
+      "lesson as the agent's own wording.",
     "prior-transcript":
       "arm 0 produced no transcript to paste back, so there is nothing for " +
       "this arm to re-read.",

--- a/packages/evals/src/harness/golden.mjs
+++ b/packages/evals/src/harness/golden.mjs
@@ -106,6 +106,54 @@ export function armById(id) {
 }
 
 /**
+ * Resolve an operator-supplied `--arm` list into the arms this run will cover.
+ *
+ * Empty (or absent) means EVERY arm — an explicit list is a NARROWING, so
+ * "asked for none" and "asked for all" never have to be told apart by a
+ * sentinel. That is the same shape `--variant` already has for the variants
+ * experiment, deliberately: the two cost dials should not need different
+ * mental models.
+ *
+ * Two rules are enforced here, before anything is spent, rather than
+ * discovered from an artifact afterwards:
+ *
+ *   - an unknown id is REFUSED, because the alternative is a typo quietly
+ *     running three arms instead of four and the missing arm reading as a
+ *     result about memory;
+ *   - selecting arm C without arm 0 is REFUSED, because arm C's entire
+ *     construction is re-reading ARM 0's transcript. Left to `armPlan` it
+ *     would be skipped for "arm 0 produced no transcript" — true, and no help
+ *     at all in working out what to type instead.
+ *
+ * Arm A is deliberately NOT forced into the selection. A run without the
+ * baseline is a legitimate thing to want ("just score the seeded arm"), and
+ * its honest consequence is that the run carries no lift — which `compareArms`
+ * states per comparison, naming the absent baseline. Forcing arm A in would
+ * silently double the cheapest run's cost to protect a number the operator did
+ * not ask for.
+ *
+ * @param {string[]} [ids]  the ids the operator asked for; empty means all
+ * @returns {string[]} the selected ids, in canonical arm order
+ */
+export function resolveArmSelection(ids = []) {
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return GOLDEN_ARMS.map((a) => a.id);
+  }
+  const asked = new Set(ids);
+  for (const id of asked) armById(id); // refuses an unknown id
+  if (asked.has(ARM_C) && !asked.has(ARM_0)) {
+    throw new Error(
+      `arm ${ARM_C} re-reads arm ${ARM_0}'s transcript, so it cannot run ` +
+        `without it. Add --arm ${ARM_0}.`,
+    );
+  }
+  // Canonical order, never the order they were typed: arm 0 has to run first
+  // because it is the source of arm C's material, and an artifact read months
+  // later should list its arms the same way every time.
+  return GOLDEN_ARMS.filter((a) => asked.has(a.id)).map((a) => a.id);
+}
+
+/**
  * Decide which arms can actually run, and record WHY each excluded one cannot.
  *
  * An arm that cannot run is dropped with a stated reason rather than quietly
@@ -114,15 +162,23 @@ export function armById(id) {
  * result as if it were the loop's own wording, which is the one thing that
  * source exists to measure.
  *
+ * An arm the operator did not SELECT is dropped through the same channel, for
+ * the same reason: a cheap subset run and a run whose organic lesson was
+ * missing must be told apart by reading the artifact, not by remembering which
+ * flags were typed.
+ *
  * @param {object}  [available]
  * @param {boolean} [available.organicLesson]  an operator-supplied lesson exists
  * @param {boolean} [available.priorTranscript] arm 0 produced a transcript
+ * @param {string[]|null} [available.selected]  `--arm` narrowing; null = all
  * @returns {{ run: object[], skipped: {id: string, reason: string}[] }}
  */
 export function armPlan({
   organicLesson = false,
   priorTranscript = false,
+  selected = null,
 } = {}) {
+  const chosen = selected === null ? null : new Set(selected);
   const have = {
     "organic-lesson": Boolean(organicLesson),
     "prior-transcript": Boolean(priorTranscript),
@@ -141,6 +197,19 @@ export function armPlan({
   const run = [];
   const skipped = [];
   for (const arm of GOLDEN_ARMS) {
+    // Selection is checked FIRST. An arm the operator excluded is skipped for
+    // that reason and not for a dependency it was never going to have — arm C
+    // dropped from a `--arm 0 A` run is "not selected", never "arm 0 produced
+    // no transcript", which would read as a fault in a run that behaved.
+    if (chosen && !chosen.has(arm.id)) {
+      skipped.push({
+        id: arm.id,
+        reason:
+          `not selected — this run asked for ` +
+          `${[...chosen].join(", ")} via --arm.`,
+      });
+      continue;
+    }
     if (arm.needs && !have[arm.needs]) {
       skipped.push({ id: arm.id, reason: reasons[arm.needs] });
       continue;
@@ -309,6 +378,14 @@ export function summarizeArm(armId, reps = []) {
  * no usable reps is not a small number with wide error bars — it is not a number
  * at all, and reporting `0` or `null` as though it were a result is how a broken
  * batch gets read as "memory made no difference".
+ *
+ * A `--arm` subset that leaves the baseline out lands in exactly the same
+ * place: no control summary, so no lift, for every treatment in the run. That
+ * is the rule which makes cheap arm subsetting safe, and it is structural — it
+ * falls out of the control being absent from `summaries`, not from a check
+ * someone has to remember to write. The two cases get DIFFERENT reasons,
+ * because "the baseline never ran" and "the baseline ran and every rep was
+ * discarded" call for different actions from whoever reads the artifact.
  */
 export function compareArms(summaries = [], { baseline = BASELINE_ARM } = {}) {
   const byId = new Map(summaries.map((s) => [s.arm, s]));
@@ -349,7 +426,10 @@ export function compareArms(summaries = [], { baseline = BASELINE_ARM } = {}) {
           : null,
       reason: comparable
         ? null
-        : "not comparable: one or both arms have zero usable reps.",
+        : control === null
+          ? `not comparable: the baseline arm ${baseline} did not run, so ` +
+            `there is nothing to measure against. Add --arm ${baseline}.`
+          : "not comparable: one or both arms have zero usable reps.",
     });
   }
   return comparisons;

--- a/packages/evals/src/sandbox/store-setup.mjs
+++ b/packages/evals/src/sandbox/store-setup.mjs
@@ -106,6 +106,53 @@ export async function seedLesson(
 }
 
 /**
+ * Read back what arm 0 wrote, so arm B (organic) can be seeded with it.
+ *
+ * This is the SAME move arm C already makes with arm 0's transcript: arm 0
+ * exists to produce the material the later arms consume, and requiring an
+ * operator to ferry that material out of an artifact by hand is why the
+ * organic arm had never once run. The transcript is carried automatically;
+ * the lesson was not, and the asymmetry was not a decision.
+ *
+ * Enumerated with `listScopes()` rather than read from the target scope,
+ * for the reason `gradeSandbox` gives: the agent may have written somewhere
+ * nobody predicted — and in practice it does, since the very mistake under
+ * test is writing to a MALFORMED scope. Reading only the canonical scope
+ * would harvest nothing from exactly the runs worth harvesting.
+ *
+ * Returns `null` when arm 0 wrote nothing usable. That is a real outcome, not
+ * an error: it means the loop this experiment is about did not produce a
+ * lesson, and the caller must skip the arm rather than substitute one.
+ *
+ * @returns {Promise<null | {value: string, key: string, scope: string, entries: number}>}
+ */
+export async function harvestOrganicLesson(sandbox) {
+  const { store } = storeFor(sandbox);
+  const inventory = await store.listScopes();
+  const found = [];
+  for (const row of Array.isArray(inventory) ? inventory : []) {
+    const res = await store.list({ scope: row.scope });
+    for (const entry of (res && res.entries) || []) {
+      if (typeof entry.value === "string" && entry.value.trim() !== "") {
+        found.push({
+          value: entry.value.trim(),
+          key: entry.key,
+          scope: row.scope,
+        });
+      }
+    }
+  }
+  if (found.length === 0) return null;
+  // ONE lesson, never a concatenation of several — the same rule arm C's
+  // digest follows. Merging what the agent wrote across two writes would seed
+  // arm B with more than any single turn of the loop ever produces, which
+  // inflates the arm the whole experiment is trying to measure honestly.
+  // `list()` is newest-first, and `listScopes()` walks in a stable order, so
+  // this is the most recent write of the first scope holding one.
+  return { ...found[0], entries: found.length };
+}
+
+/**
  * Arm B (organic): seed the lesson the agent itself distilled in arm 0.
  * The text is passed in verbatim — the point of this source is that it is the
  * model's own words, warts included, not something the harness improved.

--- a/packages/evals/src/sandbox/store-setup.mjs
+++ b/packages/evals/src/sandbox/store-setup.mjs
@@ -128,7 +128,9 @@ export async function seedLesson(
  */
 export async function harvestOrganicLesson(sandbox) {
   const { store } = storeFor(sandbox);
-  const inventory = await store.listScopes();
+  const inventory = (await store.listScopes())
+    .slice()
+    .sort((a, b) => a.scope.localeCompare(b.scope));
   const found = [];
   for (const row of Array.isArray(inventory) ? inventory : []) {
     const res = await store.list({ scope: row.scope });
@@ -147,8 +149,10 @@ export async function harvestOrganicLesson(sandbox) {
   // digest follows. Merging what the agent wrote across two writes would seed
   // arm B with more than any single turn of the loop ever produces, which
   // inflates the arm the whole experiment is trying to measure honestly.
-  // `list()` is newest-first, and `listScopes()` walks in a stable order, so
-  // this is the most recent write of the first scope holding one.
+  // `list()` is newest-first, and the inventory is sorted above because
+  // `listScopes()` documents itself as unsorted (it returns `Map` insertion
+  // order from a filesystem walk), so this is the most recent write of the
+  // alphabetically-first scope holding one — deterministic across runs.
   return { ...found[0], entries: found.length };
 }
 

--- a/packages/evals/test/bin/run-eval.test.mjs
+++ b/packages/evals/test/bin/run-eval.test.mjs
@@ -49,6 +49,18 @@ test("parseArgs rejects nonsense rather than running a bad experiment", () => {
     /positive number/,
   );
   assert.throws(() => parseArgs(["arm0", "--nope"]), /unknown option/);
+  // A bare `--arm` pushes `undefined`, which would reach the selection as an
+  // id and be refused there — with a message about an unknown arm rather than
+  // about the value that was never typed. Same trap `--variant` already has.
+  assert.throws(() => parseArgs(["golden", "--arm"]), /non-empty arm id/);
+});
+
+test("--arm is repeatable and EMPTY means every arm", () => {
+  assert.deepEqual(parseArgs(["golden"]).arms, []);
+  assert.deepEqual(
+    parseArgs(["golden", "--arm", "A", "--arm", "B-canonical"]).arms,
+    ["A", "B-canonical"],
+  );
 });
 
 test("runId is filesystem-safe and sortable", () => {
@@ -168,6 +180,46 @@ test("probe refuses the run flags it cannot honour either", async () => {
   await assert.rejects(() => main(["probe", "--command", "echo"]), /--command/);
   // Already dry; the flag would have promised something probe never does.
   await assert.rejects(() => main(["probe", "--dry-run"]), /--dry-run/);
+});
+
+test("the two narrowing flags are refused by every subcommand that runs neither", async () => {
+  // `--arm` narrows golden's arms and `--variant` narrows the variants ladder.
+  // Crossed over, or aimed at a subcommand that is already a single fixed
+  // arm, they select nothing — and being SILENTLY IGNORED is the failure that
+  // matters: `arm0 --arm B-canonical` reads exactly like a request for the
+  // seeded arm and would have delivered the empty-store one at full price.
+  await assert.rejects(
+    () => main(["golden", "--dry-run", "--variant", "full"]),
+    /golden runs ARMS, not the variants ladder/,
+  );
+  await assert.rejects(
+    () => main(["golden", "--dry-run", "--skip-off-target"]),
+    /--skip-off-target cannot be honoured here/,
+  );
+  await assert.rejects(
+    () => main(["variants", "--dry-run", "--arm", "A"]),
+    /--arm cannot be honoured here/,
+  );
+  await assert.rejects(
+    () => main(["arm0", "--dry-run", "--arm", "B-canonical"]),
+    /arm0 is a single fixed arm and selects nothing/,
+  );
+  await assert.rejects(() => main(["probe", "--arm", "A"]), /--arm/);
+  await assert.rejects(() => main(["preflight", "--arm", "A"]), /--arm/);
+});
+
+test("golden refuses a bad --arm selection BEFORE it spends anything", async () => {
+  // Both land in `resolveArmSelection`, which runs above `createSandbox` and
+  // above the first model call — the whole point of the flag is to spend less,
+  // so learning the selection was wrong from the bill would defeat it.
+  await assert.rejects(
+    () => main(["golden", "--dry-run", "--arm", "nope"]),
+    /unknown arm/,
+  );
+  await assert.rejects(
+    () => main(["golden", "--dry-run", "--arm", "C"]),
+    /Add --arm 0/,
+  );
 });
 
 test("parseArgs records which flags were actually typed", () => {

--- a/packages/evals/test/harness/golden.test.mjs
+++ b/packages/evals/test/harness/golden.test.mjs
@@ -21,6 +21,7 @@ import {
   compareArms,
   describeComparison,
   isUsable,
+  resolveArmSelection,
   summarizeArm,
   transcriptDigest,
 } from "../../src/harness/golden.mjs";
@@ -87,6 +88,81 @@ test("with everything available, all five arms run", () => {
   });
   assert.equal(run.length, GOLDEN_ARMS.length);
   assert.deepEqual(skipped, []);
+});
+
+test("an empty --arm list is every arm, and a list is a NARROWING", () => {
+  assert.deepEqual(
+    resolveArmSelection([]),
+    GOLDEN_ARMS.map((a) => a.id),
+  );
+  assert.deepEqual(
+    resolveArmSelection(),
+    GOLDEN_ARMS.map((a) => a.id),
+  );
+  assert.deepEqual(resolveArmSelection([ARM_A, ARM_B_CANONICAL]), [
+    ARM_A,
+    ARM_B_CANONICAL,
+  ]);
+});
+
+test("--arm returns CANONICAL order, not the order they were typed", () => {
+  // Arm 0 has to run first — it is the source of arm C's material — so the
+  // selection cannot be allowed to hand back a list that puts it last.
+  assert.deepEqual(resolveArmSelection([ARM_C, ARM_A, ARM_0]), [
+    ARM_0,
+    ARM_A,
+    ARM_C,
+  ]);
+  // Repeats collapse: a doubled id would otherwise run the arm twice, paying
+  // twice for one cell, exactly as a repeated --variant once did.
+  assert.deepEqual(resolveArmSelection([ARM_A, ARM_A]), [ARM_A]);
+});
+
+test("--arm refuses an unknown id rather than running a smaller experiment", () => {
+  assert.throws(() => resolveArmSelection(["B-cannonical"]), /unknown arm/);
+});
+
+test("--arm C without arm 0 is refused, and the message says what to type", () => {
+  // Arm C re-reads arm 0's transcript. Left to armPlan this is skipped for
+  // "arm 0 produced no transcript" — accurate, and useless as guidance.
+  assert.throws(() => resolveArmSelection([ARM_C]), /Add --arm 0/);
+  assert.doesNotThrow(() => resolveArmSelection([ARM_0, ARM_C]));
+});
+
+test("an unselected arm is skipped for NOT BEING SELECTED, not for a missing dep", () => {
+  const { run, skipped } = armPlan({
+    organicLesson: true,
+    priorTranscript: false,
+    selected: [ARM_A, ARM_B_CANONICAL],
+  });
+  assert.deepEqual(
+    run.map((a) => a.id),
+    [ARM_A, ARM_B_CANONICAL],
+  );
+  const c = skipped.find((s) => s.id === ARM_C);
+  assert.match(c.reason, /not selected/);
+  // The dependency reason would be TRUE here too — arm 0 was not run, so
+  // there is no transcript — and reporting it would read as a fault in a run
+  // that did exactly what it was asked.
+  assert.doesNotMatch(c.reason, /no transcript/);
+});
+
+test("a --arm subset that omits the baseline reports NO lift, and says why", () => {
+  // The rule that makes cheap subsetting safe. It is structural — the control
+  // is simply absent from `summaries` — but the REASON has to distinguish
+  // this from a baseline that ran and was entirely discarded, because the two
+  // ask the reader for different things.
+  const [b] = compareArms([
+    summarizeArm(ARM_B_CANONICAL, [clean({ success: true, score: 100 })]),
+  ]);
+  assert.equal(b.comparable, false);
+  assert.equal(b.successRateLift, null);
+  assert.equal(b.meanScoreLift, null);
+  assert.equal(b.repeatedMistakeDelta, null);
+  assert.match(b.reason, /baseline arm A did not run/);
+  assert.match(describeComparison(b), /Add --arm A/);
+  // And it must NOT claim the reps were unusable — they were fine.
+  assert.doesNotMatch(b.reason, /usable reps/);
 });
 
 test("a contaminated or harness-fault rep is not usable", () => {

--- a/packages/evals/test/sandbox/store-setup.test.mjs
+++ b/packages/evals/test/sandbox/store-setup.test.mjs
@@ -1,0 +1,77 @@
+// Harvesting arm 0's own lesson, which is what makes arm B-organic reachable.
+//
+// These run against a real scratch sandbox and the real store resolution
+// chain, with no model: the thing under test is whether the harness can read
+// back what an agent wrote, and seeding through the same write path the agent
+// uses is the only way that question is being asked honestly.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { withSandbox } from "../../src/sandbox/sandbox.mjs";
+import {
+  harvestOrganicLesson,
+  seedLesson,
+} from "../../src/sandbox/store-setup.mjs";
+
+test("an empty arm-0 store harvests NOTHING, rather than something", async () => {
+  await withSandbox({}, async (sandbox) => {
+    // The arm ran and wrote nothing. That is a real outcome about the loop,
+    // and the caller has to skip the arm — never substitute a lesson.
+    assert.equal(await harvestOrganicLesson(sandbox), null);
+  });
+});
+
+test("the lesson is harvested from the MALFORMED scope the agent actually used", async () => {
+  await withSandbox({}, async (sandbox) => {
+    // The exact shape observed in run 34109382154: every unseeded rep wrote to
+    // `branch::owner/repo@branch`, using `@` where the second `::` belongs.
+    // Harvesting only the canonical scope would return nothing from precisely
+    // the runs worth harvesting — the ones that made the mistake.
+    await seedLesson(sandbox, {
+      scope: "branch::mthines/gw-tools@feat/x",
+      key: "scope-format-lesson",
+      value: "Use :: between repo and branch.",
+    });
+    const found = await harvestOrganicLesson(sandbox);
+    assert.equal(found.value, "Use :: between repo and branch.");
+    assert.equal(found.scope, "branch::mthines/gw-tools@feat/x");
+    assert.equal(found.key, "scope-format-lesson");
+    assert.equal(found.entries, 1);
+  });
+});
+
+test("several writes harvest ONE lesson, and say how many there were", async () => {
+  await withSandbox({}, async (sandbox) => {
+    await seedLesson(sandbox, {
+      scope: "global",
+      key: "first",
+      value: "first lesson",
+    });
+    await seedLesson(sandbox, {
+      scope: "global",
+      key: "second",
+      value: "second lesson",
+    });
+    const found = await harvestOrganicLesson(sandbox);
+    // Never a concatenation: seeding arm B with two turns' output would give it
+    // more than any single pass of the loop produces, inflating the very arm
+    // the experiment exists to measure.
+    assert.ok(["first lesson", "second lesson"].includes(found.value));
+    assert.doesNotMatch(found.value, /first lesson[\s\S]*second lesson/);
+    // But the ambiguity is REPORTED, not hidden — a reader can see the pick.
+    assert.equal(found.entries, 2);
+  });
+});
+
+test("a body-less write is not harvestable material", async () => {
+  await withSandbox({}, async (sandbox) => {
+    // `seedLesson` refuses an empty body, so reaching this state means the
+    // store itself holds a blank entry; harvesting it would seed arm B with
+    // nothing and still report the arm as having run.
+    await assert.rejects(
+      () => seedLesson(sandbox, { scope: "global", key: "k", value: "   " }),
+      /non-empty lesson body/,
+    );
+    assert.equal(await harvestOrganicLesson(sandbox), null);
+  });
+});


### PR DESCRIPTION
Arm `B-organic` — the arm that asks whether **the lesson the loop writes by itself** helps, as opposed to a hand-curated one — had never once run. Not through neglect. Arm 0's *transcript* is carried into arm C automatically, in-process, but arm 0's *lesson* was carried nowhere: an operator had to ferry the text out of a CI artifact by hand and pass it back as `--lesson-file`, and `evals.yml` has no such input. The arm was unreachable from the only place the eval actually runs. That asymmetry was never a decision.

Three changes, smallest first.

**`--arm` narrows a golden run.** Repeatable, "all" when empty, so the cheapest real experiment is one arm at `--reps 1` — a single model call instead of fifteen. The one thing a subset cannot buy is a lift it did not measure: a selection without arm A has no baseline, so every comparison in it reports `comparable: false` and names the absent arm rather than printing a `0` that reads as "memory made no difference". That is structural — the control is simply not in the summary — not a check anyone has to remember.

**The workflow exposes the cost dials.** `arms` joins `reps`/`variants` as a dispatch input, allow-listed before it reaches a command line like its siblings. `probe` also joins the `subcommand` choice list, where it was previously absent — it seeds a store, installs the real SessionStart hook, prints what gets injected, and spawns no model at all, so it is the free way to see the delivery path. A `run-evals` label no longer re-spends on every subsequent push. Dropping that label needs the issues API, so the live job gains `pull-requests: write` scoped to exactly that step; the same job also checks out with `persist-credentials: false`, because it is the job that spawns the agent under test and nothing in it uses git auth.

**Arm 0's lesson now carries the way its transcript already does.** `harvestOrganicLesson` reads arm 0's own store, so `golden --arm 0 --arm A --arm B-organic` self-supplies. It enumerates with `listScopes()` rather than reading the target scope, for the reason `gradeSandbox` gives — the agent may have written somewhere nobody predicted, and here it demonstrably does, since the mistake under test *is* writing to a malformed scope. Three invariants hold: an explicit `--lesson-file` always wins; nothing is ever substituted (arm 0 writing nothing returns `null` and the arm is skipped, because "the loop produced no lesson" is a real result about the loop); and one lesson is seeded, never a concatenation, with the ambiguity reported rather than hidden. The summary records provenance, because a reader who cannot tell a harvest from a human's curated file cannot tell whether the number is about the loop or about someone writing a good lesson.

## The result it bought

[Run 34147112488](https://github.com/mthines/lorekit/actions/runs/34147112488), live against a frontier model, ~$1.08:

| Arm | Seed | Success | Mean score |
|---|---|---|---|
| 0 | empty, writes on | 0/3 | 20.0 |
| A (baseline) | empty | 1/3 | 46.7 |
| B-organic | arm 0's own harvested lesson | **3/3** | **100.0** |

`B-organic vs A: 100% vs 33% success (+67 pts), on 3 vs 3 usable reps — an INDICATOR at this N, not a significance claim.` `comparable: true`, 0 discarded, `environmentClean` on all nine reps.

The seeded lesson was written by an agent that got the answer **wrong** — arm 0 was 0/3, every rep storing `branch::…@feat/x` with `@` where the second `::` belongs. That agent's own lesson, harvested out of the malformed scope it stored it under, took a fresh agent from 1/3 to 3/3.

**Limits.** N=3; the harness refuses to call this significance and so does this description. Arm A's baseline moves between runs (0/3 in run 34109382154, 1/3 here), so the +67 is measured against an unstable control. One task, one lesson. The harvest used arm 0 rep 1's lesson only.

## Review round

Six findings from the review pass are absorbed, one commit each. Two were substantive rather than cosmetic:

- **`--dry-run` could not reach arm B-organic.** `harvested` was assigned only on the live path, so a dry run planned arm 0 yet reported B-organic skipped for "arm 0 was not run, or ran and wrote nothing to harvest" — both clauses false. This is the same artefact `DRY_RUN_DIGEST` was added to prevent for arm C, not carried across when the new accumulator landed. Since `--dry-run` is the only free way to exercise this arm's wiring, the free tier could not cover the arm the PR exists to add. Fixed with a harvest-shaped `DRY_RUN_HARVEST` sentinel — shaped, not a bare string, because the summary spreads `harvested.scope`/`.key`/`.entries` and a string would spread `undefined`s onto the artifact.
- **The harvest's scope order was undefined.** Both store implementations end their `listScopes()` docblock with "unsorted" — they return `Map` insertion order from a filesystem walk — so which scope seeded the arm was not reproducible, and the comment asserting a stable walk was simply false. The inventory is now sorted and the comment says what the code does.

The rest: the label-drop step no longer reports every DELETE failure as "already removed" (a 403 or 5xx left the label on while claiming it was gone), `resolveArmSelection` moved above `requireRunnable` so a bad `--arm` errors instead of exiting 0 as "skipped" under `--skip-if-unavailable`, and the README's choice-list heading now matches its bullets.

One reuse item is left open deliberately: `harvestOrganicLesson` hand-rolls envelope handling that `packages/cli/src/store/scope-inventory.mjs` centralises. It is a real cleanup, but the sandbox pins `LOREKIT_MODE=local`, so the store disagreement that helper exists for cannot reach this caller — consistency, not a bug, and out of scope here.

**Docs.** `packages/evals/README.md` covers the new flag, the input, and the harvest. No user-facing surface applies: `@lorekit/evals` is a private internal harness — no MCP tool, REST route, `lorekit` CLI command, config key or dashboard surface — so `llms.txt` and `src/content/docs` are untouched by design.

**Tests.** 250 pass, 0 fail (246 before, plus 4 for the harvest). The `listScopes()` enumeration is mutation-checked: hardcoding the canonical scope kills 2 of the 4.

https://claude.ai/code/session_01KsH5DqmA4jYkAf1gfWG1Xk

---
_Generated by [Claude Code](https://claude.ai/code/session_01KsH5DqmA4jYkAf1gfWG1Xk)_