### PR TITLE
feat(feature-flags): default insights-page to on

### DIFF
--- a/packages/feature-flags/generated/flags.manifest.json
+++ b/packages/feature-flags/generated/flags.manifest.json
@@ -10,7 +10,7 @@
         "off": false,
         "on": true
       },
-      "defaultVariant": "off",
+      "defaultVariant": "on",
       "experiment": null,
       "owner": "@lorekit/web",
       "tags": [

--- a/packages/feature-flags/src/client.spec.ts
+++ b/packages/feature-flags/src/client.spec.ts
@@ -27,7 +27,7 @@ describe('evaluateFlag', () => {
   });
 
   it('resolves a static boolean flag to its default variant value', async () => {
-    expect(await evaluateFlag('insights-page')).toBe(false);
+    expect(await evaluateFlag('insights-page')).toBe(true);
   });
 
   it('resolves the same flag identically across calls (no per-call state)', async () => {
@@ -53,13 +53,13 @@ describe('evaluateFlagDetails', () => {
 
   it('returns variant and reason alongside the value', async () => {
     const details = await evaluateFlagDetails('insights-page');
-    expect(details).toMatchObject({ value: false, variant: 'off', reason: 'STATIC' });
+    expect(details).toMatchObject({ value: true, variant: 'on', reason: 'STATIC' });
   });
 
   it('reports OVERRIDE when a session override is present', async () => {
     const details = await evaluateFlagDetails('insights-page', {
-      flagOverrides: { 'insights-page': 'on' },
+      flagOverrides: { 'insights-page': 'off' },
     });
-    expect(details).toMatchObject({ value: true, variant: 'on', reason: 'OVERRIDE' });
+    expect(details).toMatchObject({ value: false, variant: 'off', reason: 'OVERRIDE' });
   });
 });

--- a/packages/feature-flags/src/registry.ts
+++ b/packages/feature-flags/src/registry.ts
@@ -54,7 +54,7 @@ const REGISTRY_INPUT = [
       'The consolidated /insights dashboard page (usage health, agent breakdown, scope consumption, hot/cold lore, runs) — gates the page itself (404 when off), its sidebar nav item, and its command-palette entry.',
     type: 'boolean',
     variants: { off: false, on: true },
-    defaultVariant: 'off',
+    defaultVariant: 'on',
     owner: '@lorekit/web',
     tags: ['dashboard', 'web', 'rollout'],
   },


### PR DESCRIPTION
## Why

The `/insights` dashboard has been gated behind the `insights-page` rollout flag, off by default. It's ready to be on for everyone, so this flips the gate rather than making users opt in via a developer override.

## What changed

- `insights-page` `defaultVariant`: `off` → `on` in the registry, so the page, its sidebar nav item, and its command-palette entry are enabled by default
- Regenerated `flags.manifest.json` (TS bindings are type-only, unaffected)
- Updated `client.spec.ts`, which used this flag as its static-default fixture; the OVERRIDE test now overrides to `off` so it still demonstrably differs from the default
- Synced the Storybook flag seed in `mocks/decorators.tsx` to the registry default (the file's contract is to mirror it)

## How to verify

- `nx test feature-flags` green; `/insights` reachable without a developer override