### PR TITLE
Add preview dataset seeding for demo lore and usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       migrations: ${{ steps.filter.outputs.migrations }}
       bench: ${{ steps.filter.outputs.bench }}
       deploy: ${{ steps.filter.outputs.deploy }}
+      seed: ${{ steps.filter.outputs.seed }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
@@ -167,6 +168,15 @@ jobs:
             echo "deploy=true" >> "$GITHUB_OUTPUT"
           else
             echo "deploy=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Preview-seed gate: the pure dataset/SQL builders `/preview --seed`
+          # runs against the shared preview project. `scripts/**` is outside
+          # `nx affected`, so without this job a change here would ship with
+          # its own tests never having run.
+          if printf '%s\n' "$CHANGED" | grep -qE '^(scripts/seed/|\.github/workflows/(preview|rebuild-preview|ci)\.yml)'; then
+            echo "seed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "seed=false" >> "$GITHUB_OUTPUT"
           fi
           # Benchmark gate: the row-scaling sweep and the load test, and the
           # pure modules their unit tests protect. Its own filter — naming its
@@ -501,6 +511,26 @@ jobs:
       # node's built-in runner, zero deps — no install step needed.
       - name: Unit-test the deploy-scope resolver
         run: node --test scripts/ci/resolve-deploy-scope.test.mjs
+
+  seed-tests:
+    name: Preview-seed dataset/SQL builders (unit)
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.seed == 'true'
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 20
+
+      # node's built-in runner, zero deps — no install step needed.
+      - name: Unit-test the seed dataset, SQL builders, and CLI
+        run: node --test scripts/seed/preview-dataset.test.mjs scripts/seed/preview-sql.test.mjs scripts/seed/seed-preview.test.mjs
 
   # ── Web-preview filter — the decision that spends Vercel quota ───────────────
   #    The filter deciding whether a push deploys a dashboard preview exists in
@@ -839,7 +869,7 @@ jobs:
     # `always()` so the gate still runs (and reports) even when an upstream job
     # failed, was cancelled, or was skipped — otherwise it would be skipped too.
     if: always()
-    needs: [changes, check, plugin, integration, web-test, migration-order, deploy-scope, preview-filter, bench-tests, edge-typecheck]
+    needs: [changes, check, plugin, integration, web-test, migration-order, deploy-scope, seed-tests, preview-filter, bench-tests, edge-typecheck]
     permissions: {}
     steps:
       - name: Aggregate job results into a pass/fail gate

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -51,11 +51,17 @@ jobs:
       pr_number: ${{ github.event.issue.number }}
       pr_sha: ${{ steps.pr.outputs.sha }}
       pr_branch: ${{ steps.pr.outputs.branch }}
+      seed: ${{ steps.check.outputs.seed }}
     steps:
       - name: Check commenter authorization
         id: check
         env:
           ASSOCIATION: ${{ github.event.comment.author_association }}
+          # Read only through an env var, never interpolated into the shell —
+          # `${{ github.event.comment.body }}` inside a `run:` is a script-
+          # injection vector (same rule web-preview.yml documents for its
+          # `--if-changed` flag).
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           case "$ASSOCIATION" in
             OWNER|MEMBER|COLLABORATOR)
@@ -65,6 +71,15 @@ jobs:
               echo "authorized=false" >> "$GITHUB_OUTPUT"
               ;;
           esac
+          # Opt-in only: `/preview` alone never seeds. See "Seed the preview
+          # with demo data" in docs/deployment.md for why this stays opt-in —
+          # the preview project is shared across every open PR's `/preview`
+          # run, and most runs never open the dashboard.
+          if printf '%s\n' "$COMMENT_BODY" | grep -qE -- '--seed\b'; then
+            echo "seed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "seed=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Add 👀 reaction
         if: steps.check.outputs.authorized == 'true'
@@ -163,6 +178,45 @@ jobs:
 
       - name: Deploy edge functions
         run: supabase functions deploy --no-verify-jwt --project-ref "$PROJECT_REF"
+
+  # Opt-in only: `/preview --seed` (never plain `/preview`). Runs after the
+  # migrations are on the project, in parallel with deploy-web/smoke — it
+  # writes DEMO rows under the fixed smoke-user account, backdated so the
+  # dashboard's Insights/heatmap/Explorer read as a lived-in workspace instead
+  # of empty. See "Seed the preview with demo data" in docs/deployment.md.
+  seed:
+    name: Seed preview data
+    runs-on: ubuntu-latest
+    needs: [guard, deploy-api]
+    if: needs.guard.outputs.authorized == 'true' && needs.guard.outputs.seed == 'true'
+    environment: preview
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.guard.outputs.pr_sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 20
+
+      # The seed targets the fixed smoke user (LOREKIT_SMOKE_EMAIL) — the same
+      # account the orgs REST smoke signs in as — so it is optional in the
+      # same way that suite is: unset → skip, announced, never fail the run.
+      - name: Seed as the fixed smoke user (optional)
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+          LOREKIT_SMOKE_EMAIL: ${{ secrets.LOREKIT_SMOKE_EMAIL }}
+        run: |
+          if [ -z "$LOREKIT_SMOKE_EMAIL" ]; then
+            echo "::warning::--seed requested but LOREKIT_SMOKE_EMAIL is not set — skipping. Seed it once with scripts/smoke/seed-smoke-user.mjs to enable /preview --seed."
+            exit 0
+          fi
+          node scripts/seed/seed-preview.mjs --user-email "$LOREKIT_SMOKE_EMAIL"
 
   deploy-web:
     name: Deploy web → Vercel preview
@@ -373,7 +427,7 @@ jobs:
     name: Post result comment
     runs-on: ubuntu-latest
     if: always() && needs.guard.outputs.authorized == 'true'
-    needs: [guard, deploy-api, deploy-web, smoke]
+    needs: [guard, deploy-api, deploy-web, smoke, seed]
     environment: preview
     permissions:
       pull-requests: write
@@ -385,6 +439,8 @@ jobs:
           RESULT_DEPLOY_API: ${{ needs.deploy-api.result }}
           RESULT_DEPLOY_WEB: ${{ needs.deploy-web.result }}
           RESULT_SMOKE: ${{ needs.smoke.result }}
+          RESULT_SEED: ${{ needs.seed.result }}
+          SEED_REQUESTED: ${{ needs.guard.outputs.seed }}
           VERCEL_URL: ${{ needs.deploy-web.outputs.vercel_url }}
           PR_SHA: ${{ needs.guard.outputs.pr_sha }}
           PR_BRANCH: ${{ needs.guard.outputs.pr_branch }}
@@ -395,6 +451,8 @@ jobs:
             const api   = process.env.RESULT_DEPLOY_API;
             const web   = process.env.RESULT_DEPLOY_WEB;
             const smoke = process.env.RESULT_SMOKE;
+            const seed  = process.env.RESULT_SEED;
+            const seedRequested = process.env.SEED_REQUESTED === 'true';
             const vUrl  = process.env.VERCEL_URL || '';
             const hasWeb = /^https?:\/\//.test(vUrl);
             const webLink = hasWeb ? `[${vUrl}](${vUrl})` : '(not available)';
@@ -415,11 +473,18 @@ jobs:
               `| API (Supabase edge functions + migrations) | ${icon(api)} ${api} |`,
               `| Web (Vercel preview) | ${icon(web)} ${web} |`,
               `| Smoke tests | ${icon(smoke)} ${smoke} |`,
+              // Never reveal the smoke-user's email here — this is a public PR
+              // comment, not a masked Actions log. Sign-in details live in
+              // docs/deployment.md, not the report.
+              ...(seedRequested ? [`| Seed demo data | ${icon(seed)} ${seed} |`] : []),
               '',
               '**Endpoints:**',
               `- API: ${apiUrl}`,
               `- Web: ${webLink}`,
               '',
+              ...(seedRequested && seed === 'success'
+                ? ['Seeded with demo data — sign in as the preview\'s smoke-test account (see docs/deployment.md → "Seed the preview with demo data") and filter the Explorer by `preview-seed/` to find it.', '']
+                : []),
               `[View workflow run](${runUrl})`,
             ].join('\n');
             await github.rest.issues.createComment({

--- a/.github/workflows/rebuild-preview.yml
+++ b/.github/workflows/rebuild-preview.yml
@@ -152,6 +152,7 @@ jobs:
       - name: Remind to re-seed the orgs-smoke user
         run: |
           echo "::notice::Preview DB was reset — re-seed the orgs-smoke user out-of-band with scripts/smoke/seed-smoke-user.mjs (needs the service-role key; not run in CI). Until then the orgs REST smoke self-skips."
+          echo "::notice::The reset also wiped any demo data from a prior '/preview --seed'. Once the smoke user is re-seeded, repopulate it with a '/preview --seed' comment on any open PR (see docs/deployment.md → 'Seed the preview with demo data') — not done here, for the same service-role-key reason."
 
       - name: Deploy edge functions (mcp + health)
         # Retry up to 3 times with 10 s back-off to tolerate transient OOM

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,7 @@ Do NOT skip steps or change the order, whether the PR is a draft or ready for re
 
 Before Step 1, settle the docs: apply
 [User-facing docs](#user-facing-docs-mandatory-on-every-change) and commit those edits with the
-change they document, so `/polish` and the review bot see the finished diff.
+change they document, so `/polish` and `review-loop`'s `pr-reviewer` pass see the finished diff.
 
 ### Prerequisites — install agent-skills (once per sandbox)
 
@@ -320,53 +320,58 @@ are surfaced for awareness but do not block the workflow — they require a huma
 
 Skip this step only if the branch diff is non-code only (docs, lockfiles, generated artefacts).
 
-### Step 2 — Open the PR with `/create-pr --no-review` (as a draft)
+### Step 2 — Open the PR with `/create-pr` (as a draft)
 
-Open the PR with `/create-pr` (it opens as a **draft** — the draft state is what lets the `dash0-dev`
-bot post inline comments while the branch converges).
+Open the PR with `/create-pr` (it opens as a **draft** — the draft state is what lets `review-loop`'s
+`pr-reviewer` pass post inline comments while the branch converges).
 
-**Always pass `--no-review`.** This repo has the `dash0-dev` bot, which runs the `pr-reviewer` agent on
-the PR automatically (Step 3), so `/create-pr`'s built-in `review-loop` would run a **second**
-`pr-reviewer` on the same PR — a duplicate review by the same agent, for no gain. `--no-review` drops
-that local reviewer pass while **keeping** `create-pr`'s `polish simplify` and, crucially, its
-external-bot feedback loop (which is Step 4). Do **not** pass `--no-feedback` (that skips Step 4) or
-`--no-quality`. Undrafting is the last, human step, after the flow reaches ready-to-review.
+**Do not pass `--no-review`.** This repo has no external review bot, so the review pass is
+`/create-pr`'s own built-in `review-loop` — dropping it would leave the PR unreviewed. By default
+(no quality flags) `/create-pr`'s Step 6.5 runs `Skill("review-loop", "<pr-url> --no-ci")` for you
+immediately after opening the PR (Step 3 below covers what that does). Do **not** pass `--no-feedback`
+(that skips Step 4) or `--no-quality` (that skips Step 3 and Step 4 both). Undrafting is the last,
+human step, after the flow reaches ready-to-review.
 
-> **The one review agent on the PR is the `dash0-dev` bot — never run a second `pr-reviewer` locally.**
-> `/polish` (Step 1) runs pre-PR, where its reviewer pass (Pass A) is **skipped** — `pr-reviewer` has no
-> PR-less mode — so Step 1 only runs the `simplify` pass and never posts to GitHub; `review-loop` runs
-> `pr-reviewer` ON the open PR, where it posts a `COMMENT` review, so it is excluded here to avoid
-> duplicating the `dash0-dev` review.
+### Step 3 — `review-loop` converges the PR (the ONE review agent on the PR)
 
-### Step 3 — The `dash0-dev` bot reviews (the ONE review agent on the PR)
+`review-loop` is the sole reviewer here — there is no external bot to defer to. `/create-pr`'s Step 6.5
+invokes it automatically as `Skill("review-loop", "<pr-url> --no-ci")`: up to 5 iterations of
+`pr-reviewer` (dispatched fresh each round, read-only, posts one `COMMENT` review, and **re-reviews on
+every new push**, marking its own addressed findings resolved) → `implement-suggestion --resolve-all`
+(applies actionable findings, and replies-to-and-resolves the non-fix threads it can honestly close) →
+`polish simplify` (Class M mechanical refactors) — converging until **every review thread is resolved**,
+either by a fix or an honest reply. The only threads left open at exit are genuine human-judgment flags
+the loop will neither auto-apply nor honestly decline. On convergence it also refreshes the PR
+description to match the shipped diff — do not re-edit the body yourself afterward.
 
-The `dash0-dev` bot runs `pr-reviewer` server-side and posts a `COMMENT` review automatically — **and
-re-reviews on every new commit** (a `synchronize` push), marking addressed findings "Superseded /
-Resolving." You do NOT trigger it manually, and you do NOT run a second reviewer against the PR. Two
-facts to remember: a verdict is pinned to a `commit_id`, so a gate summary can be **stale on an older
-SHA** while already resolved on `HEAD` — check which commit a comment targets before treating it as
-open; and a push mid-review can anchor the next comments to your new SHA while still describing
-*pre-fix* content, so re-verify against `HEAD` (`git show HEAD:<file>`) rather than trusting a
-just-arrived comment.
+You do NOT need to trigger this manually if you opened the PR with `/create-pr` (Step 2) — it is
+already running. If you push a follow-up commit by hand afterward, re-run it yourself:
 
-### Step 4 — Absorb the bot's feedback with `/implement-suggestion --watch`
+```
+Skill("review-loop", "<pr-url> --no-ci")
+```
 
-`/create-pr` dispatches this automatically after opening the PR (its external-bot feedback step) as a
-**background** sub-agent — so if you opened the PR with `/create-pr` (Step 2) it is already running. If
-you pushed a follow-up commit by hand, or need to drive it yourself, dispatch a background sub-agent
-(`run_in_background: true`, subagent_type: general):
+(`--no-ci` because Step 5 below owns driving CI green; `review-loop` would otherwise also try.)
+
+### Step 4 — Absorb genuine external feedback with `/implement-suggestion --watch`
+
+This step exists for **real** external parties — CodeRabbit, a human reviewer — not a self-review
+duplicate. `/create-pr` dispatches it automatically once `review-loop` converges (its Step 6.7,
+external-bot feedback step) as a **background** sub-agent — so if you opened the PR with `/create-pr`
+(Step 2) it is already running. It is scoped to comments posted **after** `review-loop`'s last push, so
+it never re-applies `review-loop`'s own findings. If you need to drive it yourself, dispatch a
+background sub-agent (`run_in_background: true`, subagent_type: general):
 
 > Invoke: Skill('implement-suggestion', '<pr-url> --watch')
-> Absorb the `dash0-dev` (and any CodeRabbit / human) review feedback to completion. It never opens a
-> new PR and never undrafts this one. Return its per-iteration watch report.
+> Absorb any CodeRabbit / human review feedback to completion. It never opens a new PR and never
+> undrafts this one. Return its per-iteration watch report.
 
-`--watch` waits for each `dash0-dev` review, applies the actionable comments (**one commit per
-comment**, each gated by `/critical` then `/confidence`), pushes, and repeats — **bounded to 5
-iterations** (`--max-iters` default; hard cap 10), processing only comments newer than the last round
-so it never re-applies one. It **never undrafts**. Do **not** post `@dash0 resolve` — agent-posted
-comments don't trigger the webhook; the skill resolves threads via the API directly.
+`--watch` waits for each external review, applies the actionable comments (**one commit per comment**,
+each gated by `/critical` then `/confidence`), pushes, and repeats — **bounded to 5 iterations**
+(`--max-iters` default; hard cap 10), processing only comments newer than the last round so it never
+re-applies one. It **never undrafts**.
 
-### Step 5 — Drive CI green; ready-to-review = bot PASS + green CI
+### Step 5 — Drive CI green; ready-to-review = `review-loop` converged + green CI
 
 `/create-pr` watches CI and delegates mechanical failures to `/ci-auto-fix` for you. For any red check
 on a hand-pushed commit, run it yourself:
@@ -378,12 +383,15 @@ on a hand-pushed commit, run it yourself:
 This uses the `ci-auto-fix` skill (wired in during Prerequisites), diagnoses any failing GitHub
 Actions checks, applies a minimal targeted fix, and iterates until all checks are green. The skill
 is confidence-gated (>=90 auto-apply, 80-89 ask, <80 escalate) and will never disable or weaken a
-check. Skip only when CI is already fully green. A `/ci-auto-fix` push is itself a new commit, so it
-re-triggers the `dash0-dev` review that Step 4 then absorbs — the loops converge.
+check. Skip only when CI is already fully green. A `/ci-auto-fix` push is itself a new commit, so if
+you're driving this by hand, re-run Step 3's `Skill("review-loop", "<pr-url> --no-ci")` afterward to
+re-verify against the new head — `/create-pr`'s own run of Steps 6.5/6.7/7–9 already sequences this for
+you end to end.
 
-**Definition of ready-to-review:** the `dash0-dev` review is PASS with no open actionable findings
-**and** every CI check is green. That is the *content* state this flow drives to; the agent does
-**not** flip the draft flag — undrafting stays a human/explicit decision.
+**Definition of ready-to-review:** `review-loop`'s final `pr-reviewer` verdict is PASS with zero open
+threads (only genuine human-judgment flags may remain, and those must be surfaced to the user) **and**
+every CI check is green. That is the *content* state this flow drives to; the agent does **not** flip
+the draft flag — undrafting stays a human/explicit decision.
 
 ### Summary table
 
@@ -392,10 +400,10 @@ re-triggers the `dash0-dev` review that Step 4 then absorbs — the loops conver
 | 0 | Clone agent-skills + run sync-symlinks.sh (once per sandbox) | Agent |
 | 0.5 | Update user-facing docs + regenerate `llms.txt` (or state why none applied) | Agent |
 | 1 | Run `/polish` — review + simplify, auto-fix all findings, commit each pass | Agent |
-| 2 | `/create-pr --no-review` — open draft PR; NO duplicate local reviewer (keeps `polish simplify` + the feedback loop) | Agent |
-| 3 | `dash0-dev` bot reviews automatically — the ONE review agent, re-reviews on every commit | Automatic (bot) |
-| 4 | `/implement-suggestion --watch` (background) — absorb the `dash0-dev`/CodeRabbit/human feedback, one commit per comment, ≤**5** iters, never undrafts | Agent (background) |
-| 5 | `/ci-auto-fix` until green. Ready-to-review = `dash0-dev` PASS AND green CI (agent does not undraft) | Agent |
+| 2 | `/create-pr` — open draft PR; no `--no-review` (there is no external bot to defer to) | Agent |
+| 3 | `review-loop` converges automatically (`pr-reviewer` → `implement-suggestion --resolve-all` → `polish simplify`, ≤5 iters) — the ONE review agent, refreshes the PR description on convergence | Agent (auto-dispatched by `/create-pr`) |
+| 4 | `/implement-suggestion --watch` (background) — absorb genuine CodeRabbit/human feedback posted after `review-loop`'s last push, one commit per comment, ≤**5** iters, never undrafts | Agent (background) |
+| 5 | `/ci-auto-fix` until green. Ready-to-review = `review-loop` PASS with zero open threads AND green CI (agent does not undraft) | Agent |
 
 ## Scope format (canonical — `::` separator only)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -964,6 +964,56 @@ smoke path deliberately does not carry; CI only ever uses the anon key +
 email/password to mint the JWT. Re-run with the production ref + key to seed the
 production project too.
 
+#### Seed the preview with demo data
+
+A fresh `/preview` deploy pushes migrations and edge functions, but the
+account behind it usually has no lore — the dashboard shows an empty Explorer,
+a flat heatmap, and an Insights page with nothing to compute a ratio from.
+Comment **`/preview --seed`** (instead of plain `/preview`) on a PR to also
+populate it: `scripts/seed/seed-preview.mjs` writes a realistic, backdated
+dataset — memories across every scope type and Explorer filter dimension
+(label, kind, host, agent, trigger, origin repo/branch/PR), a mix of archived,
+protected, and expired-or-active-TTL rows, an org with a couple of org-owned
+memories, and ~30 days of usage events, per-memory read/opened counters, and
+citations — under the fixed smoke-user account (`LOREKIT_SMOKE_EMAIL`).
+
+**Opt-in, not the default**, for three reasons: the preview project is
+*shared* across every open PR's `/preview` run, so an implicit seed on every
+comment would mean one PR's preview silently changes what another PR's
+preview shows; most `/preview` runs exist to exercise the API contract and
+never open the dashboard; and an always-seeded account makes the genuinely
+empty state (onboarding, first-token mint, the empty Explorer) untestable.
+
+```bash
+# What the `seed` job in preview.yml runs — the Management API channel, no
+# new secret (SUPABASE_ACCESS_TOKEN is already a repo-level secret).
+SUPABASE_ACCESS_TOKEN=<token> SUPABASE_PROJECT_REF=<preview-ref> \
+  node scripts/seed/seed-preview.mjs --user-email <smoke-user-email>
+
+# Local / supabase start — no Management API token needed.
+node scripts/seed/seed-preview.mjs --user-email <email> \
+  --psql postgresql://postgres:postgres@127.0.0.1:54322/postgres
+
+node scripts/seed/seed-preview.mjs --user-email <email> --dry-run   # print the SQL, write nothing
+node scripts/seed/seed-preview.mjs --user-email <email> --reset     # wipe this seed's rows first, then reseed
+```
+
+The target user must already exist — seed it first with
+[`seed-smoke-user.mjs`](#seed-the-orgs-smoke-user) above; this script never
+creates one, for the same reason the smoke suites don't. It refuses the
+**production** project ref unconditionally (no override flag), matching
+[Rebuilding the shared preview project](#rebuilding-the-shared-preview-project)'s
+own belt-and-suspenders check. Every seeded memory's key is prefixed
+`preview-seed/` — search the Explorer for that prefix to find (or `--reset` to
+remove) exactly what this script wrote, and nothing else. Re-running it is
+close to idempotent: memories upsert on `(user_id, scope, key)`, so a reseed
+without `--reset` refreshes the same rows rather than duplicating them.
+
+A [Rebuilding the shared preview project](#rebuilding-the-shared-preview-project)
+run wipes any seeded demo data along with everything else (and the smoke
+user, per the notice above) — reseed with `/preview --seed` on any open PR
+once the smoke user is re-seeded.
+
 ### Recommended branch protection
 
 Require a PR to `main` and mark the single **`CI Summary`** job as the required

--- a/scripts/seed/preview-dataset.mjs
+++ b/scripts/seed/preview-dataset.mjs
@@ -145,7 +145,7 @@ function scopeType(scope) {
 }
 
 /** Spread `count` targeted+bulk reads across the days since a memory was created. */
-function buildReadDailyForMemory(memoryId, ageDays, deliveries, rand) {
+function buildReadDailyForMemory(memoryId, ageDays, deliveries, rand, now) {
   if (deliveries <= 0) return [];
   const span = Math.max(1, Math.min(ageDays, 30));
   const rows = [];
@@ -158,7 +158,7 @@ function buildReadDailyForMemory(memoryId, ageDays, deliveries, rand) {
     if (dayCount === 0) continue;
     const bulk = Math.round(dayCount * 0.7);
     const targeted = dayCount - bulk;
-    const day = new Date(Date.now() - d * MS_PER_DAY).toISOString().slice(0, 10);
+    const day = new Date(now.getTime() - d * MS_PER_DAY).toISOString().slice(0, 10);
     if (bulk > 0) rows.push({ memory_id: memoryId, day, read_kind: 'bulk', count: bulk });
     if (targeted > 0) rows.push({ memory_id: memoryId, day, read_kind: 'targeted', count: targeted });
     remaining -= dayCount;
@@ -233,7 +233,7 @@ export function buildDataset({ now = new Date(), days = 30 } = {}) {
     };
     memories.push(memory);
 
-    for (const row of buildReadDailyForMemory(memory.id, t.ageDays, deliveries, rand)) {
+    for (const row of buildReadDailyForMemory(memory.id, t.ageDays, deliveries, rand, now)) {
       readDaily.push(row);
     }
     for (let c = 0; c < cited; c++) {

--- a/scripts/seed/preview-dataset.mjs
+++ b/scripts/seed/preview-dataset.mjs
@@ -1,0 +1,316 @@
+/**
+ * The pure half of the preview seed — a deterministic, hand-authored dataset
+ * plus the derivation of everything the dashboard reads FROM it (per-memory
+ * read/opened/cited counters, `memory_read_daily` day rows, and 30 days of
+ * `usage_events`).
+ *
+ * Deterministic on purpose: every timestamp is computed relative to a `now`
+ * passed in by the caller (never `Date.now()` read inside this module), and
+ * the one place randomness is needed (jittering an hour-of-day so nothing
+ * lands at exact midnight, and spreading counts across days) uses a seeded
+ * PRNG — so the SAME `now` always produces the SAME dataset, which is what
+ * makes `seed-preview.mjs --dry-run` a meaningful diff and a re-seed close to
+ * idempotent (the runner upserts memories by `(user_id, scope, key)`).
+ *
+ * This module has NO I/O — it returns plain JS objects. `seed-preview.mjs`
+ * turns them into SQL and executes it.
+ */
+
+/** Tag every seeded row carries, so `--reset` can find exactly its own rows. */
+export const SEED_TAG = 'seed::preview';
+
+/**
+ * Every seeded memory's `key` is prefixed with this, so it can NEVER collide
+ * with a real memory a smoke test or a person wrote under the same account —
+ * `(user_id, scope, key)` is the table's only uniqueness constraint, and the
+ * seed reuses realistic-looking key names (some borrowed from this repo's own
+ * lore) on purpose. The prefix is also what makes the seeded rows trivially
+ * findable in the Explorer (search `preview-seed/`) without relying on tags.
+ */
+export const SEED_KEY_PREFIX = 'preview-seed/';
+
+/** Prefix every seeded usage_events.correlation_id carries, for the same reason. */
+export const SEED_CORRELATION_PREFIX = 'preview-seed';
+
+export const SEED_ORG_SLUG = 'preview-seed-org';
+export const SEED_ORG_NAME = 'Preview Seed Org';
+
+/** Deterministic (not DB-generated) so memories/read-daily/citations can reference it without a round trip. */
+export const SEED_ORG_ID = '00000000-0000-4000-9000-000000000001';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** mulberry32 — tiny deterministic PRNG. Same seed → same sequence, always. */
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return function rand() {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function isoAt(now, daysAgo, hourJitter = 0) {
+  return new Date(now.getTime() - daysAgo * MS_PER_DAY - hourJitter * 60 * 60 * 1000).toISOString();
+}
+
+/**
+ * The hand-authored lesson set. Every filterable dimension (label/tag, kind,
+ * host, agent, trigger, origin repo/branch/pr) is deliberately given several
+ * distinct values so the Explorer's filter menu, the scope tree, and the
+ * heatmap all read as a lived-in workspace rather than one repeated value.
+ *
+ * `popularity` drives the derived read/opened/cited counters below — it maps
+ * directly onto `/insights`' five utility states (`LESSON_UTILITY_THRESHOLDS`
+ * in `@lorekit/schemas`): `load-bearing` and `specialist` clear the pull-through
+ * bar, `noise-tax` is read a lot but rarely applied, `dormant` is old and
+ * unread, `unproven` is too new/thin to have evidence either way.
+ */
+const TEMPLATES = [
+  // ── global — cross-cutting agent lessons ──────────────────────────────────
+  { scope: 'global', key: 'aw-lessons::worktree-isolation', value: 'Always branch a worktree from the stacked PR head, never from main, or the diff double-counts the parent branch.', tags: ['loop::aw-lessons', 'source::stuck-loop'], host: 'aw', agent: 'aw', trigger: 'stuck-loop', kind: 'lesson', ageDays: 4, origin: { repo: 'mthines/lorekit', branch: 'main', pr: 482 }, popularity: 'load-bearing' },
+  { scope: 'global', key: 'aw-lessons::npx-over-pnpm-exec', value: 'Run browser-mode Vitest via npx — pnpm exec keeps the Playwright child stdio open and the run never returns.', tags: ['loop::aw-lessons'], host: 'aw', agent: 'aw', trigger: 'tool-failure', kind: 'lesson', ageDays: 9, popularity: 'load-bearing' },
+  { scope: 'global', key: 'aw-lessons::no-ai-coauthor', value: 'Never add Co-Authored-By AI tags to commits or PRs in this workflow.', tags: ['loop::aw-lessons'], host: 'aw', agent: 'aw', trigger: 'retrospective', kind: 'lesson', ageDays: 21, popularity: 'load-bearing' },
+  { scope: 'global', key: 'aw-lessons::mock-that-reimplements-the-thing-under-test', value: 'A mock (or eval, or contract check) that re-encodes the thing it verifies proves the mock is self-consistent, not that the real thing works.', tags: ['loop::aw-lessons'], host: 'aw', agent: 'aw', trigger: 'retrospective', kind: 'lesson', ageDays: 2, popularity: 'unproven' },
+  { scope: 'global', key: 'bash::indirect-var-length-needs-a-temp-var', value: 'Looping over env var NAMES to report length needs a temp var — `${!name}` inside `${#...}` does not expand indirectly in bash.', tags: ['bash', 'gotcha'], host: 'aw', agent: 'claude', trigger: 'tool-failure', kind: 'signal', ageDays: 33, popularity: 'specialist' },
+  { scope: 'global', key: 'claude-cli::bypasspermissions-refused-under-root', value: 'Spawning a nested `claude -p` from inside a container running as root under --dangerously-skip-permissions gives an empty transcript, not an error — check the exit code, not just stdout.', tags: ['claude-cli', 'gotcha'], host: 'aw', agent: 'claude', trigger: 'tool-failure', kind: 'signal', ageDays: 58, popularity: 'dormant' },
+  { scope: 'global', key: 'github-mcp::get_job_logs-needs-job_id', value: 'Reading a successful job\'s log needs the numeric job_id — failed_only=true skips green jobs entirely and returns nothing.', tags: ['github', 'mcp'], host: 'ci-auto-fix', agent: 'claude', trigger: 'tool-failure', kind: 'signal', ageDays: 12, popularity: 'specialist' },
+  { scope: 'global', key: 'reviewer-lessons::gh-api-raw-field-stringifies-comments', value: '`gh api --raw-field` stringifies the comments array, so a review POST carrying inline comments 422s — use --input with a JSON file instead.', tags: ['loop::reviewer-lessons', 'github'], host: 'reviewer', agent: 'claude', trigger: 'tool-failure', kind: 'lesson', ageDays: 40, popularity: 'load-bearing' },
+  { scope: 'global', key: 'release-notes-ground-a-docs-page-in-code-not-issue-titles', value: 'A release-notes docs page must be grounded in the actual diff, not issue titles — a title promises a feature the code shipped differently or not at all.', tags: ['docs', 'loop::aw-lessons'], host: 'aw', agent: 'aw', trigger: 'review-comment', kind: 'lesson', ageDays: 66, popularity: 'noise-tax' },
+  { scope: 'global', key: 'aw-tester-lessons::playwright-cli-ignores-dot-directories', value: '`playwright test <path>` silently finds 0 tests when the path lives under a dot-directory — move specs out of `.claude/` or pass --config explicitly.', tags: ['loop::aw-tester-lessons', 'playwright'], host: 'aw', agent: 'aw', trigger: 'tool-failure', kind: 'signal', ageDays: 15, popularity: 'specialist' },
+  { scope: 'global', key: 'linear-mcp-list_milestones-uses-project-not-projectid', value: 'The Linear MCP list_milestones tool takes a single param named `project` (project name or id) — `projectId` is silently ignored, not rejected.', tags: ['linear', 'mcp'], host: 'aw', agent: 'claude', trigger: 'tool-failure', kind: 'signal', ageDays: 27, popularity: 'unproven' },
+  { scope: 'global', key: 'implement-suggestion-lessons::unpushable-premise-needs-reverification', value: 'An inherited lesson claiming a fix was unpushable must be re-verified against the CURRENT push history before reuse — the blocker it recorded may already be gone.', tags: ['loop::implement-suggestion-lessons'], host: 'aw', agent: 'aw', trigger: 'retrospective', kind: 'lesson', ageDays: 3, popularity: 'unproven' },
+
+  // ── repo::mthines/lorekit — this repo's own architecture lessons ─────────
+  { scope: 'repo::mthines/lorekit', key: 'edge-parity::mirror-pattern', value: 'Pure logic that both mcp-core and the Deno edge need lives once in mcp-core and is mirrored self-contained; a drift spec guards the copy.', tags: ['architecture'], host: 'aw', agent: 'claude', trigger: 'retrospective', kind: 'lesson', ageDays: 26, origin: { repo: 'mthines/lorekit', branch: 'main' }, popularity: 'load-bearing' },
+  { scope: 'repo::mthines/lorekit', key: 'scope-format::double-colon', value: 'The canonical scope separator is :: — a single colon is a 400. All segments lowercased.', tags: ['scope', 'validation'], host: 'aw', agent: 'claude', trigger: 'manual', kind: 'lesson', ageDays: 50, popularity: 'load-bearing' },
+  { scope: 'repo::mthines/lorekit', key: 'audit::one-vocabulary', value: 'AUDIT_ACTIONS is the single list; the SQL CHECK, the web copy, and the edge mirror are all asserted equal by a drift spec.', tags: ['audit', 'loop::reviewer-comment-relevance'], host: 'reviewer', agent: 'claude', trigger: 'review-comment', kind: 'lesson', ageDays: 74, origin: { repo: 'mthines/lorekit', branch: 'main', pr: 311 }, popularity: 'specialist' },
+  { scope: 'repo::mthines/lorekit', key: 'rls::service-role-user-filter', value: 'api_key auth uses the service-role client — every query MUST .eq(user_id, userId) or it leaks across tenants.', tags: ['security', 'rls', 'loop::review-outcomes'], host: 'reviewer', agent: 'cursor', trigger: 'review-comment', kind: 'lesson', ageDays: 98, popularity: 'load-bearing' },
+  { scope: 'repo::mthines/lorekit', key: 'otel::one-service-name', value: 'All five edge functions are one service "api"; tell them apart with faas.name, never a per-function SERVICE_NAME secret.', tags: ['otel'], host: 'aw', agent: 'claude', trigger: 'manual', kind: 'lesson', ageDays: 15, popularity: 'specialist' },
+  { scope: 'repo::mthines/lorekit', key: 'edge-cors-www-apex-domain-mismatch', value: 'Dashboard CORS root cause: the canonical Vercel domain and the apex domain must both be in the allow-list, not just one of them.', tags: ['cors', 'bug'], host: 'ci-auto-fix', agent: 'claude', trigger: 'pr-webhook', kind: 'bus', ageDays: 88, origin: { repo: 'mthines/lorekit', branch: 'main', pr: 330 }, popularity: 'dormant' },
+  { scope: 'repo::mthines/lorekit', key: 'perl-sed-inplace-corrupts-utf8-emdashes', value: 'Batch-editing a source file with perl -pi or sed -i on macOS corrupts UTF-8 em-dashes — use Node\'s fs.readFileSync/writeFileSync for a text rewrite instead.', tags: ['gotcha', 'tooling'], host: 'aw', agent: 'claude', trigger: 'tool-failure', kind: 'signal', ageDays: 44, popularity: 'noise-tax' },
+  { scope: 'repo::mthines/lorekit', key: 'ci-auto-fix-lessons::vercel-preview-daily-quota', value: '"Web — Vercel preview" red on an account-level 24h quota is never a repo failure — check the Vercel dashboard quota banner before diagnosing the workflow.', tags: ['loop::ci-auto-fix-lessons', 'ci'], host: 'ci-auto-fix', agent: 'claude', trigger: 'pr-webhook', kind: 'signal', ageDays: 19, popularity: 'specialist' },
+  { scope: 'repo::mthines/lorekit', key: 'linear-workspace-mapping-for-lorekit-tasks', value: 'LoreKit issues go to the `lorekit` Linear workspace (linear.app/lorekit), team LOR — do not file them under the personal workspace.', tags: ['linear', 'process'], host: 'aw', agent: 'claude', trigger: 'manual', kind: 'signal', ageDays: 71, popularity: 'dormant' },
+  { scope: 'repo::mthines/lorekit', key: 'command-coverage::settings-nav-shortcuts', value: 'The six Settings subsections each need their own keyboard shortcut entry in command-coverage — a shared parent shortcut silently drops the children.', tags: ['ux', 'settings'], host: 'aw', agent: 'claude', trigger: 'review-comment', kind: 'lesson', ageDays: 6, popularity: 'unproven' },
+  { scope: 'repo::mthines/lorekit', key: 'nx-affected-never-run-many-all-in-sandbox', value: '`pnpm nx run-many -t … --all` saturates a cloud sandbox — every project starts at once and the session stalls. Use `nx affected` instead.', tags: ['nx', 'ci', 'sandbox'], host: 'aw', agent: 'claude', trigger: 'stuck-loop', kind: 'signal', ageDays: 1, popularity: 'unproven' },
+  { scope: 'repo::mthines/lorekit', key: 'deno-check-needs-node-modules-dir-none', value: '`deno check` must pass --node-modules-dir=none or npm: specifiers resolve from the repo\'s pnpm node_modules instead of Deno\'s own cache, hiding real edge-only errors.', tags: ['deno', 'edge'], host: 'aw', agent: 'codex', trigger: 'tool-failure', kind: 'signal', ageDays: 37, popularity: 'noise-tax' },
+  { scope: 'repo::mthines/lorekit', key: 'node-fetch-ignores-https-proxy', value: 'Node\'s built-in fetch ignores HTTPS_PROXY — telemetry exports 403 "host not in allowlist" even for an allowed host unless NODE_USE_ENV_PROXY=1 is set.', tags: ['telemetry', 'gotcha'], host: 'aw', agent: 'claude', trigger: 'tool-failure', kind: 'signal', ageDays: 24, popularity: 'specialist' },
+
+  // ── repo::mthines/gw-tools — the sibling repo, for cross-repo filtering ───
+  { scope: 'repo::mthines/gw-tools', key: 'nx-version-must-match-lorekit-exactly', value: 'NX 22.4.0 matches lorekit exactly — bump both repos together or the shared generators drift.', tags: ['nx', 'process'], host: 'aw', agent: 'claude', trigger: 'manual', kind: 'signal', ageDays: 60, origin: { repo: 'mthines/gw-tools', branch: 'main' }, popularity: 'dormant' },
+  { scope: 'repo::mthines/gw-tools', key: 'flaky-e2e-retry-budget-is-two-not-three', value: 'The e2e runner\'s retry budget is 2, not the Playwright default of 3 — a third retry silently never happens and a genuinely flaky test looks fixed.', tags: ['e2e', 'flake'], host: 'aw', agent: 'claude', trigger: 'stuck-loop', kind: 'lesson', ageDays: 8, origin: { repo: 'mthines/gw-tools', branch: 'fix/flaky-e2e', pr: 578 }, popularity: 'specialist' },
+  { scope: 'repo::mthines/gw-tools', key: 'gw-tools-shares-lorekit-eslint-config', value: 'gw-tools imports its ESLint config from lorekit\'s root package rather than vendoring its own — do not fork it locally.', tags: ['tooling'], host: 'aw', agent: 'claude', trigger: 'manual', kind: 'signal', ageDays: 95, origin: { repo: 'mthines/gw-tools', branch: 'main' }, popularity: 'dormant' },
+
+  // ── project::agent-skills — the shared skills repo ────────────────────────
+  { scope: 'project::agent-skills', key: 'routing::tier-detection', value: 'When in doubt, route Full — an over-planned Micro wastes compute, but an under-planned architectural task ships wrong code.', tags: ['aw', 'routing'], host: 'aw', agent: 'aw', trigger: 'retrospective', kind: 'lesson', ageDays: 10, origin: { repo: 'mthines/agent-skills', branch: 'main' }, popularity: 'load-bearing' },
+  { scope: 'project::agent-skills', key: 'confidence::plan-gate', value: 'A failed deterministic rule caps the confidence gate at 89% regardless of the LLM score.', tags: ['aw', 'confidence'], host: 'aw', agent: 'aw', trigger: 'retrospective', kind: 'lesson', ageDays: 12, origin: { repo: 'mthines/agent-skills', branch: 'main' }, popularity: 'load-bearing' },
+  { scope: 'project::agent-skills', key: 'intake-use-memory-search-not-list', value: 'The intake step should call memory.search with the tag filter, not memory.list — list pages by recency and can miss an older matching lesson.', tags: ['aw', 'loop::aw-lessons'], host: 'aw', agent: 'aw', trigger: 'retrospective', kind: 'signal', ageDays: 5, popularity: 'unproven' },
+  { scope: 'project::agent-skills', key: 'critical-skill-caps-one-pass-per-run', value: 'The /critical skill is deliberately one adversarial pass per run — a naive self-refine loop amplifies the same bias instead of catching it.', tags: ['critical', 'process'], host: 'aw', agent: 'aw', trigger: 'manual', kind: 'signal', ageDays: 41, origin: { repo: 'mthines/agent-skills', branch: 'main' }, popularity: 'noise-tax' },
+  { scope: 'project::agent-skills', key: 'ideate-persona-count-caps-at-six', value: 'Nominal-group persona generation caps at six personas — beyond that, novelty scores stop separating and the round just costs more tokens.', tags: ['ideate'], host: 'aw', agent: 'aw', trigger: 'retrospective', kind: 'signal', ageDays: 30, origin: { repo: 'mthines/agent-skills', branch: 'main' }, popularity: 'dormant' },
+
+  // ── branch::mthines/lorekit::feat/storybook — branch-scoped, short-lived ─
+  { scope: 'branch::mthines/lorekit::feat/storybook', key: 'msw::wildcard-origin', value: 'Match the edge function with a */functions/v1 wildcard so the handler survives an unset NEXT_PUBLIC_SUPABASE_URL.', tags: ['storybook', 'msw'], host: 'aw', agent: 'claude', trigger: 'tool-failure', kind: 'lesson', ageDays: 120, origin: { repo: 'mthines/lorekit', branch: 'feat/storybook', pr: 311 }, popularity: 'dormant' },
+  { scope: 'branch::mthines/lorekit::feat/storybook', key: 'snapshot::freeze-the-clock', value: 'Freeze Date before rendering any time-relative UI, or "3d ago" and trend chips flake the baseline overnight.', tags: ['storybook', 'flake'], host: 'aw', agent: 'claude', trigger: 'tool-failure', kind: 'lesson', ageDays: 126, origin: { repo: 'mthines/lorekit', branch: 'feat/storybook' }, popularity: 'dormant' },
+  { scope: 'branch::mthines/lorekit::feat/storybook', key: 'vitest-browser-mode-needs-npx', value: 'Invoke the Storybook Vitest suite with npx, not pnpm exec or nx run — those wrap the process and keep the Playwright browser child\'s stdio open.', tags: ['storybook', 'vitest'], host: 'aw', agent: 'claude', trigger: 'stuck-loop', kind: 'signal', ageDays: 119, origin: { repo: 'mthines/lorekit', branch: 'feat/storybook' }, popularity: 'dormant' },
+
+  // ── branch::mthines/lorekit::feat/otel-rollup — a more recent branch ─────
+  { scope: 'branch::mthines/lorekit::feat/otel-rollup', key: 'self-time-merge-not-sum', value: 'lorekit.io.wait_ms merges overlapping outbound-call intervals — summing them double-counts concurrent queries and can drive self_time negative.', tags: ['otel'], host: 'aw', agent: 'claude', trigger: 'review-comment', kind: 'lesson', ageDays: 7, origin: { repo: 'mthines/lorekit', branch: 'feat/otel-rollup', pr: 501 }, popularity: 'specialist' },
+  { scope: 'branch::mthines/lorekit::feat/otel-rollup', key: 'span-kind-client-marks-outbound', value: 'Any child span with kind CLIENT counts as an outbound call for the self-time split — a same-process helper span must not carry that kind.', tags: ['otel'], host: 'aw', agent: 'claude', trigger: 'tool-failure', kind: 'signal', ageDays: 6, origin: { repo: 'mthines/lorekit', branch: 'feat/otel-rollup', pr: 501 }, popularity: 'unproven' },
+
+  // ── branch::mthines/gw-tools::fix/flaky-e2e ───────────────────────────────
+  { scope: 'branch::mthines/gw-tools::fix/flaky-e2e', key: 'playwright-trace-viewer-needs-retain-on-failure', value: 'Set trace: "retain-on-failure" in the Playwright config, not "on" — "on" keeps a trace for every green run too and blows the CI artifact quota.', tags: ['playwright', 'ci'], host: 'aw', agent: 'claude', trigger: 'tool-failure', kind: 'signal', ageDays: 8, origin: { repo: 'mthines/gw-tools', branch: 'fix/flaky-e2e', pr: 578 }, popularity: 'unproven' },
+];
+
+/**
+ * How each `popularity` bucket resolves into the counters the dashboard
+ * derives value from — kept in one place so the numbers agree with each
+ * other (a "load-bearing" lesson must clear BOTH the pull-through bar and the
+ * broad-delivery bar `LESSON_UTILITY_THRESHOLDS` in `@lorekit/schemas` sets).
+ */
+const POPULARITY_PROFILES = {
+  'load-bearing': { deliveries: 340, pullThrough: 0.22, citationShare: 0.6 },
+  specialist: { deliveries: 40, pullThrough: 0.35, citationShare: 0.4 },
+  'noise-tax': { deliveries: 260, pullThrough: 0.01, citationShare: 0 },
+  dormant: { deliveries: 6, pullThrough: 0, citationShare: 0 },
+  unproven: { deliveries: 8, pullThrough: 0.1, citationShare: 0.1 },
+};
+
+function scopeType(scope) {
+  if (scope === 'global') return 'global';
+  if (scope.startsWith('project::')) return 'project';
+  if (scope.startsWith('branch::')) return 'branch';
+  return 'repo';
+}
+
+/** Spread `count` targeted+bulk reads across the days since a memory was created. */
+function buildReadDailyForMemory(memoryId, ageDays, deliveries, rand) {
+  if (deliveries <= 0) return [];
+  const span = Math.max(1, Math.min(ageDays, 30));
+  const rows = [];
+  let remaining = deliveries;
+  for (let d = 0; d < span && remaining > 0; d++) {
+    // Recent days carry more traffic than the tail — a lived-in heatmap, not
+    // a flat one.
+    const weight = 1 - d / span;
+    const dayCount = Math.max(0, Math.round(deliveries * weight * (0.15 + 0.15 * rand())));
+    if (dayCount === 0) continue;
+    const bulk = Math.round(dayCount * 0.7);
+    const targeted = dayCount - bulk;
+    const day = new Date(Date.now() - d * MS_PER_DAY).toISOString().slice(0, 10);
+    if (bulk > 0) rows.push({ memory_id: memoryId, day, read_kind: 'bulk', count: bulk });
+    if (targeted > 0) rows.push({ memory_id: memoryId, day, read_kind: 'targeted', count: targeted });
+    remaining -= dayCount;
+  }
+  return rows;
+}
+
+/**
+ * Build the full seed dataset relative to `now`.
+ *
+ * @param {{ now?: Date, days?: number }} opts `days` bounds the usage_events
+ *   window (default 30, matching /insights' widest bounded range).
+ */
+export function buildDataset({ now = new Date(), days = 30 } = {}) {
+  const rand = mulberry32(42);
+  const org = { id: SEED_ORG_ID, slug: SEED_ORG_SLUG, name: SEED_ORG_NAME };
+
+  const memories = [];
+  const readDaily = [];
+  const citations = [];
+
+  TEMPLATES.forEach((t, i) => {
+    const hourJitter = rand() * 20;
+    const createdAt = isoAt(now, t.ageDays, hourJitter);
+    const isArchived = t.popularity === 'dormant' && i % 5 === 0;
+    // A couple of already-expired rows (past ttl_days) and a couple of
+    // active ones (future expiry) — `purge-expired`, the expired stat, and
+    // the groom candidates view all need at least one of each to be
+    // non-empty in a demo.
+    const isExpired = t.trigger === 'pr-webhook' && t.ageDays > 60;
+    const hasActiveTtl = t.kind === 'signal' && t.ageDays < 10;
+    const isProtected = t.popularity === 'load-bearing' && i % 4 === 0;
+    // Org-owns roughly a sixth of the repo-scoped lore, so the owner facet and
+    // the org Settings page both have real rows to show.
+    const orgOwned = t.scope.startsWith('repo::') && i % 6 === 0;
+
+    const profile = POPULARITY_PROFILES[t.popularity];
+    const deliveries = Math.round(profile.deliveries * (0.7 + 0.6 * rand()));
+    const opened = Math.round(deliveries * profile.pullThrough);
+    const cited = Math.round(opened * profile.citationShare);
+
+    const memory = {
+      // A stable, content-derived id (not random) so re-running the dataset
+      // builder for a diff/dry-run always names the same row.
+      id: `00000000-0000-4000-8000-${String(i + 1).padStart(12, '0')}`,
+      scope: t.scope,
+      scopeType: scopeType(t.scope),
+      key: `${SEED_KEY_PREFIX}${t.key}`,
+      value: t.value,
+      tags: [...t.tags, SEED_TAG],
+      source_agent: t.agent,
+      trigger: t.trigger,
+      kind: t.kind,
+      host: t.host,
+      created_at: createdAt,
+      updated_at: createdAt,
+      archived_at: isArchived ? isoAt(now, Math.max(1, t.ageDays - 2), hourJitter) : null,
+      // `isoAt` subtracts days, so a NEGATIVE offset lands in the future.
+      expires_at: isExpired ? isoAt(now, 5, 0) : hasActiveTtl ? isoAt(now, -14, 0) : null,
+      protected: isProtected,
+      origin_repo: t.origin?.repo ?? null,
+      origin_branch: t.origin?.branch ?? null,
+      origin_commit: t.origin?.repo ? `${(i + 1).toString(16).padStart(7, '0')}${'a1b2c3d'}`.slice(0, 12) : null,
+      origin_pr: t.origin?.pr ?? null,
+      org_id: orgOwned ? org.id : null,
+      read_count: deliveries,
+      opened_count: opened,
+      last_read_at: deliveries > 0 ? isoAt(now, rand() * Math.min(3, t.ageDays)) : null,
+      last_opened_at: opened > 0 ? isoAt(now, rand() * Math.min(5, t.ageDays)) : null,
+      cited_count: cited,
+      last_cited_at: cited > 0 ? isoAt(now, rand() * Math.min(7, t.ageDays)) : null,
+    };
+    memories.push(memory);
+
+    for (const row of buildReadDailyForMemory(memory.id, t.ageDays, deliveries, rand)) {
+      readDaily.push(row);
+    }
+    for (let c = 0; c < cited; c++) {
+      citations.push({
+        cited_memory_id: memory.id,
+        correlation_id: `${SEED_CORRELATION_PREFIX}-run-${(i * 7 + c) % 40}`,
+        created_at: isoAt(now, rand() * Math.min(20, t.ageDays)),
+      });
+    }
+  });
+
+  const usageEvents = buildUsageEvents({ now, days, memories, rand });
+
+  return { org, memories, readDaily, citations, usageEvents };
+}
+
+const TOOLS_READ = ['memory.list', 'memory.search', 'memory.read', 'memory.scopes'];
+const CLIENTS = ['cli', 'mcp', 'web', 'dashboard'];
+const OUTCOMES_WEIGHTED = [
+  ['ok', 92],
+  ['rate_limited', 3],
+  ['cap_exceeded', 1],
+  ['permission_denied', 1],
+  ['error', 3],
+];
+const SESSION_KINDS = ['pr', 'ci', 'local', 'unknown'];
+
+function weightedPick(rand, pairs) {
+  const total = pairs.reduce((s, [, w]) => s + w, 0);
+  let r = rand() * total;
+  for (const [v, w] of pairs) {
+    r -= w;
+    if (r <= 0) return v;
+  }
+  return pairs[0][0];
+}
+
+/**
+ * ~30 days of tool-call events. Reads dominate (5:1 over writes), matching
+ * how agents actually use lore (`DEFAULT_MIX` in the load test), spread with
+ * more traffic on recent days so the Insights trend chips have a real
+ * week-over-week signal, and grouped into runs via `correlation_id` so the
+ * Runs list is non-empty.
+ */
+function buildUsageEvents({ now, days, memories, rand }) {
+  const events = [];
+  const scopes = [...new Set(memories.map((m) => m.scope))];
+  let runCounter = 0;
+  for (let d = 0; d < days; d++) {
+    const dayWeight = 1 - (d / days) * 0.6;
+    const callsToday = Math.round((14 + rand() * 10) * dayWeight);
+    for (let c = 0; c < callsToday; c++) {
+      const isWrite = rand() < 0.17;
+      const toolName = isWrite ? 'memory.write' : TOOLS_READ[Math.floor(rand() * TOOLS_READ.length)];
+      const scope = scopes[Math.floor(rand() * scopes.length)];
+      const outcome = weightedPick(rand, OUTCOMES_WEIGHTED);
+      const client = CLIENTS[Math.floor(rand() * CLIENTS.length)];
+      const hourJitter = rand() * 22;
+      if (c % 6 === 0) runCounter++;
+      events.push({
+        tool_name: toolName,
+        scope_type: scopeType(scope),
+        scope,
+        scope_count: 1,
+        auth_type: client === 'web' || client === 'dashboard' ? 'jwt' : 'api_key',
+        outcome,
+        duration_ms: Math.round(40 + rand() * 260),
+        memory_count: isWrite ? Math.round(50 + rand() * 20) : null,
+        result_count: !isWrite && outcome === 'ok' ? Math.round(rand() * 12) : null,
+        correlation_id: `${SEED_CORRELATION_PREFIX}-run-${runCounter % 40}`,
+        client,
+        kind: rand() < 0.4 ? 'lesson' : null,
+        host: rand() < 0.3 ? 'aw' : null,
+        session_kind: SESSION_KINDS[Math.floor(rand() * SESSION_KINDS.length)],
+        created_at: isoAt(now, d, hourJitter),
+      });
+    }
+  }
+  return events;
+}

--- a/scripts/seed/preview-dataset.test.mjs
+++ b/scripts/seed/preview-dataset.test.mjs
@@ -1,0 +1,115 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildDataset, SEED_KEY_PREFIX, SEED_ORG_ID } from './preview-dataset.mjs';
+
+const NOW = new Date('2026-09-10T12:00:00.000Z');
+
+test('every memory key carries the seed prefix, and (scope,key) pairs are unique', () => {
+  const { memories } = buildDataset({ now: NOW });
+  assert.ok(memories.length > 20, 'expected a real dataset, not a stub');
+  const seen = new Set();
+  for (const m of memories) {
+    assert.ok(m.key.startsWith(SEED_KEY_PREFIX), `key "${m.key}" missing the seed prefix`);
+    const pair = `${m.scope}::${m.key}`;
+    assert.ok(!seen.has(pair), `duplicate (scope,key): ${pair}`);
+    seen.add(pair);
+  }
+});
+
+test('every Explorer filter dimension has at least three distinct values', () => {
+  const { memories } = buildDataset({ now: NOW });
+  const dims = {
+    kind: new Set(), host: new Set(), source_agent: new Set(), trigger: new Set(),
+    origin_repo: new Set(), origin_branch: new Set(), origin_pr: new Set(), scope: new Set(),
+  };
+  for (const m of memories) {
+    for (const key of Object.keys(dims)) {
+      if (m[key] !== null && m[key] !== undefined) dims[key].add(m[key]);
+    }
+  }
+  for (const [key, set] of Object.entries(dims)) {
+    assert.ok(set.size >= 3, `dimension "${key}" only has ${set.size} distinct value(s): ${[...set]}`);
+  }
+});
+
+test('every scope type (global/project/repo/branch) is represented', () => {
+  const { memories } = buildDataset({ now: NOW });
+  const types = new Set(memories.map((m) => m.scopeType));
+  for (const t of ['global', 'project', 'repo', 'branch']) {
+    assert.ok(types.has(t), `no memory uses scope type "${t}"`);
+  }
+});
+
+test('at least one memory is archived, one protected, one expired, and one with an active ttl', () => {
+  const { memories } = buildDataset({ now: NOW });
+  assert.ok(memories.some((m) => m.archived_at !== null), 'expected at least one archived memory');
+  assert.ok(memories.some((m) => m.protected === true), 'expected at least one protected memory');
+  const expired = memories.filter((m) => m.expires_at !== null && new Date(m.expires_at) < NOW);
+  const active = memories.filter((m) => m.expires_at !== null && new Date(m.expires_at) >= NOW);
+  assert.ok(expired.length > 0, 'expected at least one already-expired memory');
+  assert.ok(active.length > 0, 'expected at least one memory with an active (future) ttl');
+});
+
+test('at least one memory is org-owned, and org_id always points at the seed org', () => {
+  const { memories, org } = buildDataset({ now: NOW });
+  const owned = memories.filter((m) => m.org_id !== null);
+  assert.ok(owned.length > 0, 'expected at least one org-owned memory');
+  for (const m of owned) assert.equal(m.org_id, org.id);
+  assert.equal(org.id, SEED_ORG_ID);
+});
+
+test('no timestamp is in the future, except an active-ttl expires_at', () => {
+  const { memories, readDaily, citations, usageEvents } = buildDataset({ now: NOW });
+  for (const m of memories) {
+    for (const field of ['created_at', 'updated_at', 'archived_at', 'last_read_at', 'last_opened_at', 'last_cited_at']) {
+      if (m[field]) assert.ok(new Date(m[field]) <= NOW, `${field} "${m[field]}" on ${m.key} is in the future`);
+    }
+  }
+  for (const r of readDaily) assert.ok(new Date(r.day) <= NOW, `read_daily day "${r.day}" is in the future`);
+  for (const c of citations) assert.ok(new Date(c.created_at) <= NOW, `citation created_at "${c.created_at}" is in the future`);
+  for (const e of usageEvents) assert.ok(new Date(e.created_at) <= NOW, `usage_event created_at "${e.created_at}" is in the future`);
+});
+
+test('read-daily and citation rows only reference memory ids that exist in the dataset', () => {
+  const { memories, readDaily, citations } = buildDataset({ now: NOW });
+  const ids = new Set(memories.map((m) => m.id));
+  for (const r of readDaily) assert.ok(ids.has(r.memory_id), `read_daily references unknown memory_id ${r.memory_id}`);
+  for (const c of citations) assert.ok(ids.has(c.cited_memory_id), `citation references unknown memory_id ${c.cited_memory_id}`);
+});
+
+test('a memory\'s citation row count matches its cited_count exactly', () => {
+  const { memories, citations } = buildDataset({ now: NOW });
+  const countsByMemory = new Map();
+  for (const c of citations) countsByMemory.set(c.cited_memory_id, (countsByMemory.get(c.cited_memory_id) ?? 0) + 1);
+  for (const m of memories) {
+    assert.equal(countsByMemory.get(m.id) ?? 0, m.cited_count, `citation rows for "${m.key}" don't match cited_count`);
+  }
+});
+
+test('a memory with zero read_count has no read_daily rows', () => {
+  const { memories, readDaily } = buildDataset({ now: NOW });
+  const memoriesWithReads = new Set(readDaily.map((r) => r.memory_id));
+  for (const m of memories) {
+    if (m.read_count === 0) assert.ok(!memoriesWithReads.has(m.id), `"${m.key}" has read_count 0 but has read_daily rows`);
+  }
+});
+
+test('usage_events cover the requested window and every outcome/client value used elsewhere is well-formed', () => {
+  const { usageEvents } = buildDataset({ now: NOW, days: 14 });
+  assert.ok(usageEvents.length > 50, 'expected a substantial event volume');
+  for (const e of usageEvents) {
+    assert.ok(['ok', 'rate_limited', 'cap_exceeded', 'permission_denied', 'error'].includes(e.outcome));
+    assert.ok(['api_key', 'jwt', 'service'].includes(e.auth_type));
+    assert.ok(e.client.length >= 1 && e.client.length <= 32);
+    if (e.session_kind) assert.ok(e.session_kind.length <= 16);
+  }
+  const oldest = usageEvents.reduce((min, e) => Math.min(min, new Date(e.created_at).getTime()), Infinity);
+  assert.ok(NOW.getTime() - oldest <= 14 * 24 * 60 * 60 * 1000 + 24 * 60 * 60 * 1000, 'an event falls outside the requested window');
+});
+
+test('is deterministic — the same `now` always produces the same dataset', () => {
+  const a = buildDataset({ now: NOW });
+  const b = buildDataset({ now: NOW });
+  assert.deepEqual(a, b);
+});

--- a/scripts/seed/preview-sql.mjs
+++ b/scripts/seed/preview-sql.mjs
@@ -1,0 +1,218 @@
+/**
+ * Renders the dataset from `preview-dataset.mjs` into raw SQL statements.
+ *
+ * Pure and I/O-free — `seed-preview.mjs` is the only caller that actually
+ * sends these strings anywhere. Every statement is written to be safe to
+ * re-run: memories upsert on `(user_id, scope, key)`, the org/membership rows
+ * upsert on their own primary keys, and the two per-memory detail tables
+ * (`memory_read_daily`, `memory_citations`) are deleted-then-reinserted for
+ * exactly the memory ids this dataset owns, never for anyone else's.
+ *
+ * No parameterized-query placeholders are available on the two execution
+ * channels `seed-preview.mjs` supports (the Supabase Management API's raw SQL
+ * endpoint, and a `psql -c`/`-f` fallback for `supabase start`), so every
+ * value is escaped and inlined here instead. `sqlString` is the ONE place
+ * that happens — never string-interpolate a value directly into a template
+ * literal elsewhere in this file.
+ */
+
+import { SEED_CORRELATION_PREFIX, SEED_KEY_PREFIX } from './preview-dataset.mjs';
+
+/** Single-quote a string literal, doubling embedded quotes. `null`/`undefined` become SQL NULL. */
+export function sqlString(value) {
+  if (value === null || value === undefined) return 'null';
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
+export function sqlBool(value) {
+  return value ? 'true' : 'false';
+}
+
+export function sqlInt(value) {
+  return value === null || value === undefined ? 'null' : String(Math.trunc(value));
+}
+
+/** A Postgres `text[]` literal built from `ARRAY[...]`, never the `{...}` shorthand — avoids a second escaping dialect. */
+export function sqlTextArray(values) {
+  return `ARRAY[${values.map(sqlString).join(', ')}]::text[]`;
+}
+
+export function sqlUuidArray(values) {
+  return `ARRAY[${values.map(sqlString).join(', ')}]::uuid[]`;
+}
+
+/**
+ * The org + its single membership row. Both upsert on their real primary
+ * keys, so re-running the seed never duplicates either.
+ */
+export function renderOrgSql(org, userId) {
+  return `
+insert into orgs (id, slug, name, created_by, created_at, updated_at)
+values (${sqlString(org.id)}, ${sqlString(org.slug)}, ${sqlString(org.name)}, ${sqlString(userId)}, now(), now())
+on conflict (id) do update set name = excluded.name, updated_at = now();
+
+insert into org_members (org_id, user_id, role, created_at)
+values (${sqlString(org.id)}, ${sqlString(userId)}, 'owner', now())
+on conflict (org_id, user_id) do nothing;
+`.trim();
+}
+
+const MEMORY_COLUMNS = [
+  'id', 'user_id', 'org_id', 'scope', 'key', 'value', 'tags', 'source_agent', 'trigger',
+  'kind', 'host', 'created_at', 'updated_at', 'archived_at', 'expires_at', 'protected',
+  'origin_repo', 'origin_branch', 'origin_commit', 'origin_pr',
+  'read_count', 'opened_count', 'last_read_at', 'last_opened_at', 'cited_count', 'last_cited_at',
+];
+
+function memoryRowSql(m, userId) {
+  const values = {
+    id: sqlString(m.id),
+    user_id: sqlString(userId),
+    org_id: sqlString(m.org_id),
+    scope: sqlString(m.scope),
+    key: sqlString(m.key),
+    value: sqlString(m.value),
+    tags: sqlTextArray(m.tags),
+    source_agent: sqlString(m.source_agent),
+    trigger: sqlString(m.trigger),
+    kind: sqlString(m.kind),
+    host: sqlString(m.host),
+    created_at: sqlString(m.created_at),
+    updated_at: sqlString(m.updated_at),
+    archived_at: sqlString(m.archived_at),
+    expires_at: sqlString(m.expires_at),
+    protected: sqlBool(m.protected),
+    origin_repo: sqlString(m.origin_repo),
+    origin_branch: sqlString(m.origin_branch),
+    origin_commit: sqlString(m.origin_commit),
+    origin_pr: sqlInt(m.origin_pr),
+    read_count: sqlInt(m.read_count),
+    opened_count: sqlInt(m.opened_count),
+    last_read_at: sqlString(m.last_read_at),
+    last_opened_at: sqlString(m.last_opened_at),
+    cited_count: sqlInt(m.cited_count),
+    last_cited_at: sqlString(m.last_cited_at),
+  };
+  return `(${MEMORY_COLUMNS.map((c) => values[c]).join(', ')})`;
+}
+
+/**
+ * Bulk upsert every seeded memory in one statement. Conflicts on the table's
+ * real unique constraint `(user_id, scope, key)` — safe because every
+ * seeded key carries `SEED_KEY_PREFIX`, so it can only ever conflict with a
+ * PRIOR run of this same seed, never with real data.
+ *
+ * Deliberately does NOT touch `created_at` on conflict, so a reseed keeps a
+ * memory's original backdated age rather than resetting it to "just now".
+ */
+export function renderMemoriesSql(memories, userId) {
+  if (memories.length === 0) return '-- no memories to seed';
+  const rows = memories.map((m) => memoryRowSql(m, userId)).join(',\n  ');
+  const updateSet = MEMORY_COLUMNS.filter((c) => !['id', 'user_id', 'created_at'].includes(c))
+    .map((c) => `${c} = excluded.${c}`)
+    .join(',\n    ');
+  return `
+insert into memories (${MEMORY_COLUMNS.join(', ')})
+values
+  ${rows}
+on conflict on constraint memories_user_scope_key_unique do update set
+    ${updateSet};
+`.trim();
+}
+
+/** Delete-then-insert `memory_read_daily` for exactly the memory ids this dataset owns. */
+export function renderReadDailySql(readDaily, memoryIds) {
+  if (memoryIds.length === 0) return '-- no memories to attach read-daily rows to';
+  const del = `delete from memory_read_daily where memory_id = any(${sqlUuidArray(memoryIds)});`;
+  if (readDaily.length === 0) return del;
+  const rows = readDaily
+    .map((r) => `(${sqlString(r.memory_id)}, ${sqlString(r.day)}::date, ${sqlString(r.read_kind)}, ${sqlInt(r.count)})`)
+    .join(',\n  ');
+  const insert = `
+insert into memory_read_daily (memory_id, day, read_kind, count)
+values
+  ${rows}
+on conflict (memory_id, day, read_kind) do update set count = excluded.count;
+`.trim();
+  return `${del}\n\n${insert}`;
+}
+
+/** Delete-then-insert `memory_citations` for exactly the memory ids this dataset owns. */
+export function renderCitationsSql(citations, memoryIds) {
+  if (memoryIds.length === 0) return '-- no memories to attach citations to';
+  const del = `delete from memory_citations where cited_memory_id = any(${sqlUuidArray(memoryIds)});`;
+  if (citations.length === 0) return del;
+  const rows = citations
+    .map((c) => `(${sqlString(c.cited_memory_id)}, null, ${sqlString(c.correlation_id)}, ${sqlString(c.created_at)})`)
+    .join(',\n  ');
+  const insert = `
+insert into memory_citations (cited_memory_id, citing_memory_id, correlation_id, created_at)
+values
+  ${rows};
+`.trim();
+  return `${del}\n\n${insert}`;
+}
+
+/**
+ * Delete-then-insert `usage_events` scoped to `SEED_CORRELATION_PREFIX`, for
+ * the one `userId` this dataset seeds. Never touches another user's rows —
+ * the `user_id` filter is load-bearing here, not the prefix alone.
+ */
+export function renderUsageEventsSql(usageEvents, userId) {
+  const del = `delete from usage_events where user_id = ${sqlString(userId)} and correlation_id like ${sqlString(`${SEED_CORRELATION_PREFIX}-%`)};`;
+  if (usageEvents.length === 0) return del;
+  const columns = [
+    'user_id', 'tool_name', 'scope_type', 'scope', 'scope_count', 'auth_type', 'outcome',
+    'duration_ms', 'memory_count', 'result_count', 'correlation_id', 'client', 'kind', 'host',
+    'session_kind', 'created_at',
+  ];
+  const rows = usageEvents
+    .map((e) => {
+      const values = {
+        user_id: sqlString(userId),
+        tool_name: sqlString(e.tool_name),
+        scope_type: sqlString(e.scope_type),
+        scope: sqlString(e.scope),
+        scope_count: sqlInt(e.scope_count),
+        auth_type: sqlString(e.auth_type),
+        outcome: sqlString(e.outcome),
+        duration_ms: sqlInt(e.duration_ms),
+        memory_count: sqlInt(e.memory_count),
+        result_count: sqlInt(e.result_count),
+        correlation_id: sqlString(e.correlation_id),
+        client: sqlString(e.client),
+        kind: sqlString(e.kind),
+        host: sqlString(e.host),
+        session_kind: sqlString(e.session_kind),
+        created_at: sqlString(e.created_at),
+      };
+      return `(${columns.map((c) => values[c]).join(', ')})`;
+    })
+    .join(',\n  ');
+  const insert = `
+insert into usage_events (${columns.join(', ')})
+values
+  ${rows};
+`.trim();
+  return `${del}\n\n${insert}`;
+}
+
+/**
+ * Hard-remove everything a previous run of this seed left behind, for one
+ * user: every `SEED_KEY_PREFIX`-keyed memory (cascades to its
+ * `memory_read_daily`/`memory_citations` rows via FK `on delete cascade`),
+ * every `SEED_CORRELATION_PREFIX`-prefixed usage event, and the seed org
+ * (cascades to its membership row and reverts any org-owned seed memory to
+ * personal — moot here since those rows are deleted in the same statement).
+ *
+ * Used by `--reset` before reseeding, and is exactly what makes a reseed with
+ * a CHANGED dataset shape (a template renamed or removed) converge instead of
+ * accumulating orphaned rows the upsert path can't reach.
+ */
+export function renderResetSql(org, userId) {
+  return `
+delete from memories where user_id = ${sqlString(userId)} and key like ${sqlString(`${SEED_KEY_PREFIX}%`)};
+delete from usage_events where user_id = ${sqlString(userId)} and correlation_id like ${sqlString(`${SEED_CORRELATION_PREFIX}-%`)};
+delete from orgs where id = ${sqlString(org.id)};
+`.trim();
+}

--- a/scripts/seed/preview-sql.mjs
+++ b/scripts/seed/preview-sql.mjs
@@ -138,15 +138,16 @@ on conflict (memory_id, day, read_kind) do update set count = excluded.count;
 }
 
 /** Delete-then-insert `memory_citations` for exactly the memory ids this dataset owns. */
-export function renderCitationsSql(citations, memoryIds) {
+export function renderCitationsSql(citations, memoryIds, userId) {
   if (memoryIds.length === 0) return '-- no memories to attach citations to';
   const del = `delete from memory_citations where cited_memory_id = any(${sqlUuidArray(memoryIds)});`;
   if (citations.length === 0) return del;
   const rows = citations
-    .map((c) => `(${sqlString(c.cited_memory_id)}, null, ${sqlString(c.correlation_id)}, ${sqlString(c.created_at)})`)
+    .map((c) => `(${sqlString(userId)}, ${sqlString(c.cited_memory_id)}, null, `
+      + `${sqlString(c.correlation_id)}, ${sqlString(c.created_at)})`)
     .join(',\n  ');
   const insert = `
-insert into memory_citations (cited_memory_id, citing_memory_id, correlation_id, created_at)
+insert into memory_citations (user_id, cited_memory_id, citing_memory_id, correlation_id, created_at)
 values
   ${rows};
 `.trim();
@@ -208,11 +209,16 @@ values
  * Used by `--reset` before reseeding, and is exactly what makes a reseed with
  * a CHANGED dataset shape (a template renamed or removed) converge instead of
  * accumulating orphaned rows the upsert path can't reach.
+ *
+ * The org delete is also scoped to `created_by = userId` — the org id is a
+ * fixed constant shared by every seed run, so without this filter one user's
+ * `--reset` would drop the shared preview org (and cascade its membership row)
+ * out from under whichever user actually created it.
  */
 export function renderResetSql(org, userId) {
   return `
 delete from memories where user_id = ${sqlString(userId)} and key like ${sqlString(`${SEED_KEY_PREFIX}%`)};
 delete from usage_events where user_id = ${sqlString(userId)} and correlation_id like ${sqlString(`${SEED_CORRELATION_PREFIX}-%`)};
-delete from orgs where id = ${sqlString(org.id)};
+delete from orgs where id = ${sqlString(org.id)} and created_by = ${sqlString(userId)};
 `.trim();
 }

--- a/scripts/seed/preview-sql.test.mjs
+++ b/scripts/seed/preview-sql.test.mjs
@@ -47,12 +47,20 @@ test('renderReadDailySql and renderCitationsSql scope their DELETE to the given 
   const { memories, readDaily, citations } = buildDataset({ now: NOW });
   const ids = memories.map((m) => m.id);
   const readSql = renderReadDailySql(readDaily, ids);
-  const citeSql = renderCitationsSql(citations, ids);
+  const citeSql = renderCitationsSql(citations, ids, USER_ID);
   assert.match(readSql, /delete from memory_read_daily where memory_id = any\(/);
   assert.match(citeSql, /delete from memory_citations where cited_memory_id = any\(/);
   for (const id of ids) {
     assert.ok(readSql.includes(id), `read_daily delete is missing memory id ${id}`);
   }
+});
+
+test('renderCitationsSql fills in the NOT NULL user_id column', () => {
+  const { memories, citations } = buildDataset({ now: NOW });
+  const ids = memories.map((m) => m.id);
+  const sql = renderCitationsSql(citations, ids, USER_ID);
+  assert.match(sql, /insert into memory_citations \(user_id, cited_memory_id, citing_memory_id, correlation_id, created_at\)/);
+  assert.ok(sql.includes(USER_ID), 'citations insert is missing the seeded user_id');
 });
 
 test('renderUsageEventsSql scopes its DELETE to the seeded user AND the seed correlation prefix', () => {
@@ -75,4 +83,10 @@ test('renderResetSql deletes exactly the seed-prefixed memories, seed-prefixed u
   assert.ok(sql.includes('preview-seed-%'));
   assert.ok(sql.includes(org.id));
   assert.ok(sql.includes(USER_ID));
+});
+
+test('renderResetSql scopes the org delete to created_by, so one user cannot drop another user\'s shared org', () => {
+  const { org } = buildDataset({ now: NOW });
+  const sql = renderResetSql(org, USER_ID);
+  assert.match(sql, new RegExp(`delete from orgs where id = '${org.id}' and created_by = '${USER_ID}';`));
 });

--- a/scripts/seed/preview-sql.test.mjs
+++ b/scripts/seed/preview-sql.test.mjs
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildDataset } from './preview-dataset.mjs';
+import {
+  sqlString,
+  renderOrgSql,
+  renderMemoriesSql,
+  renderReadDailySql,
+  renderCitationsSql,
+  renderUsageEventsSql,
+  renderResetSql,
+} from './preview-sql.mjs';
+
+const NOW = new Date('2026-09-10T12:00:00.000Z');
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+
+test('sqlString escapes embedded single quotes and maps null/undefined to SQL NULL', () => {
+  assert.equal(sqlString("it's here"), "'it''s here'");
+  assert.equal(sqlString(null), 'null');
+  assert.equal(sqlString(undefined), 'null');
+  assert.equal(sqlString('plain'), "'plain'");
+});
+
+test('renderMemoriesSql never leaves a raw quote unescaped, for every seeded value', () => {
+  const { memories } = buildDataset({ now: NOW });
+  // Inject one adversarial value to prove the escaping path, without hand
+  // maintaining a second fixture dataset.
+  memories[0].value = "a lesson with a ' quote and -- a comment marker";
+  const sql = renderMemoriesSql(memories, USER_ID);
+  // A raw, unescaped `'` immediately followed by non-`'` inside the literal
+  // would break the statement — the only correct escape is doubling it.
+  assert.ok(sql.includes("a lesson with a '' quote"), 'single quote was not doubled');
+  assert.ok(sql.includes('on conflict on constraint memories_user_scope_key_unique do update set'));
+  assert.ok(!sql.includes('created_at = excluded.created_at'), 'created_at must never be overwritten on conflict');
+});
+
+test('renderMemoriesSql includes every seeded memory as one VALUES row', () => {
+  const { memories } = buildDataset({ now: NOW });
+  const sql = renderMemoriesSql(memories, USER_ID);
+  // count occurrences of the id prefix used by every seeded row
+  const idMatches = sql.match(/00000000-0000-4000-8000-/g) ?? [];
+  assert.equal(idMatches.length, memories.length);
+});
+
+test('renderReadDailySql and renderCitationsSql scope their DELETE to the given memory ids only', () => {
+  const { memories, readDaily, citations } = buildDataset({ now: NOW });
+  const ids = memories.map((m) => m.id);
+  const readSql = renderReadDailySql(readDaily, ids);
+  const citeSql = renderCitationsSql(citations, ids);
+  assert.match(readSql, /delete from memory_read_daily where memory_id = any\(/);
+  assert.match(citeSql, /delete from memory_citations where cited_memory_id = any\(/);
+  for (const id of ids) {
+    assert.ok(readSql.includes(id), `read_daily delete is missing memory id ${id}`);
+  }
+});
+
+test('renderUsageEventsSql scopes its DELETE to the seeded user AND the seed correlation prefix', () => {
+  const { usageEvents } = buildDataset({ now: NOW });
+  const sql = renderUsageEventsSql(usageEvents, USER_ID);
+  assert.ok(sql.includes(USER_ID));
+  assert.ok(sql.includes('preview-seed-%'));
+});
+
+test('renderOrgSql upserts on the org\'s primary key, never on slug alone', () => {
+  const { org } = buildDataset({ now: NOW });
+  const sql = renderOrgSql(org, USER_ID);
+  assert.match(sql, /on conflict \(id\) do update/);
+});
+
+test('renderResetSql deletes exactly the seed-prefixed memories, seed-prefixed usage events, and the seed org', () => {
+  const { org } = buildDataset({ now: NOW });
+  const sql = renderResetSql(org, USER_ID);
+  assert.ok(sql.includes('preview-seed/%'));
+  assert.ok(sql.includes('preview-seed-%'));
+  assert.ok(sql.includes(org.id));
+  assert.ok(sql.includes(USER_ID));
+});

--- a/scripts/seed/seed-preview.mjs
+++ b/scripts/seed/seed-preview.mjs
@@ -16,24 +16,25 @@
  * Two ways to reach the database, so this also works against a local
  * `supabase start` stack without a Management API token:
  *
- *   --target preview   Supabase Management API (`POST /v1/projects/{ref}/database/query`),
- *                       authenticated with SUPABASE_ACCESS_TOKEN — the same
- *                       repo-level secret every deploy workflow already holds.
- *                       No new secret. Reads SUPABASE_PROJECT_REF.
- *   --psql <url>        Direct `psql` against a local/self-hosted Postgres —
- *                       for `supabase start` or a BYOD project. Never used in
- *                       CI (the runner has no route to a pooler host).
+ *   SUPABASE_PROJECT_REF  Supabase Management API (`POST /v1/projects/{ref}/database/query`),
+ *                         authenticated with SUPABASE_ACCESS_TOKEN — the same
+ *                         repo-level secret every deploy workflow already holds.
+ *                         No new secret.
+ *   --psql <url>          Direct `psql` against a local/self-hosted Postgres —
+ *                         for `supabase start` or a BYOD project. Never used in
+ *                         CI (the runner has no route to a pooler host). Still
+ *                         refused if the URL names the production project ref.
  *
  * ## Usage
  *
  *   SUPABASE_ACCESS_TOKEN=… SUPABASE_PROJECT_REF=<preview-ref> \
- *     node scripts/seed/seed-preview.mjs --target preview --user-email you@example.com
+ *     node scripts/seed/seed-preview.mjs --user-email you@example.com
  *
  *   node scripts/seed/seed-preview.mjs --psql postgresql://postgres:postgres@127.0.0.1:54322/postgres \
  *     --user-email you@example.com
  *
- *   node scripts/seed/seed-preview.mjs --target preview --user-email … --dry-run   # print SQL, write nothing
- *   node scripts/seed/seed-preview.mjs --target preview --user-email … --reset     # wipe this seed's rows first
+ *   node scripts/seed/seed-preview.mjs --user-email … --dry-run   # print SQL, write nothing
+ *   node scripts/seed/seed-preview.mjs --user-email … --reset     # wipe this seed's rows first
  *
  * The target user must already exist (seed it with
  * scripts/smoke/seed-smoke-user.mjs first) — this script never creates one,
@@ -63,11 +64,11 @@ export const PRODUCTION_PROJECT_REF = 'pqokxlhvnosogizsjztg';
 
 export function parseArgs(argv) {
   const opts = {
-    target: null, psqlUrl: null, projectRef: null, userEmail: null,
+    psqlUrl: null, projectRef: null, userEmail: null,
     days: 30, reset: false, dryRun: false,
   };
   const flags = {
-    '--target': 'target', '--psql': 'psqlUrl', '--project-ref': 'projectRef',
+    '--psql': 'psqlUrl', '--project-ref': 'projectRef',
     '--user-email': 'userEmail', '--days': 'days',
   };
   for (let i = 0; i < argv.length; i += 1) {
@@ -87,6 +88,9 @@ export function parseArgs(argv) {
  */
 export function resolveChannel(opts, env = {}) {
   if (opts.psqlUrl) {
+    if (opts.psqlUrl.includes(PRODUCTION_PROJECT_REF)) {
+      return { ok: false, error: `Refusing to seed the PRODUCTION project (${PRODUCTION_PROJECT_REF}). This script only ever targets a preview or local stack — there is no override.` };
+    }
     return { ok: true, channel: 'psql', url: opts.psqlUrl };
   }
   const ref = opts.projectRef ?? env.SUPABASE_PROJECT_REF ?? '';
@@ -177,7 +181,7 @@ export function buildStatements({ dataset, userId, reset }) {
   statements.push({ name: 'memories', sql: renderMemoriesSql(dataset.memories, userId) });
   const memoryIds = dataset.memories.map((m) => m.id);
   statements.push({ name: 'read_daily', sql: renderReadDailySql(dataset.readDaily, memoryIds) });
-  statements.push({ name: 'citations', sql: renderCitationsSql(dataset.citations, memoryIds) });
+  statements.push({ name: 'citations', sql: renderCitationsSql(dataset.citations, memoryIds, userId) });
   statements.push({ name: 'usage_events', sql: renderUsageEventsSql(dataset.usageEvents, userId) });
   return statements;
 }
@@ -198,7 +202,10 @@ async function main() {
   console.log(`Dataset: ${dataset.memories.length} memories, ${dataset.usageEvents.length} usage events, ${dataset.readDaily.length} read-daily rows, ${dataset.citations.length} citations, keys prefixed "${SEED_KEY_PREFIX}".`);
 
   if (opts.dryRun) {
-    console.log(`\n[dry-run] Resolving on channel: ${resolved.channel === 'api' ? `Management API (ref ${resolved.ref})` : `psql (${resolved.url})`}`);
+    // Redact any embedded credentials (postgresql://user:PASSWORD@host) before
+    // this ever reaches a terminal or a CI log.
+    const redactedUrl = resolved.channel === 'psql' ? resolved.url.replace(/\/\/[^@/]*@/, '//***@') : null;
+    console.log(`\n[dry-run] Resolving on channel: ${resolved.channel === 'api' ? `Management API (ref ${resolved.ref})` : `psql (${redactedUrl})`}`);
     console.log('[dry-run] Would resolve user id for', opts.userEmail, 'then run:');
     const statements = buildStatements({ dataset, userId: '<resolved-user-id>', reset: opts.reset });
     for (const s of statements) {

--- a/scripts/seed/seed-preview.mjs
+++ b/scripts/seed/seed-preview.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * Seed the shared preview Supabase project with a realistic, backdated
+ * dataset — memories across every filterable dimension, an org, and 30 days
+ * of usage/read/citation activity — so the dashboard shows a lived-in
+ * workspace instead of an empty account after a fresh `/preview` deploy.
+ *
+ * PREVIEW ONLY. This script refuses the production project ref unconditionally
+ * — there is no override flag, matching rebuild-preview.yml's own
+ * belt-and-suspenders check. Seeding writes backdated demo rows under a real
+ * account; that is a reasonable thing to do to a disposable preview project
+ * and never to production.
+ *
+ * ## Execution channel
+ *
+ * Two ways to reach the database, so this also works against a local
+ * `supabase start` stack without a Management API token:
+ *
+ *   --target preview   Supabase Management API (`POST /v1/projects/{ref}/database/query`),
+ *                       authenticated with SUPABASE_ACCESS_TOKEN — the same
+ *                       repo-level secret every deploy workflow already holds.
+ *                       No new secret. Reads SUPABASE_PROJECT_REF.
+ *   --psql <url>        Direct `psql` against a local/self-hosted Postgres —
+ *                       for `supabase start` or a BYOD project. Never used in
+ *                       CI (the runner has no route to a pooler host).
+ *
+ * ## Usage
+ *
+ *   SUPABASE_ACCESS_TOKEN=… SUPABASE_PROJECT_REF=<preview-ref> \
+ *     node scripts/seed/seed-preview.mjs --target preview --user-email you@example.com
+ *
+ *   node scripts/seed/seed-preview.mjs --psql postgresql://postgres:postgres@127.0.0.1:54322/postgres \
+ *     --user-email you@example.com
+ *
+ *   node scripts/seed/seed-preview.mjs --target preview --user-email … --dry-run   # print SQL, write nothing
+ *   node scripts/seed/seed-preview.mjs --target preview --user-email … --reset     # wipe this seed's rows first
+ *
+ * The target user must already exist (seed it with
+ * scripts/smoke/seed-smoke-user.mjs first) — this script never creates one,
+ * for the same reason the smoke suites don't: provisioning a user is a
+ * separate, deliberate, out-of-CI act.
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { buildDataset, SEED_KEY_PREFIX } from './preview-dataset.mjs';
+import {
+  renderOrgSql,
+  renderMemoriesSql,
+  renderReadDailySql,
+  renderCitationsSql,
+  renderUsageEventsSql,
+  renderResetSql,
+  sqlString,
+} from './preview-sql.mjs';
+
+/** The one project this script will never touch, no matter what flag is passed. */
+export const PRODUCTION_PROJECT_REF = 'pqokxlhvnosogizsjztg';
+
+// ── argv ─────────────────────────────────────────────────────────────────────
+
+export function parseArgs(argv) {
+  const opts = {
+    target: null, psqlUrl: null, projectRef: null, userEmail: null,
+    days: 30, reset: false, dryRun: false,
+  };
+  const flags = {
+    '--target': 'target', '--psql': 'psqlUrl', '--project-ref': 'projectRef',
+    '--user-email': 'userEmail', '--days': 'days',
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === '--reset') { opts.reset = true; continue; }
+    if (argv[i] === '--dry-run') { opts.dryRun = true; continue; }
+    const key = flags[argv[i]];
+    if (key) { opts[key] = argv[i + 1]; i += 1; }
+  }
+  opts.days = Number.parseInt(opts.days, 10);
+  return opts;
+}
+
+/**
+ * Resolve which channel reaches the database, and refuse production before
+ * anything else runs. Pure decision logic — no I/O — so it is unit-testable
+ * without a network.
+ */
+export function resolveChannel(opts, env = {}) {
+  if (opts.psqlUrl) {
+    return { ok: true, channel: 'psql', url: opts.psqlUrl };
+  }
+  const ref = opts.projectRef ?? env.SUPABASE_PROJECT_REF ?? '';
+  if (!ref) {
+    return { ok: false, error: 'No target. Pass --psql <url> for a local stack, or set SUPABASE_PROJECT_REF (with SUPABASE_ACCESS_TOKEN) for the preview project.' };
+  }
+  if (ref === PRODUCTION_PROJECT_REF) {
+    return { ok: false, error: `Refusing to seed the PRODUCTION project (${PRODUCTION_PROJECT_REF}). This script only ever targets a preview or local stack — there is no override.` };
+  }
+  const accessToken = env.SUPABASE_ACCESS_TOKEN ?? '';
+  // A dry-run never calls the network, so it can preview the SQL for a real
+  // project ref without a real token on hand.
+  if (!accessToken && !opts.dryRun) {
+    return { ok: false, error: 'SUPABASE_PROJECT_REF is set but SUPABASE_ACCESS_TOKEN is missing — both are required for the Management API channel.' };
+  }
+  return { ok: true, channel: 'api', ref, accessToken };
+}
+
+// ── execution ────────────────────────────────────────────────────────────────
+
+/**
+ * One SQL round trip via the Supabase Management API. Node's built-in fetch
+ * ignores HTTPS_PROXY (see CLAUDE.md's sandbox-baseline note #6) — set
+ * NODE_USE_ENV_PROXY=1 in whatever shell runs this if it 403s with "host not
+ * in allowlist" for a host that IS allowlisted.
+ */
+async function execApi({ ref, accessToken, sql }) {
+  const res = await fetch(`https://api.supabase.com/v1/projects/${ref}/database/query`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: sql }),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`Management API query failed (${res.status}): ${text.slice(0, 2000)}`);
+  }
+  return text ? JSON.parse(text) : [];
+}
+
+/** One SQL round trip via `psql -f <tmpfile>`, so quoting never touches a shell. */
+function execPsql({ url, sql }) {
+  const dir = mkdtempSync(path.join(tmpdir(), 'lorekit-seed-'));
+  const file = path.join(dir, 'seed.sql');
+  try {
+    // -t -A: unaligned, no header — the one caller that reads rows back
+    // (resolveUserId) parses this format itself.
+    writeFileSync(file, sql, 'utf8');
+    const res = spawnSync('psql', [url, '-v', 'ON_ERROR_STOP=1', '-t', '-A', '-f', file], { encoding: 'utf8' });
+    if (res.status !== 0) {
+      throw new Error(`psql failed (exit ${res.status}): ${res.stderr || res.stdout}`);
+    }
+    return res.stdout;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function runSql(channelInfo, sql) {
+  if (channelInfo.channel === 'api') {
+    return execApi({ ref: channelInfo.ref, accessToken: channelInfo.accessToken, sql });
+  }
+  return execPsql({ url: channelInfo.url, sql });
+}
+
+/** Look up the seed target's user id by email. Never creates one. */
+async function resolveUserId(channelInfo, email) {
+  const sql = `select id from auth.users where email = ${sqlString(email)} limit 1;`;
+  const result = await runSql(channelInfo, sql);
+  const id = channelInfo.channel === 'api'
+    ? result?.[0]?.id
+    : String(result).trim().split('\n')[0]?.trim();
+  if (!id) {
+    throw new Error(
+      `No user found for email ${email}. Seed it first with:\n` +
+      `  SUPABASE_URL=… SUPABASE_SERVICE_ROLE_KEY=… LOREKIT_SMOKE_EMAIL=${email} LOREKIT_SMOKE_PASSWORD=… node scripts/smoke/seed-smoke-user.mjs`,
+    );
+  }
+  return id;
+}
+
+// ── orchestration ────────────────────────────────────────────────────────────
+
+/** Build every SQL statement this run needs, in EXECUTION ORDER (FK-dependency order). */
+export function buildStatements({ dataset, userId, reset }) {
+  const statements = [];
+  if (reset) statements.push({ name: 'reset', sql: renderResetSql(dataset.org, userId) });
+  statements.push({ name: 'org', sql: renderOrgSql(dataset.org, userId) });
+  statements.push({ name: 'memories', sql: renderMemoriesSql(dataset.memories, userId) });
+  const memoryIds = dataset.memories.map((m) => m.id);
+  statements.push({ name: 'read_daily', sql: renderReadDailySql(dataset.readDaily, memoryIds) });
+  statements.push({ name: 'citations', sql: renderCitationsSql(dataset.citations, memoryIds) });
+  statements.push({ name: 'usage_events', sql: renderUsageEventsSql(dataset.usageEvents, userId) });
+  return statements;
+}
+
+async function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (!opts.userEmail) {
+    console.error('Missing --user-email <email>. The account whose lore/usage this seeds — must already exist (see scripts/smoke/seed-smoke-user.mjs).');
+    process.exit(1);
+  }
+  const resolved = resolveChannel(opts, process.env);
+  if (!resolved.ok) {
+    console.error(`::error::${resolved.error}`);
+    process.exit(1);
+  }
+
+  const dataset = buildDataset({ now: new Date(), days: Number.isFinite(opts.days) ? opts.days : 30 });
+  console.log(`Dataset: ${dataset.memories.length} memories, ${dataset.usageEvents.length} usage events, ${dataset.readDaily.length} read-daily rows, ${dataset.citations.length} citations, keys prefixed "${SEED_KEY_PREFIX}".`);
+
+  if (opts.dryRun) {
+    console.log(`\n[dry-run] Resolving on channel: ${resolved.channel === 'api' ? `Management API (ref ${resolved.ref})` : `psql (${resolved.url})`}`);
+    console.log('[dry-run] Would resolve user id for', opts.userEmail, 'then run:');
+    const statements = buildStatements({ dataset, userId: '<resolved-user-id>', reset: opts.reset });
+    for (const s of statements) {
+      console.log(`\n-- ${s.name} --\n${s.sql}`);
+    }
+    return;
+  }
+
+  const userId = await resolveUserId(resolved, opts.userEmail);
+  console.log(`Seeding as user ${opts.userEmail} (${userId})${opts.reset ? ' — resetting first' : ''}...`);
+
+  const statements = buildStatements({ dataset, userId, reset: opts.reset });
+  for (const s of statements) {
+    console.log(`Running ${s.name}...`);
+    await runSql(resolved, s.sql);
+  }
+
+  console.log(`Done. Sign in to the preview dashboard as ${opts.userEmail} to see it — filter the Explorer by "${SEED_KEY_PREFIX}" to find exactly these rows.`);
+}
+
+const invokedDirectly = process.argv[1] && process.argv[1].endsWith('seed-preview.mjs');
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error(`::error::${err.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/seed/seed-preview.test.mjs
+++ b/scripts/seed/seed-preview.test.mjs
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseArgs, resolveChannel, buildStatements, PRODUCTION_PROJECT_REF } from './seed-preview.mjs';
+import { buildDataset } from './preview-dataset.mjs';
+
+test('parseArgs reads flags and defaults days to 30', () => {
+  const opts = parseArgs(['--target', 'preview', '--user-email', 'a@b.com', '--reset', '--dry-run']);
+  assert.equal(opts.userEmail, 'a@b.com');
+  assert.equal(opts.reset, true);
+  assert.equal(opts.dryRun, true);
+  assert.equal(opts.days, 30);
+});
+
+test('parseArgs reads --days as an integer', () => {
+  const opts = parseArgs(['--user-email', 'a@b.com', '--days', '14']);
+  assert.equal(opts.days, 14);
+});
+
+test('resolveChannel refuses the production project ref UNCONDITIONALLY — no flag can override it', () => {
+  const result = resolveChannel(
+    { psqlUrl: null, projectRef: PRODUCTION_PROJECT_REF, userEmail: 'a@b.com' },
+    { SUPABASE_ACCESS_TOKEN: 'token' },
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.error, /production/i);
+});
+
+test('resolveChannel refuses the production ref even when it comes from the environment, not a flag', () => {
+  const result = resolveChannel(
+    { psqlUrl: null, projectRef: null },
+    { SUPABASE_PROJECT_REF: PRODUCTION_PROJECT_REF, SUPABASE_ACCESS_TOKEN: 'token' },
+  );
+  assert.equal(result.ok, false);
+});
+
+test('resolveChannel accepts a non-production ref with an access token', () => {
+  const result = resolveChannel(
+    { psqlUrl: null, projectRef: 'some-preview-ref' },
+    { SUPABASE_ACCESS_TOKEN: 'token' },
+  );
+  assert.equal(result.ok, true);
+  assert.equal(result.channel, 'api');
+});
+
+test('resolveChannel requires an access token for the API channel', () => {
+  const result = resolveChannel({ psqlUrl: null, projectRef: 'some-preview-ref' }, {});
+  assert.equal(result.ok, false);
+  assert.match(result.error, /SUPABASE_ACCESS_TOKEN/);
+});
+
+test('resolveChannel skips the access-token requirement on a dry run — it never touches the network', () => {
+  const result = resolveChannel({ psqlUrl: null, projectRef: 'some-preview-ref', dryRun: true }, {});
+  assert.equal(result.ok, true);
+  assert.equal(result.channel, 'api');
+});
+
+test('resolveChannel prefers an explicit --psql url over any project ref, and never checks it for production', () => {
+  const result = resolveChannel({ psqlUrl: 'postgresql://localhost/x', projectRef: PRODUCTION_PROJECT_REF }, {});
+  assert.equal(result.ok, true);
+  assert.equal(result.channel, 'psql');
+});
+
+test('resolveChannel demands SOME target — no implicit default', () => {
+  const result = resolveChannel({ psqlUrl: null, projectRef: null }, {});
+  assert.equal(result.ok, false);
+});
+
+test('buildStatements runs reset (when requested) before org, org before memories, and memories before its detail tables', () => {
+  const dataset = buildDataset({ now: new Date('2026-09-10T12:00:00.000Z') });
+  const withReset = buildStatements({ dataset, userId: 'u1', reset: true }).map((s) => s.name);
+  assert.deepEqual(withReset, ['reset', 'org', 'memories', 'read_daily', 'citations', 'usage_events']);
+
+  const withoutReset = buildStatements({ dataset, userId: 'u1', reset: false }).map((s) => s.name);
+  assert.deepEqual(withoutReset, ['org', 'memories', 'read_daily', 'citations', 'usage_events']);
+});

--- a/scripts/seed/seed-preview.test.mjs
+++ b/scripts/seed/seed-preview.test.mjs
@@ -5,7 +5,7 @@ import { parseArgs, resolveChannel, buildStatements, PRODUCTION_PROJECT_REF } fr
 import { buildDataset } from './preview-dataset.mjs';
 
 test('parseArgs reads flags and defaults days to 30', () => {
-  const opts = parseArgs(['--target', 'preview', '--user-email', 'a@b.com', '--reset', '--dry-run']);
+  const opts = parseArgs(['--user-email', 'a@b.com', '--reset', '--dry-run']);
   assert.equal(opts.userEmail, 'a@b.com');
   assert.equal(opts.reset, true);
   assert.equal(opts.dryRun, true);
@@ -55,10 +55,19 @@ test('resolveChannel skips the access-token requirement on a dry run — it neve
   assert.equal(result.channel, 'api');
 });
 
-test('resolveChannel prefers an explicit --psql url over any project ref, and never checks it for production', () => {
+test('resolveChannel prefers an explicit --psql url over any project ref', () => {
   const result = resolveChannel({ psqlUrl: 'postgresql://localhost/x', projectRef: PRODUCTION_PROJECT_REF }, {});
   assert.equal(result.ok, true);
   assert.equal(result.channel, 'psql');
+});
+
+test('resolveChannel refuses a --psql url that names the production project ref too', () => {
+  const result = resolveChannel(
+    { psqlUrl: `postgresql://postgres.${PRODUCTION_PROJECT_REF}:pw@aws-0-region.pooler.supabase.com:5432/postgres`, projectRef: null },
+    {},
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.error, /production/i);
 });
 
 test('resolveChannel demands SOME target — no implicit default', () => {


### PR DESCRIPTION
## Summary

Adds a deterministic preview dataset seeder (`scripts/seed/preview-dataset.mjs`, `scripts/seed/seed-preview.mjs`, `scripts/seed/preview-sql.mjs`) that populates the shared preview Supabase project with realistic, backdated demo data — memories across every filterable dimension, an org, and 30 days of usage/read/citation activity — so the dashboard shows a lived-in workspace instead of an empty account after a fresh `/preview` deploy.

The seeder is **opt-in only** via `/preview --seed` (never the default), since the preview project is shared across every open PR's `/preview` run and most runs never open the dashboard.

## Key changes

- **`scripts/seed/preview-dataset.mjs`** — Pure, deterministic dataset builder. Hand-authored lesson set covering every Explorer filter dimension (label/tag, kind, host, agent, trigger, origin repo/branch/PR) and scope type (global/project/repo/branch). Uses a seeded PRNG (mulberry32) so the same `now` always produces the same dataset, making `--dry-run` a meaningful diff and re-seeds close to idempotent. Derives per-memory read/opened/cited counters, `memory_read_daily` day rows, and 30 days of `usage_events` from a `popularity` field that maps to `/insights`' five utility states.

- **`scripts/seed/seed-preview.mjs`** — Orchestrator and execution layer. Parses CLI flags (`--project-ref <ref>` or `SUPABASE_PROJECT_REF` env var / `--psql <url>`, `--user-email`, `--days`, `--reset`, `--dry-run`). Resolves execution channel (Supabase Management API or direct `psql`). **Unconditionally refuses the production project ref** — no override flag exists, whether the ref comes from a flag, the environment, or is embedded in a `--psql` URL. Looks up the target user by email (never creates one). Builds SQL statements in FK-dependency order and executes them.

- **`scripts/seed/preview-sql.mjs`** — SQL renderer. Converts dataset objects to safe, re-runnable SQL: memories upsert on `(user_id, scope, key)`, org/membership upsert on primary keys, per-memory detail tables (`memory_read_daily`, `memory_citations`) are deleted-then-reinserted for exactly the memory ids this dataset owns. All values are escaped via `sqlString` (the one place escaping happens) — no parameterized placeholders available on either execution channel.

- **Unit tests** — `preview-dataset.test.mjs`, `preview-sql.test.mjs`, `seed-preview.test.mjs` validate dataset structure (every key carries the seed prefix, (scope,key) pairs are unique, every filter dimension has ≥3 distinct values, all scope types represented, at least one archived/protected/expired/active-TTL memory, no future timestamps except active TTLs, citations/read-daily only reference existing memory ids), SQL escaping, and channel resolution logic (production ref refusal — including a `--psql` URL naming the production ref — access token requirements, dry-run bypass).

- **Workflow integration** — `preview.yml` adds a `seed` job (runs after migrations, in parallel with deploy-web/smoke) triggered by `/preview --seed` comment. `ci.yml` gates the seed tests on changes to `scripts/seed/` or workflow files. `rebuild-preview.yml` reminds to re-seed the smoke user after a DB reset.

- **Documentation** — `docs/deployment.md` explains the opt-in seeding, why it's not the default, and how to run it locally or in CI. `CLAUDE.md` updated to reflect the new `review-loop` workflow (unrelated to seeding, but included in the diff).

## Notable implementation details

- **Deterministic on purpose**: Every timestamp is computed relative to a `now` passed by the caller (never `Date.now()` read inside the module). The seeded PRNG ensures the same `now` always produces the same dataset.

- **Collision-safe**: Every seeded memory's `key` is prefixed with `preview-seed/`, and every `usage_events.correlation_id` is prefixed with `preview-seed`, so they can never collide with real data. The prefix also makes seeded rows trivial to find and clean up (`--reset`), and the org delete is scoped to `created_by` so one user's `--reset` can never drop another user's shared preview org.

https://claude.ai/code/session_01BMhjCeyiruZNLcLr1op8Fi