### PR TITLE
fix(web): skeleton loading states for the Organization settings surface

### DIFF
--- a/packages/web/src/app/(dashboard)/settings/organization/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/organization/page.tsx
@@ -21,9 +21,8 @@ export default async function OrganizationSettingsPage() {
     >
       {/* OrganizationManager reads the `?org=` search param (useUrlState) to drive
           its deep-linkable master/detail view, which requires a Suspense boundary
-          per the useUrlState SSR contract. */}
-      {/* Fallback mirrors the org list's row shape so the layout doesn't jump
-          once the client value hydrates. */}
+          per the useUrlState SSR contract. The fallback mirrors the org list's row
+          shape so the layout doesn't jump once the client value hydrates. */}
       <Suspense fallback={<OrgListSkeleton />}>
         <OrganizationManager initialOrgs={orgs} currentUserId={user?.id ?? ''} />
       </Suspense>

--- a/packages/web/src/app/(dashboard)/settings/organization/page.tsx
+++ b/packages/web/src/app/(dashboard)/settings/organization/page.tsx
@@ -4,25 +4,10 @@ import { Users } from 'lucide-react';
 import { getVerifiedUser } from '@/lib/auth/verified-user';
 import { listMyOrgs } from '@/lib/orgs';
 import { OrganizationManager } from '@/components/dashboard/OrganizationManager';
+import { OrgListSkeleton } from '@/components/dashboard/OrganizationSkeleton';
 import { SectionPanel } from '@/components/ui/SectionPanel';
 
 export const metadata: Metadata = { title: 'Organization — Settings' };
-
-// Fallback for the Suspense boundary the manager needs (it reads the `?org=`
-// search param via useUrlState). Mirrors the shape of the org list so the
-// layout doesn't jump once the client value hydrates.
-function OrganizationLoading() {
-  return (
-    <div role="status" aria-label="Loading organizations" className="flex flex-col gap-2">
-      {[0, 1].map((i) => (
-        <div
-          key={i}
-          className="h-[62px] animate-pulse rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-elevated)]"
-        />
-      ))}
-    </div>
-  );
-}
 
 export default async function OrganizationSettingsPage() {
   const user = await getVerifiedUser();
@@ -37,7 +22,9 @@ export default async function OrganizationSettingsPage() {
       {/* OrganizationManager reads the `?org=` search param (useUrlState) to drive
           its deep-linkable master/detail view, which requires a Suspense boundary
           per the useUrlState SSR contract. */}
-      <Suspense fallback={<OrganizationLoading />}>
+      {/* Fallback mirrors the org list's row shape so the layout doesn't jump
+          once the client value hydrates. */}
+      <Suspense fallback={<OrgListSkeleton />}>
         <OrganizationManager initialOrgs={orgs} currentUserId={user?.id ?? ''} />
       </Suspense>
     </SectionPanel>

--- a/packages/web/src/components/dashboard/OrganizationManager.tsx
+++ b/packages/web/src/components/dashboard/OrganizationManager.tsx
@@ -44,6 +44,11 @@ import {
   ORG_DELETE_RETENTION_DAYS,
 } from '@/lib/org-ui';
 import { useUrlState } from '@/lib/hooks/useUrlState';
+import {
+  OrgMembersSkeleton,
+  OrgInvitesSkeleton,
+  OrgScopesSkeleton,
+} from '@/components/dashboard/OrganizationSkeleton';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Button, IconButton } from '@/components/ui/Button';
@@ -863,7 +868,7 @@ export function OrganizationManager({ initialOrgs, currentUserId }: Organization
               )}
             </div>
             {loadingOrgData ? (
-              <p className="text-xs text-[var(--color-content-tertiary)]">Loading members…</p>
+              <OrgMembersSkeleton manageable={Boolean(caps?.canManageRoles)} />
             ) : (
               <AnimatePresence>
                 {members.map((member) => {
@@ -955,6 +960,7 @@ export function OrganizationManager({ initialOrgs, currentUserId }: Organization
           {(caps?.canInvite || pendingInvites.length > 0) && (
             <section className="flex flex-col gap-1.5">
               <SectionLabel>Invites</SectionLabel>
+              {loadingOrgData && <OrgInvitesSkeleton />}
               {pendingInvites.length > 0 && (
                 <AnimatePresence>
                   {pendingInvites.map((invite) => (
@@ -1015,7 +1021,7 @@ export function OrganizationManager({ initialOrgs, currentUserId }: Organization
                 Writes under a bound scope auto-route to {selectedOrg.name} for write-capable members.
               </p>
               {loadingOrgData ? (
-                <p className="text-xs text-[var(--color-content-tertiary)]">Loading scopes…</p>
+                <OrgScopesSkeleton />
               ) : bindings.length === 0 ? (
                 <EmptyState
                   icon={Link}

--- a/packages/web/src/components/dashboard/OrganizationSkeleton.stories.tsx
+++ b/packages/web/src/components/dashboard/OrganizationSkeleton.stories.tsx
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
+
+import {
+  OrgListSkeleton,
+  OrgMembersSkeleton,
+  OrgInvitesSkeleton,
+  OrgScopesSkeleton,
+} from './OrganizationSkeleton';
+
+/**
+ * The Organization settings placeholders — the route-level Suspense fallback
+ * and the three async sections inside `OrganizationManager`.
+ *
+ * ## Why structural assertions and not pixel baselines
+ * Every block carries Tailwind's `animate-pulse`, a CSS keyframe animation the
+ * preview's `MotionConfig reducedMotion="always"` does not collapse (that
+ * governs `motion/react` only). A `toMatchScreenshot` baseline would then be
+ * pinned to whatever opacity the pulse happened to be at when the screenshot
+ * fired — so these stories opt out of visual-regression snapshotting and pin
+ * the shape with play assertions instead, the same convention as the sibling
+ * `LessonCardSkeleton`.
+ */
+const meta: Meta = {
+  title: 'Dashboard/OrganizationSkeleton',
+  parameters: { layout: 'padded', chromatic: { disableSnapshot: true } },
+};
+
+export default meta;
+type Story = StoryObj;
+
+/** The master list, as it renders in the page's Suspense fallback. */
+export const OrgList: Story = {
+  render: () => <OrgListSkeleton />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('announces the load and stands in for two org rows', async () => {
+      const status = canvas.getByRole('status', { name: 'Loading organizations' });
+      await expect(status.children).toHaveLength(2);
+    });
+  },
+};
+
+/**
+ * Members as an owner/admin sees them — rows sized for the `min-h-11` role
+ * `<select>` and the remove button, so the placeholder resolves to the height
+ * the real rows will have.
+ */
+export const Members: Story = {
+  render: () => <OrgMembersSkeleton manageable />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('three member rows, each ending in a select + remove placeholder', async () => {
+      const status = canvas.getByRole('status', { name: 'Loading members' });
+      await expect(status.children).toHaveLength(3);
+      const trailing = status.querySelector('[aria-hidden="true"] > div:last-child');
+      await expect(trailing?.children).toHaveLength(2);
+    });
+  },
+};
+
+/** Members as a member/viewer sees them — a role badge, no row controls. */
+export const MembersReadOnly: Story = {
+  render: () => <OrgMembersSkeleton manageable={false} />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('a row without management controls ends in the lone role badge', async () => {
+      const status = canvas.getByRole('status', { name: 'Loading members' });
+      const trailing = status.querySelector('[aria-hidden="true"] > div:last-child');
+      await expect(trailing?.children).toHaveLength(1);
+    });
+  },
+};
+
+/** A single pending-invite row — most orgs have none, so one is the honest count. */
+export const Invites: Story = {
+  render: () => <OrgInvitesSkeleton />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('one invite row, not a stack', async () => {
+      const status = canvas.getByRole('status', { name: 'Loading invites' });
+      await expect(status.children).toHaveLength(1);
+    });
+  },
+};
+
+/** The bound-scope rows. */
+export const Scopes: Story = {
+  render: () => <OrgScopesSkeleton />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+    await step('two scope rows', async () => {
+      const status = canvas.getByRole('status', { name: 'Loading shared scopes' });
+      await expect(status.children).toHaveLength(2);
+    });
+  },
+};
+
+/** All three sections stacked, the way the detail view renders them together. */
+export const DetailView: Story = {
+  render: () => (
+    <div className="flex flex-col gap-5">
+      <OrgMembersSkeleton manageable />
+      <OrgInvitesSkeleton />
+      <OrgScopesSkeleton />
+    </div>
+  ),
+};

--- a/packages/web/src/components/dashboard/OrganizationSkeleton.tsx
+++ b/packages/web/src/components/dashboard/OrganizationSkeleton.tsx
@@ -16,7 +16,11 @@
 
 const ROW =
   'flex items-center gap-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-raised)] px-3 py-2.5';
-const BLOCK = 'animate-pulse rounded bg-[var(--color-bg-elevated)]';
+// No radius here: this repo has no `tailwind-merge` (see `lib/cn.ts`), so a
+// radius baked in would be a second, conflicting `rounded-*` on every call site
+// that needs a different one — decided by CSS source order, not by the class
+// list. Each block states its own.
+const BLOCK = 'animate-pulse bg-[var(--color-bg-elevated)]';
 
 /** Bar widths — varied so each stack reads as content, not a table column. */
 const ORG_NAME_WIDTHS = [96, 72];
@@ -33,13 +37,13 @@ function OrgListRowSkeleton({ width }: { width: number }) {
       aria-hidden
       className="flex min-h-11 items-center gap-3 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)] px-3 py-2.5"
     >
-      <div className={`size-9 shrink-0 ${BLOCK} rounded-lg`} />
+      <div className={`size-9 shrink-0 rounded-lg ${BLOCK}`} />
       <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-        <div className={`h-4 ${BLOCK}`} style={{ width: `${width}px` }} />
-        <div className={`h-3 w-16 ${BLOCK}`} />
+        <div className={`h-4 rounded ${BLOCK}`} style={{ width: `${width}px` }} />
+        <div className={`h-3 w-16 rounded ${BLOCK}`} />
       </div>
-      <div className={`h-5 w-14 shrink-0 ${BLOCK} rounded-md`} />
-      <div className={`size-4 shrink-0 ${BLOCK}`} />
+      <div className={`h-5 w-14 shrink-0 rounded-md ${BLOCK}`} />
+      <div className={`size-4 shrink-0 rounded ${BLOCK}`} />
     </div>
   );
 }
@@ -65,17 +69,20 @@ export function OrgMembersSkeleton({ manageable }: { manageable: boolean }) {
   return (
     <div role="status" aria-label="Loading members" className="flex flex-col gap-1.5">
       {MEMBER_NAME_WIDTHS.map((width) => (
-        <div key={width} aria-hidden className={ROW}>
-          <div className={`size-6 shrink-0 ${BLOCK} rounded-full`} />
-          <div className={`h-4 ${BLOCK}`} style={{ width: `${width}px` }} />
+        // `flex-wrap` only here: the real member row carries it (the role select
+        // and remove button drop to a second line on a narrow viewport), while
+        // the invite and scope rows do not.
+        <div key={width} aria-hidden className={`${ROW} flex-wrap`}>
+          <div className={`size-6 shrink-0 rounded-full ${BLOCK}`} />
+          <div className={`h-4 rounded ${BLOCK}`} style={{ width: `${width}px` }} />
           <div className="ml-auto flex items-center gap-3">
             {manageable ? (
               <>
-                <div className={`h-11 w-24 shrink-0 ${BLOCK} rounded-lg`} />
-                <div className={`size-8 shrink-0 ${BLOCK} rounded-lg`} />
+                <div className={`h-11 w-24 shrink-0 rounded-lg ${BLOCK}`} />
+                <div className={`size-8 shrink-0 rounded-lg ${BLOCK}`} />
               </>
             ) : (
-              <div className={`h-5 w-16 shrink-0 ${BLOCK} rounded-md`} />
+              <div className={`h-5 w-16 shrink-0 rounded-md ${BLOCK}`} />
             )}
           </div>
         </div>
@@ -93,12 +100,12 @@ export function OrgInvitesSkeleton() {
   return (
     <div role="status" aria-label="Loading invites" className="flex flex-col gap-1.5">
       <div aria-hidden className={ROW}>
-        <div className={`size-4 shrink-0 ${BLOCK}`} />
+        <div className={`size-4 shrink-0 rounded ${BLOCK}`} />
         <div className="flex min-w-0 flex-1 flex-col gap-1.5">
-          <div className={`h-4 w-44 ${BLOCK}`} />
-          <div className={`h-3 w-24 ${BLOCK}`} />
+          <div className={`h-4 w-44 rounded ${BLOCK}`} />
+          <div className={`h-3 w-24 rounded ${BLOCK}`} />
         </div>
-        <div className={`h-8 w-[72px] shrink-0 ${BLOCK} rounded-lg`} />
+        <div className={`h-8 w-[72px] shrink-0 rounded-lg ${BLOCK}`} />
       </div>
     </div>
   );
@@ -110,9 +117,9 @@ export function OrgScopesSkeleton() {
     <div role="status" aria-label="Loading shared scopes" className="flex flex-col gap-1.5">
       {SCOPE_WIDTHS.map((width) => (
         <div key={width} aria-hidden className={ROW}>
-          <div className={`size-4 shrink-0 ${BLOCK}`} />
-          <div className={`h-4 ${BLOCK}`} style={{ width: `${width}px` }} />
-          <div className={`ml-auto h-8 w-[92px] shrink-0 ${BLOCK} rounded-lg`} />
+          <div className={`size-4 shrink-0 rounded ${BLOCK}`} />
+          <div className={`h-4 rounded ${BLOCK}`} style={{ width: `${width}px` }} />
+          <div className={`ml-auto h-8 w-[92px] shrink-0 rounded-lg ${BLOCK}`} />
         </div>
       ))}
     </div>

--- a/packages/web/src/components/dashboard/OrganizationSkeleton.tsx
+++ b/packages/web/src/components/dashboard/OrganizationSkeleton.tsx
@@ -1,0 +1,120 @@
+/**
+ * Loading placeholders for the Organization settings surface — the route-level
+ * Suspense fallback (`settings/organization/page.tsx`) and the three async
+ * sections inside `OrganizationManager` (members, invites, shared scopes).
+ *
+ * Each skeleton mirrors the row it stands in for — same wrapper classes, same
+ * leading glyph box, same trailing control — so the section keeps its shape
+ * when the data lands instead of collapsing a one-line "Loading…" string into a
+ * stack of 60px rows.
+ *
+ * The pulse blocks are `aria-hidden` (decorative until the data arrives) and
+ * each section wrapper carries the `role="status"` that announces the load,
+ * matching `LessonCardSkeleton`/`LoreExplorerSkeleton` in the lore surface.
+ * Widths are fixed px so the blocks are stable between renders.
+ */
+
+const ROW =
+  'flex items-center gap-3 rounded-lg border border-[var(--color-border)] bg-[var(--color-bg-raised)] px-3 py-2.5';
+const BLOCK = 'animate-pulse rounded bg-[var(--color-bg-elevated)]';
+
+/** Bar widths — varied so each stack reads as content, not a table column. */
+const ORG_NAME_WIDTHS = [96, 72];
+const MEMBER_NAME_WIDTHS = [88, 132, 104];
+const SCOPE_WIDTHS = [188, 148];
+
+/**
+ * One row of the master list (`OrgListView`): the size-9 org glyph, the
+ * name/slug pair, a role badge and the chevron.
+ */
+function OrgListRowSkeleton({ width }: { width: number }) {
+  return (
+    <div
+      aria-hidden
+      className="flex min-h-11 items-center gap-3 rounded-xl border border-[var(--color-border)] bg-[var(--color-bg-raised)] px-3 py-2.5"
+    >
+      <div className={`size-9 shrink-0 ${BLOCK} rounded-lg`} />
+      <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+        <div className={`h-4 ${BLOCK}`} style={{ width: `${width}px` }} />
+        <div className={`h-3 w-16 ${BLOCK}`} />
+      </div>
+      <div className={`h-5 w-14 shrink-0 ${BLOCK} rounded-md`} />
+      <div className={`size-4 shrink-0 ${BLOCK}`} />
+    </div>
+  );
+}
+
+/** The organization list, for the page's Suspense fallback. */
+export function OrgListSkeleton() {
+  return (
+    <div role="status" aria-label="Loading organizations" className="flex flex-col gap-2">
+      {ORG_NAME_WIDTHS.map((width) => (
+        <OrgListRowSkeleton key={width} width={width} />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * The members list. `manageable` is the viewer's own capability, known before
+ * the fetch resolves: a role-managing viewer gets rows sized for the `min-h-11`
+ * role `<select>` plus a remove button, everyone else the shorter badge row —
+ * so the placeholder resolves to the height the real rows will have.
+ */
+export function OrgMembersSkeleton({ manageable }: { manageable: boolean }) {
+  return (
+    <div role="status" aria-label="Loading members" className="flex flex-col gap-1.5">
+      {MEMBER_NAME_WIDTHS.map((width) => (
+        <div key={width} aria-hidden className={ROW}>
+          <div className={`size-6 shrink-0 ${BLOCK} rounded-full`} />
+          <div className={`h-4 ${BLOCK}`} style={{ width: `${width}px` }} />
+          <div className="ml-auto flex items-center gap-3">
+            {manageable ? (
+              <>
+                <div className={`h-11 w-24 shrink-0 ${BLOCK} rounded-lg`} />
+                <div className={`size-8 shrink-0 ${BLOCK} rounded-lg`} />
+              </>
+            ) : (
+              <div className={`h-5 w-16 shrink-0 ${BLOCK} rounded-md`} />
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/**
+ * A single pending-invite row — the email line over its status/role meta line,
+ * with the Revoke button. One row, not a stack: most orgs have no pending
+ * invites, so a taller placeholder would promise rows that never arrive.
+ */
+export function OrgInvitesSkeleton() {
+  return (
+    <div role="status" aria-label="Loading invites" className="flex flex-col gap-1.5">
+      <div aria-hidden className={ROW}>
+        <div className={`size-4 shrink-0 ${BLOCK}`} />
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+          <div className={`h-4 w-44 ${BLOCK}`} />
+          <div className={`h-3 w-24 ${BLOCK}`} />
+        </div>
+        <div className={`h-8 w-[72px] shrink-0 ${BLOCK} rounded-lg`} />
+      </div>
+    </div>
+  );
+}
+
+/** The bound-scope rows — mono scope string plus the Unbind button. */
+export function OrgScopesSkeleton() {
+  return (
+    <div role="status" aria-label="Loading shared scopes" className="flex flex-col gap-1.5">
+      {SCOPE_WIDTHS.map((width) => (
+        <div key={width} aria-hidden className={ROW}>
+          <div className={`size-4 shrink-0 ${BLOCK}`} />
+          <div className={`h-4 ${BLOCK}`} style={{ width: `${width}px` }} />
+          <div className={`ml-auto h-8 w-[92px] shrink-0 ${BLOCK} rounded-lg`} />
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
The org detail view announced its three async sections with bare one-line
strings ("Loading members…", "Loading scopes…") and no placeholder at all for
invites, so each section collapsed to a single line of text and then jumped to
a stack of ~60px rows when the data landed.

Adds `OrganizationSkeleton.tsx` — one module for the surface's placeholders,
each mirroring the row it stands in for (wrapper classes, leading glyph box,
trailing control), and wires it into all four load points:

- members: three rows, sized off the viewer's OWN capability (known before the
  fetch resolves) so a role-managing viewer gets rows tall enough for the
  `min-h-11` role select + remove button, everyone else the shorter badge row
- invites: one row, not a stack — most orgs have no pending invites, so a
  taller placeholder would promise rows that never arrive
- shared scopes: two rows
- the route-level Suspense fallback: the generic pulse boxes become org-list
  rows (glyph, name/slug pair, role badge, chevron)

Pulse blocks are `aria-hidden`; each section wrapper carries the `role="status"`
that announces the load, matching `LessonCardSkeleton`/`LoreExplorerSkeleton`.

Stories pin the shape structurally rather than with pixel baselines: every block
carries `animate-pulse`, a CSS keyframe animation `MotionConfig
reducedMotion="always"` does not collapse, so a screenshot baseline would be
pinned to whatever opacity the pulse happened to be at — same opt-out the
sibling `LessonCardSkeleton` story takes.

No user-facing docs surface applies: this changes only how the Organization
settings page renders while its data is in flight — no new capability, flag,
route, limit, or config key.

Claude-Session: https://claude.ai/code/session_01YWCvLnpUhCipy3uuz9qyQ9